### PR TITLE
ndctl/region.go: fix fallback alignement in Region.CreateNamespace

### DIFF
--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -172,7 +172,7 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 			glog.Infof("%s mode does not support setting an alignment, hence ignoring alignment", opts.Mode)
 		} else {
 			resource := uint64(C.ndctl_region_get_resource(ndr))
-			if resource < uint64(C.ULLONG_MAX) && resource&(mib2-1) == 0 {
+			if resource < uint64(C.ULLONG_MAX) && resource&(mib2-1) != 0 {
 				glog.Infof("%s: falling back to a 4K alignment", regionName)
 				opts.Align = uint32(kib4)
 			}


### PR DESCRIPTION
This code seems to mimic it's counterpart in ndctl namespace.c
However the check for lower bits being non-zero is other way.