### PR TITLE
fix deployment RBAC rules

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -35,6 +35,9 @@ rules:
 - apiGroups: [ "csi.storage.k8s.io" ]
   resources: [ "csinodeinfos" ] # attacher - {get, list, watch}
   verbs: [ "get", "list", "watch" ]
+- apiGroups: [ "csi.storage.k8s.io" ]
+  resources: [ "csidrivers" ] # driver-registrar
+  verbs: [ "create", "delete" ]
 # NOTE: cluster-driver-registrar v1.0.1 RBAC rules are broken and does not list
 # customresourcedefinitions in its RBAC rules:
 # https://github.com/kubernetes-csi/cluster-driver-registrar/blob/v1.0.1/deploy/kubernetes/rbac.yaml

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -35,6 +35,10 @@ rules:
 - apiGroups: [ "csi.storage.k8s.io" ]
   resources: [ "csinodeinfos" ] # attacher
   verbs: [ "get", "list", "watch" ]
+- apiGroups: [ "csi.storage.k8s.io" ]
+  resources: [ "csidrivers" ] # driver-registrar
+  verbs: [ "create", "delete" ]
+
 # NOTE: cluster-driver-registrar v1.0.1 RBAC rules are broken and does not list
 # customresourcedefinitions in its RBAC rules:
 # https://github.com/kubernetes-csi/cluster-driver-registrar/blob/v1.0.1/deploy/kubernetes/rbac.yaml


### PR DESCRIPTION
cluster-driver-registrar sidecar needs to "create/delete" csidrivers hence need
these RBAC rules.

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>