### PR TITLE
deployment: Remove node selector from application deployment

### DIFF
--- a/deploy/kubernetes-1.13/pmem-app.yaml
+++ b/deploy/kubernetes-1.13/pmem-app.yaml
@@ -10,8 +10,6 @@ spec:
       volumeMounts:
       - mountPath: "/data"
         name: my-csi-volume
-  nodeSelector:
-    storage: pmem
   volumes:
   - name: my-csi-volume
     persistentVolumeClaim:


### PR DESCRIPTION
As we implemented csi topology, scheduler has to consider this and launch
application only on node where the volume created, so applications need not be
aware of "stoage:pmem" label anymore.

Signed-off-by: Amarnath Valluri <amarnath.valluri@intel.com>