### PR TITLE
Use two volumes instead of one in deploy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,19 +492,30 @@ future, currently untested releases.
 ```
 
 The application uses **storage: pmem** in its <i>nodeSelector</i>
-list to ensure that it runs on the right node.
+list to ensure that it runs on the right node, and it requests mount of two volumes,
+one with ext4-format and another with xfs-format file system.
 
-- **Once the application pod is in 'Running' status, check that it has a pmem volume**
+- **Verify the application pod reaches 'Running' status**
 
 ```sh
     $ kubectl get po my-csi-app
     NAME                        READY     STATUS    RESTARTS   AGE
     my-csi-app                  1/1       Running   0          1m
-    
-    $ kubectl exec my-csi-app -- df /data
+```
+
+- **Check that application has two pmem volumes mounted with added dax option**
+
+```sh
+    $ kubectl exec my-csi-app -- df /data-ext4 /data-xfs
     Filesystem           1K-blocks      Used Available Use% Mounted on
-    /dev/ndbus0region0fsdax/7a4cc7b2-ddd2-11e8-8275-0a580af40161
-                           8191416     36852   7718752   0% /data
+    /dev/ndbus0region0fsdax/10c1dcbc-508a-11e9-934e-120f08717a12
+                           4062912     16376   3820440   0% /data-ext4
+    /dev/ndbus0region0fsdax/10a3673e-508a-11e9-934e-120f08717a12
+                           4184064     37264   4146800   1% /data-xfs
+
+    $ kubectl exec my-csi-app -- mount |grep /data
+    /dev/ndbus0region0fsdax/10c1dcbc-508a-11e9-934e-120f08717a12 on /data-ext4 type ext4 (rw,relatime,dax)
+    /dev/ndbus0region0fsdax/10a3673e-508a-11e9-934e-120f08717a12 on /data-xfs type xfs (rw,relatime,attr2,dax,inode64,noquota)
 ```
 
 <!-- FILL TEMPLATE:

--- a/deploy/kubernetes-1.13/pmem-app.yaml
+++ b/deploy/kubernetes-1.13/pmem-app.yaml
@@ -8,11 +8,16 @@ spec:
       image: busybox
       command: [ "sleep", "100000" ]
       volumeMounts:
-      - mountPath: "/data"
-        name: my-csi-volume
+      - mountPath: "/data-ext4"
+        name: my-csi-volume-ext4
+      - mountPath: "/data-xfs"
+        name: my-csi-volume-xfs
   nodeSelector:
     storage: pmem
   volumes:
-  - name: my-csi-volume
+  - name: my-csi-volume-ext4
     persistentVolumeClaim:
-      claimName: pmem-csi-pvc
+      claimName: pmem-csi-pvc-ext4
+  - name: my-csi-volume-xfs
+    persistentVolumeClaim:
+      claimName: pmem-csi-pvc-xfs

--- a/deploy/kubernetes-1.13/pmem-pvc.yaml
+++ b/deploy/kubernetes-1.13/pmem-pvc.yaml
@@ -1,11 +1,23 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: pmem-csi-pvc
+  name: pmem-csi-pvc-ext4
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 8Gi
-  storageClassName: pmem-csi-sc # defined in deploy/kubernetes-1.13/pmem-storageclass.yaml
+      storage: 4Gi
+  storageClassName: pmem-csi-sc-ext4 # defined in deploy/kubernetes-1.13/pmem-storageclass.yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pmem-csi-pvc-xfs
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi
+  storageClassName: pmem-csi-sc-xfs # defined in deploy/kubernetes-1.13/pmem-storageclass.yaml

--- a/deploy/kubernetes-1.13/pmem-storageclass.yaml
+++ b/deploy/kubernetes-1.13/pmem-storageclass.yaml
@@ -1,7 +1,19 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: pmem-csi-sc
+  name: pmem-csi-sc-ext4
 provisioner: pmem-csi.intel.com
 reclaimPolicy: Delete
-volumeBindingMode: Immediate
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  fsType: ext4
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: pmem-csi-sc-xfs
+provisioner: pmem-csi.intel.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  fsType: xfs


### PR DESCRIPTION
Using two volumes serves multiple purposes:
- makes use and demonstrates configuration of ext4 vs xfs formats
- stresses driver more as 2 creations on same node go in parallel
Note that in storageclass we change
volumeBindingMode from Immediate to WaitForFirstConsumer
to make deployment work for two volumes