### PR TITLE
pmem-ns-init/main.go: simplify namespace creation, use leftover

### DIFF
--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -187,8 +187,9 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 	if opts.Size != 0 {
 		ways := uint32(C.ndctl_region_get_interleave_ways(ndr))
 		if opts.Size%uint64(opts.Align*ways) != 0 {
-			return nil, fmt.Errorf("size(%v) must align to interleave-width(%v) and alignment: %v",
-				opts.Size, ways, opts.Align)
+			opts.Size &= ^uint64(opts.Align*ways - 1)
+			glog.Warningf("%s: NS size must align to interleave-width(%v) and alignment: %v, force-align to %v",
+				regionName, ways, opts.Align, opts.Size)
 		}
 	}
 


### PR DESCRIPTION
Namespace creation is simplified and instead of creating fixed
amount of namespaces we calculate, we advance in while-style loop
until all allowed space is used. The last,smaller namespace will use
all remaining space, thus solving unused-leftover problem we had,
also it solves "cant fit 4G into 4G region" risk.
In addition we try tp do it all without hard-coding namespace
overhead. But we start taking account alignement rounding.
Also, this commit adds check for "own" namespace name
if adding up already use space, this check remained missing
in an earlier change when we introduced own vs foreign checks.