### PR TITLE
SSL support added to registry server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -171,6 +171,8 @@
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/connectivity",
+    "google.golang.org/grpc/credentials",
+    "google.golang.org/grpc/resolver",
     "google.golang.org/grpc/status",
     "k8s.io/kubernetes/pkg/util/mount",
   ]

--- a/cmd/pmem-csi-driver/main.go
+++ b/cmd/pmem-csi-driver/main.go
@@ -25,7 +25,10 @@ var (
 	nodeID           = flag.String("nodeid", "nodeid", "node id")
 	endpoint         = flag.String("endpoint", "unix:///tmp/csi-pmem.sock", "PMEM CSI endpoint")
 	mode             = flag.String("mode", "unified", "driver run mode : controller, node or unified")
-	registryEndpoint = flag.String("registryEndpoint", "", "endpoint to connect/listen resgistery server")
+	registryEndpoint = flag.String("registryEndpoint", "", "endpoint to connect/listen registry server")
+	registryCertFile = flag.String("registryCertFile", "", "certificate file to use for registry server")
+	/* controller mode options */
+	registryKeyFile = flag.String("registryKeyFile", "", "key file to use for registry server")
 	/* node mode options */
 	controllerEndpoint = flag.String("controllerEndpoint", "", "internal node controller endpoint")
 	deviceManager      = flag.String("deviceManager", "lvm", "device manager to use to manage pmem devices. supported types: 'lvm' or 'ndctl'")
@@ -40,6 +43,8 @@ func main() {
 		Endpoint:           *endpoint,
 		Mode:               pmemcsidriver.DriverMode(*mode),
 		RegistryEndpoint:   *registryEndpoint,
+		RegistryCertFile:   *registryCertFile,
+		RegistryKeyFile:    *registryKeyFile,
 		ControllerEndpoint: *controllerEndpoint,
 		DeviceManager:      *deviceManager,
 	})

--- a/pkg/pmem-csi-driver/controllerserver.go
+++ b/pkg/pmem-csi-driver/controllerserver.go
@@ -307,7 +307,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
 
-		conn, err := pmemgrpc.Connect(node.Endpoint, connectionTimeout)
+		conn, err := pmemgrpc.Connect(node.Endpoint, "", connectionTimeout)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -381,7 +381,7 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 		if err != nil {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
-		conn, errr := pmemgrpc.Connect(node.Endpoint, connectionTimeout)
+		conn, errr := pmemgrpc.Connect(node.Endpoint, "", connectionTimeout)
 		if errr != nil {
 			return nil, status.Error(codes.Internal, errr.Error())
 		}

--- a/pkg/pmem-csi-driver/registryserver.go
+++ b/pkg/pmem-csi-driver/registryserver.go
@@ -44,7 +44,7 @@ func (rs *registryServer) RegisterController(ctx context.Context, req *registry.
 		return nil, fmt.Errorf("Missing endpoint address")
 	}
 
-	fmt.Printf("Registring node: %s, endpont: %s", req.NodeId, req.Endpoint)
+	fmt.Printf("Registering node: %s, endpont: %s", req.NodeId, req.Endpoint)
 
 	rs.nodeClients[req.NodeId] = NodeInfo{
 		NodeID:   req.NodeId,

--- a/pkg/pmem-csi-driver/server.go
+++ b/pkg/pmem-csi-driver/server.go
@@ -17,7 +17,7 @@ import (
 // Defines Non blocking GRPC server interfaces
 type NonBlockingGRPCServer interface {
 	// Start services at the endpoint
-	Start(endpoint string, register pmemgrpc.RegisterService) error
+	Start(endpoint, certFile, keyFile string, register pmemgrpc.RegisterService) error
 	// Waits for the service to stop
 	Wait()
 	// Stops the service gracefully
@@ -36,12 +36,15 @@ type nonBlockingGRPCServer struct {
 	servers []*grpc.Server
 }
 
-func (s *nonBlockingGRPCServer) Start(endpoint string, register pmemgrpc.RegisterService) error {
+func (s *nonBlockingGRPCServer) Start(endpoint, certFile, keyFile string, register pmemgrpc.RegisterService) error {
 	if endpoint == "" {
 		return fmt.Errorf("endpoint cannot be empty")
 	}
 	s.wg.Add(1)
-	return pmemgrpc.StartNewServer(endpoint, register)
+	server, err := pmemgrpc.StartNewServer(endpoint, certFile, keyFile, register)
+	s.servers = append(s.servers, server)
+
+	return err
 }
 
 func (s *nonBlockingGRPCServer) Wait() {


### PR DESCRIPTION
This change adds support for securing controller <-> node communication by
enabling ssl credentials. Provided ssl certificate and private key files are used
while starting the registry server.

Added new command line arguments to pmem-csi-driver:
 -registryCertFile : SSL certificate file path
 -registryKeyFile  : Private key file path

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>