### PR TITLE
run_driver: Added 2 pre-stages which are in separate binaries now

### DIFF
--- a/run_driver
+++ b/run_driver
@@ -1,3 +1,5 @@
-# Example how to run the PMEM-CSI driver as standalone (run as root)
+# Run this as root to start PMEM-CSI driver as standalone
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+$DIR/_output/pmem-ns-init
+$DIR/_output/pmem-vgm
 $DIR/_output/pmem-csi-driver --endpoint tcp://127.0.0.1:10000


### PR DESCRIPTION
note, this relies on changes made in #18, providing separate binaries for pre-stages