### PR TITLE
test fixes: don't use old-style tail +N option

### DIFF
--- a/test/test.make
+++ b/test/test.make
@@ -26,7 +26,7 @@ fmt:
 test: test_vendor_bom
 test_vendor_bom:
 	@ if ! diff -c \
-		<(tail +2 vendor-bom.csv | sed -e 's/;.*//') \
+		<(tail -n +2 vendor-bom.csv | sed -e 's/;.*//') \
 		<((grep '^  name =' Gopkg.lock  | sed -e 's/.*"\(.*\)"/\1/') | sort); then \
 		echo; \
 		echo "vendor-bom.csv not in sync with vendor directory (aka Gopk.lock):"; \


### PR DESCRIPTION
Not all systems accept old-style tail +N option,
result will be failure opening file:+2 and
showing 10 lines from file we wanted.

P.S. seems my editor added newline as complimentary fix