### PR TITLE
pmd-lvm.go: change shred iterations count argument to short version

### DIFF
--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -148,7 +148,7 @@ func flushDevice(dev PmemDeviceInfo) error {
 	// erase data on block device, if not disabled by driver option
 	// use one iteration instead of shred's default=3 for speed
 	glog.Infof("Wiping data on: %s", dev.Path)
-	if _, err := pmemexec.RunCommand("shred", "--iterations=1", dev.Path); err != nil {
+	if _, err := pmemexec.RunCommand("shred", "-n", "1", dev.Path); err != nil {
 		return fmt.Errorf("device flush failure: %v", err.Error())
 	}
 	return nil


### PR DESCRIPTION
Short argument "-n 1" is supported by busybox
while long "--iterations 1" is not