### PR TITLE
run_client_csc: fix mess around Name and VolumeID used mixed

### DIFF
--- a/run_client_csc
+++ b/run_client_csc
@@ -4,16 +4,19 @@ export CSI_ENDPOINT=tcp://127.0.0.1:10000
 # can be used to verify some main functions.
 
 $GOPATH/bin/csc controller create-volume --req-bytes 33554432 --cap SINGLE_NODE_WRITER,block nspace1
-$GOPATH/bin/csc controller publish --node-id c87ec8bf-cc70-11e8-8580-525400a0ae35 --cap SINGLE_NODE_WRITER,mount,xfs --attrib name=nspace1,size=32000000 nspace1
+
+# note: use UUID value reported by above cmd as VOLUME_ID in commands below.
+# for scripted use, could parse output, assign VolumeID to variable for use in following commands
+
+$GOPATH/bin/csc controller publish --node-id node-1 --cap SINGLE_NODE_WRITER,mount,xfs --attrib name=nspace1,size=33554432 VOLUME_ID
 $GOPATH/bin/csc node stage nspace1 --cap SINGLE_NODE_WRITER,mount,xfs --staging-target-path /tmp/stage1 --attrib name=nspace1
-$GOPATH/bin/csc node publish nspace1 --cap SINGLE_NODE_WRITER,mount,xfs --staging-target-path /tmp/stage1 --target-path /tmp/target1
-$GOPATH/bin/csc node unpublish nspace1 --target-path /tmp/target1
+$GOPATH/bin/csc node publish VOLUME_ID --cap SINGLE_NODE_WRITER,mount,xfs --staging-target-path /tmp/stage1 --target-path /tmp/target1
+$GOPATH/bin/csc node unpublish VOLUME_ID --target-path /tmp/target1
 $GOPATH/bin/csc node unstage nspace1 --staging-target-path /tmp/stage1
-$GOPATH/bin/csc controller unpublish nspace1
+$GOPATH/bin/csc controller unpublish VOLUME_ID
 
 ### just as example what else is implemented in driver,
 ### the 2 commands below are not part of above lifecycle.
-### anyhow, it does not harm to run this whole file as one script
 
 # Check driver-reported capabilities
 $GOPATH/bin/csc controller get-capabilities


### PR DESCRIPTION
In early stages, name was used in context of volumeID, we
need to get this cleaned out, and csc example commands
were full of it.