### PR TITLE
Direct-mode deploy example: no Bidirectional, use /sys

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -262,6 +262,8 @@ spec:
           mountPath: /certs/
         - name: dev-dir
           mountPath: /dev
+        - name: sys-dir
+          mountPath: /sys
       volumes:
         - name: plugin-socket-dir
           hostPath:
@@ -285,4 +287,8 @@ spec:
         - name: dev-dir
           hostPath:
             path: /dev
+            type: DirectoryOrCreate
+        - name: sys-dir
+          hostPath:
+            path: /sys
             type: DirectoryOrCreate

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -262,7 +262,6 @@ spec:
           mountPath: /certs/
         - name: dev-dir
           mountPath: /dev
-          mountPropagation: Bidirectional
       volumes:
         - name: plugin-socket-dir
           hostPath:


### PR DESCRIPTION
Bidirectional was accidentally copy-pasted in original
version of that file, it may potentially cause
some side effects propagating state from container to host /dev
so we should not have it there.

Pass of /sys is vital for direct mode to work. This was
tested and tuned in e2e tests which uses another deployment
file, so it was never carried over here, but it is needed.