### PR TITLE
pmem-vgm: Fix issue in device grouping

### DIFF
--- a/cmd/pmem-vgm/main.go
+++ b/cmd/pmem-vgm/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/intel/pmem-csi/pkg/ndctl"
@@ -56,8 +57,8 @@ func createVolumesForRegion(r *ndctl.Region, vgName string) error {
 		devName := "/dev/" + ns.BlockDeviceName()
 		/* check if this pv is already part of a group, if yes ignore this pv
 		   if not add to arg list */
-		_, err := pmemexec.RunCommand("pvdisplay", devName)
-		if err != nil {
+		output, err := pmemexec.RunCommand("pvs", "--noheadings", "-o", "vg_name", devName)
+		if err != nil || len(strings.TrimSpace(output)) == 0 {
 			cmdArgs = append(cmdArgs, devName)
 		}
 	}


### PR DESCRIPTION
We were expecting that pvdisplay returns error if it run on the existing physical
volume which is not part of any volume group, but our assumption was wrong.

To fix this case now we run "pvs -o vg_name" command on every physical volume it
returns it's exact volume group name if any other wise error.

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>