### PR TITLE
pmem-ns-init: Avoid zero-size namespace creation request

### DIFF
--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -100,6 +100,10 @@ func createNS(r *ndctl.Region, nsSize uint64, uselimit int, nsmode ndctl.Namespa
 			glog.Infof("MaxAvailableExtent in Region:%v is less than desired nsSize, limit nsSize to that", r.MaxAvailableExtent())
 			nsSize = r.MaxAvailableExtent()
 		}
+		// In typical case, NSize drops to zero at some point, avoid zero-size create request
+		if nsSize == 0 {
+			break
+		}
 		glog.Infof("Create next %v-bytes %s-namespace", nsSize, nsmode)
 		_, err := r.CreateNamespace(ndctl.CreateNamespaceOpts{
 			Name: "pmem-csi",


### PR DESCRIPTION
At some point in creation loop, we typically reach the state
where calculated size remains available but actual available
is zero, so detect this and break, instead of calling
zero-size creation request and breaking loop
based on returned error.
Fixes #125 