### PR TITLE
few fixes in volume create, stage that were left behind

### DIFF
--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -149,8 +149,9 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	glog.Infof("NodeStageVolume: Requested fsType is %v", requestedFsType)
 
 	var devicepath string
+	var err error
 	if lvmode() == true {
-		devicepath, err := lvPath(attrs["name"])
+		devicepath, err = lvPath(attrs["name"])
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, "No such volume")
 		}


### PR DESCRIPTION
In creation, return after success to avoid creating volumes
in more than one region. In stage, we had local variable scope
which caused determineFilesystem function to get empty arg.