### PR TITLE
WIP: Add mutex lock around device-oriented operations

### DIFF
--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -78,6 +78,8 @@ func (lvm *pmemLvm) CreateDevice(name string, size uint64, nsmode string) error 
 	if nsmode != string(ndctl.FsdaxMode) && nsmode != string(ndctl.SectorMode) {
 		return fmt.Errorf("Unknown nsmode(%v)", nsmode)
 	}
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
 	// Check that such name does not exist. In certain error states, for example when
 	// namespace creation works but device zeroing fails (missing /dev/pmemX.Y in container),
 	// this function is asked to create new devices repeatedly, forcing running out of space.
@@ -129,6 +131,8 @@ func (lvm *pmemLvm) CreateDevice(name string, size uint64, nsmode string) error 
 }
 
 func (lvm *pmemLvm) DeleteDevice(name string, flush bool) error {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
 	device, err := lvm.GetDevice(name)
 	if err != nil {
 		return err
@@ -142,6 +146,8 @@ func (lvm *pmemLvm) DeleteDevice(name string, flush bool) error {
 }
 
 func (lvm *pmemLvm) FlushDeviceData(name string) error {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
 	device, err := lvm.GetDevice(name)
 	if err != nil {
 		return err

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -65,6 +65,8 @@ func (pmem *pmemNdctl) GetCapacity() (map[string]uint64, error) {
 }
 
 func (pmem *pmemNdctl) CreateDevice(name string, size uint64, nsmode string) error {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
 	// Check that such name does not exist. In certain error states, for example when
 	// namespace creation works but device zeroing fails (missing /dev/pmemX.Y in container),
 	// this function is asked to create new devices repeatedly, forcing running out of space.
@@ -105,6 +107,8 @@ func (pmem *pmemNdctl) CreateDevice(name string, size uint64, nsmode string) err
 }
 
 func (pmem *pmemNdctl) DeleteDevice(name string, flush bool) error {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
 	device, err := pmem.GetDevice(name)
 	if err != nil {
 		return err
@@ -117,6 +121,8 @@ func (pmem *pmemNdctl) DeleteDevice(name string, flush bool) error {
 }
 
 func (pmem *pmemNdctl) FlushDeviceData(name string) error {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
 	device, err := pmem.GetDevice(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
When two volumes are requested at once, Creation typically
causes two parallel Creation calls to run, and without
mutex locking we will run into troubles.

Fixes #205