### PR TITLE
crd installation + test

### DIFF
--- a/test/e2e/storage/pmem_csi.go
+++ b/test/e2e/storage/pmem_csi.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 Intel Corporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storage
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PMEM Cluster", func() {
+	f := framework.NewDefaultFramework("pmem")
+
+	// This checks that cluster-driver-registrar added the
+	// CSIDriverInfo for pmem-csi at some point in the past. A
+	// full test must include resetting the cluster and installing
+	// pmem-csi.
+	It("has CSIDriverInfo", func() {
+		dc := f.DynamicClient
+		csiDriverGVR := schema.GroupVersionResource{Group: "csi.storage.k8s.io", Version: "v1alpha1", Resource: "csidrivers"}
+		_, err := dc.Resource(csiDriverGVR).Namespace("").Get("pmem-csi.intel.com", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred(), "get csidriver.csi.storage.k8s.io for pmem-csi failed")
+	})
+})

--- a/test/setup-clear-kvm.sh
+++ b/test/setup-clear-kvm.sh
@@ -382,10 +382,15 @@ done
 # From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network
 _work/ssh-clear-kvm $PROXY_ENV kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml
 
-# Install addon storage CRDs, needed if CSINodeInfo feature-gate enabled
-if [[ "$TEST_FEATURE_GATES" == *"CSINodeInfo=true"* ]]; then
-    _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/storage-crds/csidriver.yaml
-    _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/storage-crds/csinodeinfo.yaml
+# Install addon storage CRDs, needed if certain feature gates are enabled.
+# Only applicable to Kubernetes 1.13 and older. 1.14 will have them as builtin APIs.
+if _work/ssh-clear-kvm $PROXY_ENV kubectl version | grep -q '^Server Version.*Major:"1", Minor:"1[0123]"'; then
+    if [[ "$TEST_FEATURE_GATES" == *"CSINodeInfo=true"* ]]; then
+        _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.13/cluster/addons/storage-crds/csidriver.yaml
+    fi
+    if [[ "$TEST_FEATURE_GATES" == *"CSIDriverRegistry=true"* ]]; then
+        _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.13/cluster/addons/storage-crds/csinodeinfo.yaml
+    fi
 fi
 
 # Run additional commands specified in config.


### PR DESCRIPTION
We had broken RBAC rules in one of the previous PRs and didn't notice because `cluster-driver-registrar` continued running and we didn't have tests for it's expected behavior.

This PR adds such a test and also updates the CRD installation.