### PR TITLE
Reduce use of "nvdimm" in favor of pmem

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ This runs two preparation parts, and starts the driver binary, which listens and
 - **Label the cluster nodes that have NVDIMM support**
 
 ```sh
-    $ kubectl label node pmem-csi-4 storage=nvdimm
-    $ kubectl label node pmem-csi-5 storage=nvdimm
+    $ kubectl label node pmem-csi-4 storage=pmem
+    $ kubectl label node pmem-csi-5 storage=pmem
 ```
 
 - **Deploy the driver to Kubernetes**
@@ -210,8 +210,8 @@ This runs two preparation parts, and starts the driver binary, which listens and
 **Notes:**
 
 * The images registry address in the manifest is not final and may need tuning.
-* A label **storage: nvdimm** needs to be added to the cluster node that provides NVDIMM device(s).
-* The application should add **storage: nvdimm** to its <i>nodeSelector</i> list.
+* A label **storage: pmem** needs to be added to the cluster node that provides NVDIMM device(s).
+* The application should add **storage: pmem** to its <i>nodeSelector</i> list.
 
 
 ## Test plugin

--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -21,7 +21,7 @@ var (
 	/* generic options */
 	//TODO: reading name configuration not yet supported
 	//configFile    = flag.String("configfile", "/etc/csi-pmem/config", "PMEM CSI driver namespace configuration file")
-	namespacesize = flag.Int("namespacesize", 32, "NVDIMM namespace size in GB")
+	namespacesize = flag.Int("namespacesize", 32, "Namespace size in GB")
 	useforfsdax   = flag.Int("useforfsdax", 100, "Percentage of total to use in Fsdax mode")
 	useforsector  = flag.Int("useforsector", 0, "Percentage of total to use in Sector mode")
 )

--- a/deploy/k8s/pmem-app.yaml
+++ b/deploy/k8s/pmem-app.yaml
@@ -11,7 +11,7 @@ spec:
       - mountPath: "/data"
         name: my-csi-volume
   nodeSelector:
-    storage: nvdimm
+    storage: pmem
   volumes:
   - name: my-csi-volume
     persistentVolumeClaim:

--- a/deploy/k8s/pmem-csi.yaml
+++ b/deploy/k8s/pmem-csi.yaml
@@ -134,7 +134,7 @@ spec:
     spec:
       serviceAccount: csi-service-account
       nodeSelector:
-        storage: nvdimm
+        storage: pmem
       hostNetwork: true
       initContainers:
       - name: pmem-ns-init


### PR DESCRIPTION
In recent overview mtg it was pointed out we should stick to one
notation, either pmem or nvdimm, and as we have lot of pmem
used already, let's change some more of "nvdimm" to "pmem".