### PR TITLE
pmem-csi-driver: add install of xfsprogs in Dockerfile

### DIFF
--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -21,7 +21,7 @@ RUN mv ./_output/pmem-csi-driver /go/bin/
 FROM golang:alpine
 LABEL maintainers="Intel"
 LABEL description="Pmem CSI Driver"
-RUN apk add --update kmod eudev util-linux libuuid e2fsprogs lvm2 file
+RUN apk add --update kmod eudev util-linux libuuid e2fsprogs xfsprogs lvm2 file
 # move required binaries and libraries to clean container
 COPY --from=build /usr/lib/libndctl* /usr/lib/
 COPY --from=build /usr/lib/libdaxctl* /usr/lib/


### PR DESCRIPTION
We have to support ext4 and xfs file systems. Lack of xfs
utils remained undetected as by default testers use ext4.

Fixes #135