### PR TITLE
Deploy examples: Clean and streamline LVM vs Direct files

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -33,7 +33,7 @@ rules:
   resources: [ "volumeattachments" ] #attacher 
   verbs: [ "get", "list", "watch", "update" ]
 - apiGroups: [ "csi.storage.k8s.io" ]
-  resources: [ "csinodeinfos" ] # attacher - {get, list, watch}
+  resources: [ "csinodeinfos" ] # attacher
   verbs: [ "get", "list", "watch" ]
 - apiGroups: [ "csi.storage.k8s.io" ]
   resources: [ "csidrivers" ] # driver-registrar
@@ -150,13 +150,9 @@ spec:
       - name: pmem-driver
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
-        # Passing /dev to container may cause container creation error because termination-log is located on /dev/ by default.
-        # Adding this clause works around failure, although it's bogus as this file is not actually used.
-        terminationMessagePath: /tmp/termination-log
         args:  [ "-v=5",
                  "-drivername=pmem-csi.intel.com",
                  "-mode=controller",
-                 "-deviceManager=ndctl",
                  "-endpoint=unix:///csi/csi-controller.sock",
                  "-registryEndpoint=tcp://0.0.0.0:10000",
                  "-nodeid=$(KUBE_NODE_NAME)",
@@ -226,6 +222,8 @@ spec:
       - name: pmem-driver
         imagePullPolicy: Always
         image: 192.168.8.1:5000/pmem-csi-driver:canary
+        # Passing /dev to container may cause container creation error because termination-log is located on /dev/ by default.
+        # Adding this clause works around failure, although it's bogus as this file is not actually used.
         terminationMessagePath: /tmp/termination-log
         args: [ "-v=5",
                   "-drivername=pmem-csi.intel.com",

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -38,7 +38,6 @@ rules:
 - apiGroups: [ "csi.storage.k8s.io" ]
   resources: [ "csidrivers" ] # driver-registrar
   verbs: [ "create", "delete" ]
-
 # NOTE: cluster-driver-registrar v1.0.1 RBAC rules are broken and does not list
 # customresourcedefinitions in its RBAC rules:
 # https://github.com/kubernetes-csi/cluster-driver-registrar/blob/v1.0.1/deploy/kubernetes/rbac.yaml
@@ -238,6 +237,7 @@ spec:
         args: [ "-v=5",
                   "-drivername=pmem-csi.intel.com",
                   "-mode=node",
+                  "-deviceManager=lvm",
                   "-endpoint=$(CSI_ENDPOINT)",
                   "-nodeid=$(KUBE_NODE_NAME)",
                   "-controllerEndpoint=tcp://$(KUBE_POD_IP):10001",

--- a/deploy/kubernetes-1.13/pmem-unified-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-unified-csi-lvm.yaml
@@ -48,6 +48,7 @@ spec:
         args:  [ "-v=5",
                  "-drivername=pmem-csi.intel.com",
                  "-mode=unified",
+                 "-deviceManager=lvm",
                  "-endpoint=$(CSI_ENDPOINT)",
                  "-nodeid=$(KUBE_NODE_NAME)" ]
         env:


### PR DESCRIPTION
Reduce diff between LVM and Direct variants for clarity.
Use terminationPath clause and deviceManager option in node part
only as these are relevant only in mode=node case.
Give deviceManager option in both deviceMode files for clarity.