### PR TITLE
controllerserver.go: hotfix misspelled word

### DIFF
--- a/pkg/pmem-csi-driver/controllerserver.go
+++ b/pkg/pmem-csi-driver/controllerserver.go
@@ -358,7 +358,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		}
 		volumeName = attrs["name"]
 		volumeSize, _ = strconv.ParseUint(attrs["size"], 10, 64)
-		nsmode = attrs["nsname"]
+		nsmode = attrs["nsmode"]
 	} else /* if cs.mode == Unified */ {
 		vol, ok := cs.pmemVolumes[req.VolumeId]
 		if !ok {


### PR DESCRIPTION
which was broken coming in with recent namespacemode change set