### PR TITLE
Docker build of ndctl: specify config flags once without defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_VERSION_pmem-csi-driver=canary
 IMAGE_VERSION_pmem-ns-init=canary
 IMAGE_VERSION_pmem-vgm=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$*:$(IMAGE_VERSION_$*)
-IMAGE_BUILD_ARGS=--build-arg NDCTLVER=63
+IMAGE_BUILD_ARGS=--build-arg NDCTLVER=63 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd'
 # Pass proxy config via --build-arg only if these are set,
 # enabling proxy config other way, like ~/.docker/config.json
 BUILD_ARGS=

--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -3,12 +3,13 @@ FROM golang:alpine AS build
 RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 ARG NDCTLVER
+ARG NDCTL_CONFIGFLAGS
 WORKDIR /
 RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
 RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
 WORKDIR /ndctl
 RUN ./autogen.sh
-RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
+RUN ./configure ${NDCTL_CONFIGFLAGS}
 RUN make install
 
 # build pmem-csi-driver

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -3,12 +3,13 @@ FROM golang:alpine AS build
 RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 ARG NDCTLVER
+ARG NDCTL_CONFIGFLAGS
 WORKDIR /
 RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
 RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
 WORKDIR /ndctl
 RUN ./autogen.sh
-RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
+RUN ./configure ${NDCTL_CONFIGFLAGS}
 RUN make install
 
 # build pmem-ns-init

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -3,12 +3,13 @@ FROM golang:alpine AS build
 RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 ARG NDCTLVER
+ARG NDCTL_CONFIGFLAGS
 WORKDIR /
 RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
 RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
 WORKDIR /ndctl
 RUN ./autogen.sh
-RUN ./configure CFLAGS='-g -O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --disable-docs --without-systemd
+RUN ./configure ${NDCTL_CONFIGFLAGS}
 RUN make install
 
 # build pmem-vgm


### PR DESCRIPTION
Instead of repeated flags for configure pass of ndctl,
define flags once in Makefile and pass via build-args parameter.
Also, do not specify those flags which are same with defaults.