### PR TITLE
code cleanup: reduce debug prints, clean old comments and unused code, variables

### DIFF
--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// we get this as argument 'namespacesize'
-	//namespaceSize uint64 = (4*1024*1024*1024)
 	// TODO: try to get rid of hard-coded overhead
 	namespaceOverhead = 4 * 1024 * 1024
 	// smaller namespace size (in GB) for devel mode in VM

--- a/cmd/pmem-vgm/main.go
+++ b/cmd/pmem-vgm/main.go
@@ -22,9 +22,6 @@ func main() {
 	prepareVolumeGroups(ctx)
 }
 
-// TODO: could combine loops in above and below function, as loops traverse
-// same buses, regions, namespaces. But readability,clarity will suffer, so I prefer not to combine right now
-
 // for all regions:
 // - Check that VG exists for this region. Create if does not exist
 // - For all namespaces in region:

--- a/pkg/pmem-csi-driver/controllerserver-default.go
+++ b/pkg/pmem-csi-driver/controllerserver-default.go
@@ -33,28 +33,6 @@ func (cs *DefaultControllerServer) ControllerUnpublishVolume(ctx context.Context
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-func (cs *DefaultControllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	for _, c := range req.GetVolumeCapabilities() {
-		found := false
-		for _, c1 := range cs.Driver.vc {
-			if c1.GetMode() == c.GetAccessMode().GetMode() {
-				found = true
-			}
-		}
-		if !found {
-			return &csi.ValidateVolumeCapabilitiesResponse{
-				Supported: false,
-				Message:   "Driver doesnot support mode:" + c.GetAccessMode().GetMode().String(),
-			}, status.Error(codes.InvalidArgument, "Driver doesnot support mode:"+c.GetAccessMode().GetMode().String())
-		}
-		// TODO: Ignoring mount & block types for now.
-	}
-
-	return &csi.ValidateVolumeCapabilitiesResponse{
-		Supported: true,
-	}, nil
-}
-
 func (cs *DefaultControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }

--- a/pkg/pmem-csi-driver/controllerserver.go
+++ b/pkg/pmem-csi-driver/controllerserver.go
@@ -23,13 +23,6 @@ import (
 	"github.com/intel/pmem-csi/pkg/pmem-grpc"
 )
 
-const (
-	deviceID = "deviceID"
-	// LV mode in emulated case: if LV Group named nvdimm exists, we use Lvolumes instead of libndctl
-	// to achieve stable emulated env. LV storage is set up outside of this driver
-	//lvgroup  = "ndbus0region0"
-)
-
 //VolumeStatus type representation for volume status
 type VolumeStatus int
 

--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -197,13 +197,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	// MkdirAll is equal to mkdir -p i.e. it creates parent dirs if needed, and is no-op if dir exists
-	//glog.Infof("NodeStageVolume: mkdir -p %s", stagingtargetPath)
-	//err = os.MkdirAll(stagingtargetPath, 0777)
-	//if err != nil {
-	//	pmemcommon.Infof(3, ctx, "failed to create volume: %v", err)
-	//	return nil, err
-	//}
 	// If file system is already mounted, can happen if out-of-sync "stage" is asked again without unstage
 	// then the mount here will fail. I guess it's ok to not check explicitly for existing mount,
 	// as end result after mount attempt will be same: no new mount and existing mount remains.

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -135,7 +135,7 @@ func (lvm *pmemLvm) ListDevices() ([]PmemDeviceInfo, error) {
 	args := append(lvsArgs, lvm.volumeGroups...)
 	output, err := pmemexec.RunCommand("lvs", args...)
 	if err != nil {
-		return nil, fmt.Errorf("list volumes failed : %s(lvs output: %s)", err.Error())
+		return nil, fmt.Errorf("list volumes failed : %s(lvs output: %s)", err.Error(), output)
 	}
 	return parseLVSOuput(output)
 }


### PR DESCRIPTION
TODO comment outside function is  old leftover, should delete

pvdisplay output:
we show full ouput of pvdisplay but seems without real reason, so stop this.
(it fills driver stdout with long useless print)
We are not using output, dont take it into variable.

Comment above it "check this pv.." does not match the functionality as we append without checking.
