### PR TITLE
Set default driver name to pmem-csi.intel.com

### DIFF
--- a/cmd/pmem-csi-driver/main.go
+++ b/cmd/pmem-csi-driver/main.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	/* generic options */
-	driverName       = flag.String("drivername", "pmem-csi", "name of the driver")
+	driverName       = flag.String("drivername", "pmem-csi.intel.com", "name of the driver")
 	nodeID           = flag.String("nodeid", "nodeid", "node id")
 	endpoint         = flag.String("endpoint", "unix:///tmp/pmem-csi.sock", "PMEM CSI endpoint")
 	mode             = flag.String("mode", "unified", "driver run mode : controller, node or unified")

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -130,7 +130,7 @@ spec:
       - name: external-provisioner
         imagePullPolicy: Always
         image: quay.io/k8scsi/csi-provisioner:v1.0.1
-        args: [ "--v=5", "--provisioner=pmem-csi", "--csi-address=/csi/csi-controller.sock", "--feature-gates=Topology=true" ]
+        args: [ "--v=5", "--provisioner=pmem-csi.intel.com", "--csi-address=/csi/csi-controller.sock", "--feature-gates=Topology=true" ]
         volumeMounts:
         - name: plugin-socket-dir
           mountPath: /csi
@@ -148,7 +148,7 @@ spec:
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         args:  [ "-v=5",
-                 "-drivername=pmem-csi",
+                 "-drivername=pmem-csi.intel.com",
                  "-mode=controller",
                  "-endpoint=unix:///csi/csi-controller.sock",
                  "-registryEndpoint=tcp://0.0.0.0:10000",
@@ -207,7 +207,7 @@ spec:
         imagePullPolicy: Always
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
         args: [ "--v=5",
-            "--kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi/csi.sock",
+            "--kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock",
             "--csi-address=/csi/csi.sock" ]
         volumeMounts:
         - name: plugin-socket-dir
@@ -220,7 +220,7 @@ spec:
         imagePullPolicy: Always
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         args: [ "-v=5",
-                  "-drivername=pmem-csi",
+                  "-drivername=pmem-csi.intel.com",
                   "-mode=node",
                   "-deviceManager=ndctl", 
                   "-endpoint=$(CSI_ENDPOINT)",
@@ -263,7 +263,7 @@ spec:
       volumes:
         - name: plugin-socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/pmem-csi/
+            path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -130,7 +130,7 @@ spec:
       - name: external-provisioner
         imagePullPolicy: Always
         image: quay.io/k8scsi/csi-provisioner:v1.0.1
-        args: [ "--v=5", "--provisioner=pmem-csi", "--csi-address=/csi/csi-controller.sock", "--feature-gates=Topology=true" ]
+        args: [ "--v=5", "--provisioner=pmem-csi.intel.com", "--csi-address=/csi/csi-controller.sock", "--feature-gates=Topology=true" ]
         volumeMounts:
         - name: plugin-socket-dir
           mountPath: /csi
@@ -148,7 +148,7 @@ spec:
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         args:  [ "-v=5",
-                 "-drivername=pmem-csi",
+                 "-drivername=pmem-csi.intel.com",
                  "-mode=controller",
                  "-endpoint=unix:///csi/csi-controller.sock",
                  "-registryEndpoint=tcp://0.0.0.0:10000",
@@ -219,7 +219,7 @@ spec:
         imagePullPolicy: Always
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
         args: [ "--v=5",
-            "--kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi/csi.sock",
+            "--kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock",
             "--csi-address=/csi/csi.sock" ]
         volumeMounts:
         - name: plugin-socket-dir
@@ -232,7 +232,7 @@ spec:
         imagePullPolicy: Always
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         args: [ "-v=5",
-                  "-drivername=pmem-csi",
+                  "-drivername=pmem-csi.intel.com",
                   "-mode=node",
                   "-endpoint=$(CSI_ENDPOINT)",
                   "-nodeid=$(KUBE_NODE_NAME)",
@@ -271,7 +271,7 @@ spec:
       volumes:
         - name: plugin-socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/pmem-csi/
+            path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:

--- a/deploy/kubernetes-1.13/pmem-storageclass-cache.yaml
+++ b/deploy/kubernetes-1.13/pmem-storageclass-cache.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: pmem-csi-sc-cache
-provisioner: pmem-csi
+provisioner: pmem-csi.intel.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:

--- a/deploy/kubernetes-1.13/pmem-storageclass.yaml
+++ b/deploy/kubernetes-1.13/pmem-storageclass.yaml
@@ -2,6 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: pmem-csi-sc
-provisioner: pmem-csi
+provisioner: pmem-csi.intel.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate

--- a/deploy/kubernetes-1.13/pmem-unified-csi.yaml
+++ b/deploy/kubernetes-1.13/pmem-unified-csi.yaml
@@ -47,7 +47,7 @@ spec:
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         args:  [ "-v=5",
-                 "-drivername=pmem-csi",
+                 "-drivername=pmem-csi.intel.com",
                  "-mode=unified",
                  "-endpoint=$(CSI_ENDPOINT)",
                  "-nodeid=$(KUBE_NODE_NAME)" ]

--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -35,8 +35,11 @@ const (
 	Node DriverMode = "node"
 	//Unified defintion for unified driver mode
 	Unified DriverMode = "unified"
+)
+
+var (
 	//PmemDriverTopologyKey key to use for topology constraint
-	PmemDriverTopologyKey = "pmem-csi.intel.com/node"
+	PmemDriverTopologyKey = ""
 )
 
 //Config type for driver configuration
@@ -124,6 +127,8 @@ func GetPMEMDriver(cfg Config) (*pmemDriver, error) {
 			return nil, err
 		}
 	}
+
+	PmemDriverTopologyKey = cfg.DriverName + "/node"
 
 	return &pmemDriver{
 		cfg:             cfg,


### PR DESCRIPTION
As per CSI specification plugin name should include plugin's host company name
and the plugin name. And it must follow domain name notation format.

Hence set default plugin name to 'pmem-csi.intel.com', which can be altered
using -driverName command-line argument.

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>