### PR TITLE
ndctl/region.go: reverse opts.Name check to make Namespace name assignement work

### DIFF
--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -209,7 +209,7 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 		if err == nil {
 			err = ns.SetSize(opts.Size)
 		}
-		if err == nil && opts.Name == "" {
+		if err == nil && opts.Name != "" {
 			err = ns.SetAltName(opts.Name)
 		}
 	}


### PR DESCRIPTION
This check seems accidentally being wrong way, we should
set name if it's not empty.