### PR TITLE
k8s/deployment: Added example application that requests pmem storage.

### DIFF
--- a/deploy/k8s/pmem-app.yaml
+++ b/deploy/k8s/pmem-app.yaml
@@ -1,0 +1,18 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-csi-app
+spec:
+  containers:
+    - name: my-frontend
+      image: busybox
+      command: [ "sleep", "100000" ]
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+  nodeSelector:
+    storage: nvdimm
+  volumes:
+  - name: my-csi-volume
+    persistentVolumeClaim:
+      claimName: csi-pmem-pvc

--- a/deploy/k8s/pmem-pvc.yaml
+++ b/deploy/k8s/pmem-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pmem-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+  storageClassName: csi-pmem-sc # defined in pmem-csi.yaml


### PR DESCRIPTION
Added examples of persistent volume claim and application that uses the claim
for its volume mount.

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>