### PR TITLE
pmd-ndctl.go: implement FlushDeviceData

### DIFF
--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -70,7 +70,11 @@ func (pmem *pmemNdctl) DeleteDevice(name string, flush bool) error {
 }
 
 func (pmem *pmemNdctl) FlushDeviceData(name string) error {
-	return fmt.Errorf("Unsupported for pmem devices")
+	device, err := pmem.GetDevice(name)
+	if err != nil {
+		return err
+	}
+	return flushDevice(device)
 }
 
 func (pmem *pmemNdctl) GetDevice(name string) (PmemDeviceInfo, error) {


### PR DESCRIPTION
call flushDevice on block device, this improves pass rate
of csi-sanity in direct-nvdimm mode.