### PR TITLE
Use Namespace name to mark own vs foreign Namespaces

### DIFF
--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -98,7 +98,7 @@ func createNS(r *ndctl.Region, nsSize uint64, uselimit int, nsmode ndctl.Namespa
 	// Find sum of sizes of existing active namespaces with currently handled mode
 	var used uint64 = 0
 	for _, ns := range r.ActiveNamespaces() {
-		glog.Infof("createNS: Existing namespace: Size %16d Mode: %v Device:%v", ns.Size(), ns.Mode(), ns.DeviceName())
+		glog.Infof("createNS: Exists: Size %16d Mode:%v Device:%v Name:%v", ns.Size(), ns.Mode(), ns.DeviceName(), ns.Name())
 		if ns.Mode() == nsmode {
 			used += ns.Size() + namespaceOverhead
 		}
@@ -116,6 +116,7 @@ func createNS(r *ndctl.Region, nsSize uint64, uselimit int, nsmode ndctl.Namespa
 		for i := 0; i < nPossibleNS; i++ {
 			glog.Infof("Creating namespace %d", i)
 			_, err := r.CreateNamespace(ndctl.CreateNamespaceOpts{
+				Name: "csi-pmem",
 				Mode: nsmode,
 				Size: nsSize,
 				// TODO: setting mapping location to "mem" avoids use (and problems in qemu env) of pfn

--- a/cmd/pmem-vgm/main.go
+++ b/cmd/pmem-vgm/main.go
@@ -58,8 +58,9 @@ func createVolumesForRegion(r *ndctl.Region, vgName string, nsmode ndctl.Namespa
 		return nil
 	}
 	for _, ns := range nsArray {
-		// consider only namespaces in asked namespacemode
-		if ns.Mode() == ndctl.NamespaceMode(nsmode) {
+		// consider only namespaces in asked namespacemode,
+		// and having name given by this driver, to exclude foreign ones
+		if ns.Mode() == ndctl.NamespaceMode(nsmode) && ns.Name() == "csi-pmem" {
 			devName := "/dev/" + ns.BlockDeviceName()
 			glog.Infof("createVolumesForRegion: %s has nsmode %s", ns.BlockDeviceName(), nsmode)
 			/* check if this pv is already part of a group, if yes ignore this pv


### PR DESCRIPTION
In Namespace creation, we give them fixed name "csi-pmem".
During adding to Volume Groups, we only consider "own" namespaces.
The name is now as static string in two places, which is not so good,
but these are built as separate binaries, so they don't share much.