### PR TITLE
Repository name change: pmem-csi -> csi-pmem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMPORT_PATH=github.com/intel/pmem-csi
+IMPORT_PATH=github.com/intel/csi-pmem
 SHELL=bash
 
 REGISTRY_NAME=localhost:5000
@@ -114,7 +114,7 @@ RUNTIME_DEPS =
 RUNTIME_DEPS += go list -f '{{ join .Deps "\n" }}' ./cmd/pmem-csi-driver |
 
 # This focuses on packages that are not in Golang core.
-RUNTIME_DEPS += grep '^github.com/intel/pmem-csi/vendor/' |
+RUNTIME_DEPS += grep '^github.com/intel/csi-pmem/vendor/' |
 
 # Filter out some packages that aren't really code.
 RUNTIME_DEPS += grep -v -e 'github.com/container-storage-interface/spec' |
@@ -122,7 +122,7 @@ RUNTIME_DEPS += grep -v -e 'google.golang.org/genproto/googleapis/rpc/status' |
 
 # Reduce the package import paths to project names + download URL.
 # - strip prefix
-RUNTIME_DEPS += sed -e 's;github.com/intel/pmem-csi/vendor/;;' |
+RUNTIME_DEPS += sed -e 's;github.com/intel/csi-pmem/vendor/;;' |
 # - use path inside github.com as project name
 RUNTIME_DEPS += sed -e 's;^github.com/\([^/]*\)/\([^/]*\).*;github.com/\1/\2;' |
 # - everything from gRPC is one project

--- a/README.md
+++ b/README.md
@@ -196,15 +196,15 @@ The driver deployment in Kubernetes cluster has been verified on:
 
 ### Get source code
 
-Use the command: `git clone https://github.com/otcshare/Pmem-CSI pmem-csi`
+Use the command: `git clone https://github.com/otcshare/Pmem-CSI csi-pmem`
 
 > **NOTE:** The repository name is mixed-case but the paths are
 > lowercase-only. If you want to build the code using Go, then
-> the driver code must reside on the path `github.com/intel/pmem-csi/`
+> the driver code must reside on the path `github.com/intel/csi-pmem/`
 >
 > You must specify a different destination path when cloning:
-> `git clone .../Pmem-CSI pmem-csi`
-> or rename the directory from `Pmem-CSI` to `pmem-csi` after cloning.
+> `git clone .../Pmem-CSI csi-pmem`
+> or rename the directory from `Pmem-CSI` to `csi-pmem` after cloning.
 
 ### Build plugin
 

--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -10,11 +10,11 @@ RUN ./autogen.sh
 RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs with_systemd_unit_dir=no
 RUN make install
 
-# build pmem-csi-driver
-ADD . /go/src/github.com/intel/pmem-csi
-WORKDIR /go/src/github.com/intel/pmem-csi
-RUN make pmem-csi-driver
-RUN mv ./_output/pmem-csi-driver /go/bin/
+# build csi-pmem-driver
+ADD . /go/src/github.com/intel/csi-pmem
+WORKDIR /go/src/github.com/intel/csi-pmem
+RUN make csi-pmem-driver
+RUN mv ./_output/csi-pmem-driver /go/bin/
 
 # build clean container
 FROM golang:alpine
@@ -25,6 +25,6 @@ RUN apk add --update kmod eudev util-linux libuuid e2fsprogs lvm2 file
 COPY --from=build /usr/lib/libndctl* /usr/lib/
 COPY --from=build /usr/lib/libdaxctl* /usr/lib/
 RUN mkdir -p /go/bin
-COPY --from=build /go/bin/pmem-csi-driver /go/bin/
+COPY --from=build /go/bin/csi-pmem-driver /go/bin/
 
-ENTRYPOINT ["/go/bin/pmem-csi-driver"]
+ENTRYPOINT ["/go/bin/csi-pmem-driver"]

--- a/cmd/pmem-csi-driver/main.go
+++ b/cmd/pmem-csi-driver/main.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/intel/pmem-csi/pkg/pmem-csi-driver"
+	"github.com/intel/csi-pmem/pkg/pmem-csi-driver"
 )
 
 func init() {
@@ -23,7 +23,7 @@ var (
 	/* generic options */
 	driverName       = flag.String("drivername", "csi-pmem", "name of the driver")
 	nodeID           = flag.String("nodeid", "nodeid", "node id")
-	endpoint         = flag.String("endpoint", "unix:///tmp/pmem-csi.sock", "PMEM CSI endpoint")
+	endpoint         = flag.String("endpoint", "unix:///tmp/csi-pmem.sock", "PMEM CSI endpoint")
 	mode             = flag.String("mode", "unified", "driver run mode : controller, node or unified")
 	registryEndpoint = flag.String("registryEndpoint", "", "endpoint to connect/listen resgistery server")
 	/* node mode options */

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -11,8 +11,8 @@ RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/li
 RUN make install
 
 # build pmem-ns-init
-ADD . /go/src/github.com/intel/pmem-csi
-WORKDIR /go/src/github.com/intel/pmem-csi
+ADD . /go/src/github.com/intel/csi-pmem
+WORKDIR /go/src/github.com/intel/csi-pmem
 RUN make pmem-ns-init
 RUN mv ./_output/pmem-ns-init /go/bin/
 

--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	"github.com/intel/pmem-csi/pkg/ndctl"
+	"github.com/intel/csi-pmem/pkg/ndctl"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 var (
 	/* generic options */
 	//TODO: reading name configuration not yet supported
-	//configFile    = flag.String("configfile", "/etc/pmem-csi/config", "PMEM CSI driver namespace configuration file")
+	//configFile    = flag.String("configfile", "/etc/csi-pmem/config", "PMEM CSI driver namespace configuration file")
 	namespacesize = flag.Int("namespacesize", 32, "NVDIMM namespace size in GB")
 	uselimit      = flag.Int("uselimit", 100, "Limit use of total PMEM amount, used percent")
 )

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -11,8 +11,8 @@ RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/li
 RUN make install
 
 # build pmem-vgm
-ADD . /go/src/github.com/intel/pmem-csi
-WORKDIR /go/src/github.com/intel/pmem-csi
+ADD . /go/src/github.com/intel/csi-pmem
+WORKDIR /go/src/github.com/intel/csi-pmem
 RUN make pmem-vgm
 RUN mv ./_output/pmem-vgm /go/bin/
 

--- a/cmd/pmem-vgm/main.go
+++ b/cmd/pmem-vgm/main.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/intel/pmem-csi/pkg/ndctl"
-	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
+	"github.com/intel/csi-pmem/pkg/ndctl"
+	pmemexec "github.com/intel/csi-pmem/pkg/pmem-exec"
 )
 
 func init() {

--- a/docs/diagrams/sequence.wsd
+++ b/docs/diagrams/sequence.wsd
@@ -1,6 +1,6 @@
 @startuml "pmem-csi-sequence-diagram"
 
-title \nDynamic volume provisioning with pmem-csi driver\n
+title \nDynamic volume provisioning with csi-pmem driver\n
 
 skinparam BoxPadding 40
 

--- a/pkg/pmem-csi-driver/controllerserver.go
+++ b/pkg/pmem-csi-driver/controllerserver.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 
-	"github.com/intel/pmem-csi/pkg/pmem-common"
-	pmdmanager "github.com/intel/pmem-csi/pkg/pmem-device-manager"
-	"github.com/intel/pmem-csi/pkg/pmem-grpc"
+	"github.com/intel/csi-pmem/pkg/pmem-common"
+	pmdmanager "github.com/intel/csi-pmem/pkg/pmem-device-manager"
+	"github.com/intel/csi-pmem/pkg/pmem-grpc"
 )
 
 //VolumeStatus type representation for volume status

--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -19,9 +19,9 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 
 	"github.com/golang/glog"
-	"github.com/intel/pmem-csi/pkg/pmem-common"
-	pmdmanager "github.com/intel/pmem-csi/pkg/pmem-device-manager"
-	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
+	"github.com/intel/csi-pmem/pkg/pmem-common"
+	pmdmanager "github.com/intel/csi-pmem/pkg/pmem-device-manager"
+	pmemexec "github.com/intel/csi-pmem/pkg/pmem-exec"
 )
 
 type nodeServer struct {

--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"github.com/golang/glog"
-	pmdmanager "github.com/intel/pmem-csi/pkg/pmem-device-manager"
-	pmemgrpc "github.com/intel/pmem-csi/pkg/pmem-grpc"
-	registry "github.com/intel/pmem-csi/pkg/pmem-registry"
+	pmdmanager "github.com/intel/csi-pmem/pkg/pmem-device-manager"
+	pmemgrpc "github.com/intel/csi-pmem/pkg/pmem-grpc"
+	registry "github.com/intel/csi-pmem/pkg/pmem-registry"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/pmem-csi-driver/registryserver.go
+++ b/pkg/pmem-csi-driver/registryserver.go
@@ -3,7 +3,7 @@ package pmemcsidriver
 import (
 	"fmt"
 
-	"github.com/intel/pmem-csi/pkg/pmem-registry"
+	"github.com/intel/csi-pmem/pkg/pmem-registry"
 	"golang.org/x/net/context"
 )
 

--- a/pkg/pmem-csi-driver/server.go
+++ b/pkg/pmem-csi-driver/server.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/intel/pmem-csi/pkg/pmem-grpc"
+	"github.com/intel/csi-pmem/pkg/pmem-grpc"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/intel/pmem-csi/pkg/ndctl"
-	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
+	"github.com/intel/csi-pmem/pkg/ndctl"
+	pmemexec "github.com/intel/csi-pmem/pkg/pmem-exec"
 )
 
 type pmemLvm struct {

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/intel/pmem-csi/pkg/ndctl"
+	"github.com/intel/csi-pmem/pkg/ndctl"
 )
 
 type pmemNdctl struct {

--- a/pkg/pmem-grpc/grpc.go
+++ b/pkg/pmem-grpc/grpc.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 
-	"github.com/intel/pmem-csi/pkg/pmem-common"
+	"github.com/intel/csi-pmem/pkg/pmem-common"
 )
 
 func Connect(endpoint string, timeout time.Duration) (*grpc.ClientConn, error) {


### PR DESCRIPTION
This commit changes all occurrence of 'pmem-csi' to 'csi-pmem' in:
- go package import paths
- relevant parts in ReadMe documentation

We still using the binary/docker image names with 'pmem-' prefix.