### PR TITLE
advance to ndctl version 64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_VERSION_pmem-csi-driver=canary
 IMAGE_VERSION_pmem-ns-init=canary
 IMAGE_VERSION_pmem-vgm=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$*:$(IMAGE_VERSION_$*)
-IMAGE_BUILD_ARGS=--build-arg NDCTLVER=63 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd'
+IMAGE_BUILD_ARGS=--build-arg NDCTLVER=63 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd' --build-arg NDCTL_BUILD_DEPS='build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file'
 # Pass proxy config via --build-arg only if these are set,
 # enabling proxy config other way, like ~/.docker/config.json
 BUILD_ARGS=

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_VERSION_pmem-csi-driver=canary
 IMAGE_VERSION_pmem-ns-init=canary
 IMAGE_VERSION_pmem-vgm=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$*:$(IMAGE_VERSION_$*)
-IMAGE_BUILD_ARGS=--build-arg NDCTLVER=63 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd' --build-arg NDCTL_BUILD_DEPS='build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file'
+IMAGE_BUILD_ARGS=--build-arg NDCTLVER=64 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd' --build-arg NDCTL_BUILD_DEPS='build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file keyutils-dev'
 # Pass proxy config via --build-arg only if these are set,
 # enabling proxy config other way, like ~/.docker/config.json
 BUILD_ARGS=

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_VERSION_pmem-csi-driver=canary
 IMAGE_VERSION_pmem-ns-init=canary
 IMAGE_VERSION_pmem-vgm=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$*:$(IMAGE_VERSION_$*)
-IMAGE_BUILD_ARGS=--build-arg NDCTLVER=64 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd' --build-arg NDCTL_BUILD_DEPS='build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file keyutils-dev'
+IMAGE_BUILD_ARGS=--build-arg NDCTL_VERSION=64 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd' --build-arg NDCTL_BUILD_DEPS='build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file keyutils-dev'
 # Pass proxy config via --build-arg only if these are set,
 # enabling proxy config other way, like ~/.docker/config.json
 BUILD_ARGS=

--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:alpine AS build
-#pull dependencies required for downloading and building libndctl
-RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 ARG NDCTLVER
 ARG NDCTL_CONFIGFLAGS
+ARG NDCTL_BUILD_DEPS
+#pull dependencies required for downloading and building libndctl
+RUN apk add --update ${NDCTL_BUILD_DEPS}
+
 WORKDIR /
 RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
 RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl

--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -1,14 +1,14 @@
 FROM golang:alpine AS build
 
-ARG NDCTLVER
+ARG NDCTL_VERSION
 ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
 #pull dependencies required for downloading and building libndctl
 RUN apk add --update ${NDCTL_BUILD_DEPS}
 
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
-RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
+RUN wget https://github.com/pmem/ndctl/archive/v${NDCTL_VERSION}.tar.gz
+RUN tar zxvf v${NDCTL_VERSION}.tar.gz && mv ndctl-${NDCTL_VERSION} ndctl
 WORKDIR /ndctl
 RUN ./autogen.sh
 RUN ./configure ${NDCTL_CONFIGFLAGS}

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:alpine AS build
-#pull dependencies required for downloading and building libndctl
-RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 ARG NDCTLVER
 ARG NDCTL_CONFIGFLAGS
+ARG NDCTL_BUILD_DEPS
+#pull dependencies required for downloading and building libndctl
+RUN apk add --update ${NDCTL_BUILD_DEPS}
+
 WORKDIR /
 RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
 RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -1,14 +1,14 @@
 FROM golang:alpine AS build
 
-ARG NDCTLVER
+ARG NDCTL_VERSION
 ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
 #pull dependencies required for downloading and building libndctl
 RUN apk add --update ${NDCTL_BUILD_DEPS}
 
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
-RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
+RUN wget https://github.com/pmem/ndctl/archive/v${NDCTL_VERSION}.tar.gz
+RUN tar zxvf v${NDCTL_VERSION}.tar.gz && mv ndctl-${NDCTL_VERSION} ndctl
 WORKDIR /ndctl
 RUN ./autogen.sh
 RUN ./configure ${NDCTL_CONFIGFLAGS}

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:alpine AS build
-#pull dependencies required for downloading and building libndctl
-RUN apk add --update build-base autoconf automake bash-completion libtool libuuid json-c kmod asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers wget tar file
 
 ARG NDCTLVER
 ARG NDCTL_CONFIGFLAGS
+ARG NDCTL_BUILD_DEPS
+#pull dependencies required for downloading and building libndctl
+RUN apk add --update ${NDCTL_BUILD_DEPS}
+
 WORKDIR /
 RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
 RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -1,14 +1,14 @@
 FROM golang:alpine AS build
 
-ARG NDCTLVER
+ARG NDCTL_VERSION
 ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
 #pull dependencies required for downloading and building libndctl
 RUN apk add --update ${NDCTL_BUILD_DEPS}
 
 WORKDIR /
-RUN wget https://github.com/pmem/ndctl/archive/v${NDCTLVER}.tar.gz
-RUN tar zxvf v${NDCTLVER}.tar.gz && mv ndctl-${NDCTLVER} ndctl
+RUN wget https://github.com/pmem/ndctl/archive/v${NDCTL_VERSION}.tar.gz
+RUN tar zxvf v${NDCTL_VERSION}.tar.gz && mv ndctl-${NDCTL_VERSION} ndctl
 WORKDIR /ndctl
 RUN ./autogen.sh
 RUN ./configure ${NDCTL_CONFIGFLAGS}


### PR DESCRIPTION
Also, some streamlining in ndctl build deps definition, so that we can define
those once instead of three replicas that we had previously

Fixes #163