### PR TITLE
Implement release versioning

### DIFF
--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:alpine AS build
 
+ARG VERSION
 ARG NDCTL_VERSION
 ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
@@ -17,7 +18,7 @@ RUN make install
 # build pmem-csi-driver
 ADD . /go/src/github.com/intel/pmem-csi
 WORKDIR /go/src/github.com/intel/pmem-csi
-RUN make pmem-csi-driver
+RUN make pmem-csi-driver VERSION=${VERSION}
 RUN mv ./_output/pmem-csi-driver /go/bin/
 
 # build clean container

--- a/cmd/pmem-csi-driver/main.go
+++ b/cmd/pmem-csi-driver/main.go
@@ -13,8 +13,9 @@ import (
 	"os"
 
 	"k8s.io/klog"
+	"k8s.io/klog/glog"
 
-	"github.com/intel/pmem-csi/pkg/pmem-csi-driver"
+	pmemcsidriver "github.com/intel/pmem-csi/pkg/pmem-csi-driver"
 )
 
 var (
@@ -32,12 +33,22 @@ var (
 	/* Node mode options */
 	controllerEndpoint = flag.String("controllerEndpoint", "", "internal node controller endpoint")
 	deviceManager      = flag.String("deviceManager", "lvm", "device manager to use to manage pmem devices. supported types: 'lvm' or 'ndctl'")
+	showVersion        = flag.Bool("version", false, "Show release version and exit")
+
+	version = "unknown" // Set version during build time
 )
 
 func main() {
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	glog.Info("Version: ", version)
 
 	driver, err := pmemcsidriver.GetPMEMDriver(pmemcsidriver.Config{
 		DriverName:         *driverName,
@@ -52,6 +63,7 @@ func main() {
 		ClientKeyFile:      *clientKeyFile,
 		ControllerEndpoint: *controllerEndpoint,
 		DeviceManager:      *deviceManager,
+		Version:            version,
 	})
 	if err != nil {
 		fmt.Printf("Failed to Initialized driver: %s", err.Error())

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:alpine AS build
 
+ARG VERSION
 ARG NDCTL_VERSION
 ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
@@ -17,7 +18,7 @@ RUN make install
 # build pmem-ns-init
 ADD . /go/src/github.com/intel/pmem-csi
 WORKDIR /go/src/github.com/intel/pmem-csi
-RUN make pmem-ns-init
+RUN make pmem-ns-init VERSION=${VERSION}
 RUN mv ./_output/pmem-ns-init /go/bin/
 
 # build clean container

--- a/cmd/pmem-ns-init/main.go
+++ b/cmd/pmem-ns-init/main.go
@@ -18,12 +18,23 @@ var (
 	namespacesize = flag.Int("namespacesize", 32, "Namespace size in GB")
 	useforfsdax   = flag.Int("useforfsdax", 100, "Percentage of total to use in Fsdax mode")
 	useforsector  = flag.Int("useforsector", 0, "Percentage of total to use in Sector mode")
+	showVersion   = flag.Bool("version", false, "Show release version and exit")
+
+	version = "unknown"
 )
 
 func main() {
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	glog.Info("Version: ", version)
+
 	ctx, err := ndctl.NewContext()
 	if err != nil {
 		fmt.Printf("Failed to initialize pmem context: %s", err.Error())

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:alpine AS build
 
+ARG VERSION
 ARG NDCTL_VERSION
 ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
@@ -17,7 +18,7 @@ RUN make install
 # build pmem-vgm
 ADD . /go/src/github.com/intel/pmem-csi
 WORKDIR /go/src/github.com/intel/pmem-csi
-RUN make pmem-vgm
+RUN make pmem-vgm VERSION=${VERSION}
 RUN mv ./_output/pmem-vgm /go/bin/
 
 # build clean container

--- a/cmd/pmem-vgm/main.go
+++ b/cmd/pmem-vgm/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"strings"
 
 	"k8s.io/klog"
@@ -11,10 +13,24 @@ import (
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
 )
 
+var (
+	showVersion = flag.Bool("version", false, "Show release version and exit")
+
+	version = "unknown"
+)
+
 func main() {
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	glog.Info("Version: ", version)
+
 	ctx, err := ndctl.NewContext()
 	if err != nil {
 		klog.Fatalf("Failed to initialize pmem context: %s", err.Error())

--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	vendorVersion     string        = "0.0.1"
 	connectionTimeout time.Duration = 10 * time.Second
 	retryTimeout      time.Duration = 10 * time.Second
 	requestTimeout    time.Duration = 10 * time.Second
@@ -66,6 +65,8 @@ type Config struct {
 	ControllerEndpoint string
 	//DeviceManager device manager to use
 	DeviceManager string
+	//Version driver release version
+	Version string
 }
 
 type pmemDriver struct {
@@ -133,7 +134,7 @@ func GetPMEMDriver(cfg Config) (*pmemDriver, error) {
 
 func (pmemd *pmemDriver) Run() error {
 	// Create GRPC servers
-	ids, err := NewIdentityServer(pmemd.cfg.DriverName, vendorVersion)
+	ids, err := NewIdentityServer(pmemd.cfg.DriverName, pmemd.cfg.Version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Setting driver version from $(git describe). Currently this version is not
generated from "tags", which should be fixed once we have release tagging.

All driver commands have "-version" flag which shows the current version and
exits.

FIXES #183

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>