### PR TITLE
cmd/pmem-ns-init/main.go: hotfix missing arg

### DIFF
--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -50,7 +50,7 @@ func initNVdimms(ctx *ndctl.Context, namespacesize int, useforfsdax int, usefors
 	// TODO: Should we detect device(s) explicitly here?
 
 	glog.Infof("Configured namespacesize; %v GB", namespacesize)
-	createNamespaces(ctx, namespacesize, uselimit)
+	createNamespaces(ctx, namespacesize, useforfsdax, useforsector)
 	/* for debug
 	nss := ctx.GetActiveNamespaces()
 	glog.Info("elems in Namespaces:", len(nss))


### PR DESCRIPTION
This somehow escaped recent namespacemode change set