### PR TITLE
Fix to test failure

### DIFF
--- a/pkg/pmem-csi-driver/registryserver_test.go
+++ b/pkg/pmem-csi-driver/registryserver_test.go
@@ -113,9 +113,6 @@ var _ = Describe("pmem registry", func() {
 			registerReq = registry.RegisterControllerRequest{
 				NodeId:   nodeId,
 				Endpoint: controllerServerEndpoint,
-				Capacity: map[string]uint64{
-					"fsdax": 1 * 1024 * 1024, // 1GB
-				},
 			}
 
 			unregisterReq = registry.UnregisterControllerRequest{
@@ -198,9 +195,6 @@ var _ = Describe("pmem registry", func() {
 				req := registry.RegisterControllerRequest{
 					NodeId:   "pmem-evil",
 					Endpoint: evilEndpoint,
-					Capacity: map[string]uint64{
-						"fsdax": 1 * 1024 * 1024, // 1GB
-					},
 				}
 
 				_, err = client.RegisterController(context.Background(), &req)


### PR DESCRIPTION
In reset change 911d0b97fb4308fabf8d076012b9e3a95a40b9b6, where Capacity field in
RegisterControllerRequest is removed. This needs fixes to registry tests.

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>