### PR TITLE
Dockerfiles: advance to ndctl version 63, use single version definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_VERSION_pmem-csi-driver=canary
 IMAGE_VERSION_pmem-ns-init=canary
 IMAGE_VERSION_pmem-vgm=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$*:$(IMAGE_VERSION_$*)
-IMAGE_BUILD_ARGS=
+IMAGE_BUILD_ARGS=--build-arg NDCTLVER=63
 # Pass proxy config via --build-arg only if these are set,
 # enabling proxy config other way, like ~/.docker/config.json
 BUILD_ARGS=

--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -2,10 +2,11 @@ FROM golang:alpine AS build
 #pull dependencies required for downloading and building libndctl
 RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
+ARG NDCTLVER
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v63.tar.gz
-RUN tar zxvf v63.tar.gz
-WORKDIR /ndctl-63
+RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
+RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
+WORKDIR /ndctl
 RUN ./autogen.sh
 RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
 RUN make install

--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:alpine AS build
 #pull dependencies required for downloading and building libndctl
-RUN apk add --update build-base autoconf automake libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
+RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v62.tar.gz
-RUN tar zxvf v62.tar.gz
-WORKDIR /ndctl-62
+RUN wget https://github.com/pmem/ndctl/archive/v63.tar.gz
+RUN tar zxvf v63.tar.gz
+WORKDIR /ndctl-63
 RUN ./autogen.sh
-RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs with_systemd_unit_dir=no
+RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
 RUN make install
 
 # build pmem-csi-driver

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -2,10 +2,11 @@ FROM golang:alpine AS build
 #pull dependencies required for downloading and building libndctl
 RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
+ARG NDCTLVER
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v63.tar.gz
-RUN tar zxvf v63.tar.gz
-WORKDIR /ndctl-63
+RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
+RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
+WORKDIR /ndctl
 RUN ./autogen.sh
 RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
 RUN make install

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:alpine AS build
 #pull dependencies required for downloading and building libndctl
-RUN apk add --update build-base autoconf automake libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
+RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v62.tar.gz
-RUN tar zxvf v62.tar.gz
-WORKDIR /ndctl-62
+RUN wget https://github.com/pmem/ndctl/archive/v63.tar.gz
+RUN tar zxvf v63.tar.gz
+WORKDIR /ndctl-63
 RUN ./autogen.sh
-RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs with_systemd_unit_dir=no
+RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
 RUN make install
 
 # build pmem-ns-init

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -2,10 +2,11 @@ FROM golang:alpine AS build
 #pull dependencies required for downloading and building libndctl
 RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
+ARG NDCTLVER
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v63.tar.gz
-RUN tar zxvf v63.tar.gz
-WORKDIR /ndctl-63
+RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
+RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
+WORKDIR /ndctl
 RUN ./autogen.sh
 RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
 RUN make install

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:alpine AS build
 #pull dependencies required for downloading and building libndctl
-RUN apk add --update build-base autoconf automake libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
+RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v62.tar.gz
-RUN tar zxvf v62.tar.gz
-WORKDIR /ndctl-62
+RUN wget https://github.com/pmem/ndctl/archive/v63.tar.gz
+RUN tar zxvf v63.tar.gz
+WORKDIR /ndctl-63
 RUN ./autogen.sh
-RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs with_systemd_unit_dir=no
+RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
 RUN make install
 
 # build pmem-vgm


### PR DESCRIPTION
This change required addition of bash-completion to deps,
and --without-systemd in config options.