### PR TITLE
Use correct mode=safe for sector-mode namespace

### DIFF
--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -84,8 +84,8 @@ func createNamespaces(ctx *ndctl.Context, namespacesize int, useforfsdax int, us
 	nsSize := (uint64(namespacesize) * 1024 * 1024 * 1024)
 	for _, bus := range ctx.GetBuses() {
 		for _, r := range bus.ActiveRegions() {
-			createNS(r, nsSize, useforfsdax, "fsdax")
-			createNS(r, nsSize, useforsector, "sector")
+			createNS(r, nsSize, useforfsdax, ndctl.FsdaxMode)
+			createNS(r, nsSize, useforsector, ndctl.SectorMode)
 		}
 	}
 }

--- a/cmd/pmem-vgm/main.go
+++ b/cmd/pmem-vgm/main.go
@@ -33,7 +33,7 @@ func prepareVolumeGroups(ctx *ndctl.Context) {
 		glog.Infof("CheckVG: Bus: %v", bus.DeviceName())
 		for _, r := range bus.ActiveRegions() {
 			glog.Infof("Region: %v", r.DeviceName())
-			nsmodes := []string{"fsdax", "sector"}
+			nsmodes := []ndctl.NamespaceMode{ndctl.FsdaxMode, ndctl.SectorMode}
 			for _, nsmod := range nsmodes {
 				glog.Infof("NsMode: %v", nsmod)
 				vgName := vgName(bus, r, nsmod)
@@ -45,11 +45,11 @@ func prepareVolumeGroups(ctx *ndctl.Context) {
 	}
 }
 
-func vgName(bus *ndctl.Bus, region *ndctl.Region, nsmode string) string {
-	return bus.DeviceName() + region.DeviceName() + nsmode
+func vgName(bus *ndctl.Bus, region *ndctl.Region, nsmode ndctl.NamespaceMode) string {
+	return bus.DeviceName() + region.DeviceName() + string(nsmode)
 }
 
-func createVolumesForRegion(r *ndctl.Region, vgName string, nsmode string) error {
+func createVolumesForRegion(r *ndctl.Region, vgName string, nsmode ndctl.NamespaceMode) error {
 	cmd := ""
 	cmdArgs := []string{"--force", vgName}
 	nsArray := r.ActiveNamespaces()
@@ -87,6 +87,6 @@ func createVolumesForRegion(r *ndctl.Region, vgName string, nsmode string) error
 		return err
 	}
 	// Tag add works without error if repeated, so it is safe to run without checking for existing
-	_, err = pmemexec.RunCommand("vgchange", "--addtag", nsmode, vgName)
+	_, err = pmemexec.RunCommand("vgchange", "--addtag", string(nsmode), vgName)
 	return err
 }

--- a/pkg/ndctl/namespace.go
+++ b/pkg/ndctl/namespace.go
@@ -32,7 +32,7 @@ const (
 	DaxMode     NamespaceMode = "dax"   //DevDax
 	FsdaxMode   NamespaceMode = "fsdax" //Memory
 	RawMode     NamespaceMode = "raw"
-	SafeMode    NamespaceMode = "safe"
+	SectorMode  NamespaceMode = "sector"
 	UnknownMode NamespaceMode = "unknown"
 )
 
@@ -56,7 +56,7 @@ func (mode NamespaceMode) toCMode() C.enum_ndctl_namespace_mode {
 		return C.NDCTL_NS_MODE_FSDAX
 	case RawMode:
 		return C.NDCTL_NS_MODE_RAW
-	case SafeMode:
+	case SectorMode:
 		return C.NDCTL_NS_MODE_SAFE
 	}
 	return C.NDCTL_NS_MODE_UNKNOWN
@@ -135,7 +135,7 @@ func (ns *Namespace) Size() uint64 {
 		if DaxMode := C.ndctl_namespace_get_dax(ndns); DaxMode != nil {
 			size = C.ndctl_dax_get_size(DaxMode)
 		}
-	case SafeMode:
+	case SectorMode:
 		if btt := C.ndctl_namespace_get_btt(ndns); btt != nil {
 			size = C.ndctl_btt_get_size(btt)
 		}
@@ -164,7 +164,7 @@ func (ns *Namespace) Mode() NamespaceMode {
 	}
 
 	if mode == C.NDCTL_NS_MODE_SAFE {
-		return SafeMode
+		return SectorMode
 	}
 
 	return UnknownMode

--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -127,7 +127,7 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 		if opts.Type == PmemNamespace {
 			opts.Mode = FsdaxMode // == MemoryMode
 		} else {
-			opts.Mode = SafeMode
+			opts.Mode = SectorMode
 		}
 	}
 	if opts.Location == "" {
@@ -135,7 +135,7 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 	}
 
 	if opts.SectorSize == 0 {
-		if opts.Type == BlockNamespace || opts.Mode == SafeMode {
+		if opts.Type == BlockNamespace || opts.Mode == SectorMode {
 			// default sector size for blk-type or safe-mode
 			opts.SectorSize = kib4
 		}
@@ -168,7 +168,7 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 	}
 
 	if opts.Align != 0 {
-		if opts.Mode == SafeMode || opts.Mode == RawMode {
+		if opts.Mode == SectorMode || opts.Mode == RawMode {
 			glog.Infof("%s mode does not support setting an alignment, hence ignoring alignment", opts.Mode)
 		} else {
 			resource := uint64(C.ndctl_region_get_resource(ndr))
@@ -230,7 +230,7 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 		case DaxMode:
 			glog.Infof("setting dax")
 			err = ns.setDaxSeed(opts.Location, uint64(opts.Align))
-		case SafeMode:
+		case SectorMode:
 			glog.Infof("setting btt")
 			err = ns.setBttSeed(opts.SectorSize)
 		}

--- a/pkg/pmem-csi-driver/controllerserver.go
+++ b/pkg/pmem-csi-driver/controllerserver.go
@@ -129,10 +129,8 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 					eraseafter = false
 				}
 			} else if key == "nsmode" {
-				if val == "fsdax" {
-					nsmode = "fsdax"
-				} else if val == "sector" {
-					nsmode = "sector"
+				if val == "fsdax" || val == "sector" {
+					nsmode = val
 				}
 			}
 		}


### PR DESCRIPTION
 Enable use of both names sector, safe for namespace modes
   
Remapping for "SAFE" for libndctl layer will happen only
in function in ndctl layer.
Reduced use of hard-coded strings for NS mode.