### PR TITLE
Wrapping exec.Command() to specific to our usage

### DIFF
--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -4,11 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/golang/glog"
 	"github.com/intel/pmem-csi/pkg/ndctl"
+	"github.com/intel/pmem-csi/pkg/pmem-exec"
 )
 
 const (
@@ -59,13 +59,13 @@ func initNVdimms(ctx *ndctl.Context, namespacesize, uselimit int) {
 	// if cmd returns nonzero, its either "cmd exists and we run on baremetal (retval 1)" or "cmd does not exist: retval 127"
 	// in both cases we settle to baremetal mode, no harm done
 	glog.Infof("Configured namespacesize; %v GB", namespacesize)
-	output, err := exec.Command("systemd-detect-virt", "-v").CombinedOutput() //nolint: gosec
+	output, err := pmemexec.RunCommand("systemd-detect-virt", "-v")
 	if err != nil {
-		glog.Infof("VM detection: [%v] [%v], seem to run on bare metal, use default %v GB namespace size",
-			strings.TrimSpace(string(output)), err, namespacesize)
+		glog.Infof("VM detection: [%v], seem to run on bare metal, use default %v GB namespace size",
+			err, namespacesize)
 	} else {
 		glog.Infof("VM detection: [%v], this looks like VM, use smaller %v GB namespace size",
-			strings.TrimSpace(string(output)), namespacesizeVM)
+			strings.TrimSpace(output), namespacesizeVM)
 		namespacesize = namespacesizeVM
 	}
 	createNamespaces(ctx, namespacesize, uselimit)

--- a/pkg/pmem-exec/pmem-exec.go
+++ b/pkg/pmem-exec/pmem-exec.go
@@ -1,0 +1,18 @@
+package pmemexec
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// RunCommand wrapper around exec.Command()
+func RunCommand(cmd string, args ...string) (string, error) {
+	glog.V(5).Infof("Executing: %s %s", cmd, strings.Join(args, " "))
+	output, err := exec.Command(cmd, args...).CombinedOutput()
+	strOutput := string(output)
+	glog.V(5).Infof("Output: %s", output)
+
+	return strOutput, err
+}


### PR DESCRIPTION
Created new single function package that wraps exec.Command().CombinedOutput().
The main intention behind this change was to verbose the command running and the
result of the command.

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>