### PR TITLE
test/e2e: use kubernetes-1.13 path for manifest

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -102,7 +102,7 @@ var _ = Describe("PMEM Volumes", func() {
 						ClientNodeName: "host-1",
 					},
 				},
-				scManifest: "deploy/kubernetes/pmem-storageclass.yaml",
+				scManifest: "deploy/kubernetes-1.13/pmem-storageclass.yaml",
 				// Renaming of the driver *not* enabled. It doesn't support
 				// that because there is only one instance of the registry
 				// and on each node the driver assumes that it has exclusive


### PR DESCRIPTION
This reduces e2e test failure count 4->3
We may consider using symlinks in deploy/ directory instead of explicit path
which we have to maintain then in sources, but as elsewhere already kubernetes-1.13 was used,
I continue same style here.