### PR TITLE
Support test on 1.14 cluster

### DIFF
--- a/deploy/kubernetes-1.14
+++ b/deploy/kubernetes-1.14
@@ -1,0 +1,1 @@
+kubernetes-1.13

--- a/test/setup-clear-kvm.sh
+++ b/test/setup-clear-kvm.sh
@@ -375,8 +375,9 @@ fi
 ${TEST_CONFIGURE_POST_MASTER}
 
 # Let the other machines join the cluster.
+# Join multi-lines using 'sed' so that grep finds whole line
 for i in $(seq 1 $LAST_NODE); do
-    _work/ssh-clear-kvm.$i $(grep "kubeadm join.*token" _work/clear-kvm-kubeadm.0.log) $kubeadm_args
+    _work/ssh-clear-kvm.$i $(sed -z 's/\\\n//g' _work/clear-kvm-kubeadm.0.log |grep "kubeadm join.*token" ) $kubeadm_args
 done
 
 # From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network

--- a/test/setup-clear-kvm.sh
+++ b/test/setup-clear-kvm.sh
@@ -385,7 +385,8 @@ _work/ssh-clear-kvm $PROXY_ENV kubectl apply -f https://raw.githubusercontent.co
 
 # Install addon storage CRDs, needed if certain feature gates are enabled.
 # Only applicable to Kubernetes 1.13 and older. 1.14 will have them as builtin APIs.
-if _work/ssh-clear-kvm $PROXY_ENV kubectl version | grep -q '^Server Version.*Major:"1", Minor:"1[0123]"'; then
+# Temporarily install also on 1.14 until we migrate to sidecars which use the builtin beta API.
+if _work/ssh-clear-kvm $PROXY_ENV kubectl version | grep -q '^Server Version.*Major:"1", Minor:"1[01234]"'; then
     if [[ "$TEST_FEATURE_GATES" == *"CSINodeInfo=true"* ]]; then
         _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.13/cluster/addons/storage-crds/csinodeinfo.yaml
     fi

--- a/test/setup-clear-kvm.sh
+++ b/test/setup-clear-kvm.sh
@@ -387,10 +387,10 @@ _work/ssh-clear-kvm $PROXY_ENV kubectl apply -f https://raw.githubusercontent.co
 # Only applicable to Kubernetes 1.13 and older. 1.14 will have them as builtin APIs.
 if _work/ssh-clear-kvm $PROXY_ENV kubectl version | grep -q '^Server Version.*Major:"1", Minor:"1[0123]"'; then
     if [[ "$TEST_FEATURE_GATES" == *"CSINodeInfo=true"* ]]; then
-        _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.13/cluster/addons/storage-crds/csidriver.yaml
+        _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.13/cluster/addons/storage-crds/csinodeinfo.yaml
     fi
     if [[ "$TEST_FEATURE_GATES" == *"CSIDriverRegistry=true"* ]]; then
-        _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.13/cluster/addons/storage-crds/csinodeinfo.yaml
+        _work/ssh-clear-kvm $PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.13/cluster/addons/storage-crds/csidriver.yaml
     fi
 fi
 


### PR DESCRIPTION
First change:
Kubernetes 1.14 brings output change, join command example
is printed on two lines separated by `\` which is
problematic for grep. Join all multi-lines before grep
using sed. Currently there is just this one.