### PR TITLE
WIP: Add govm-based targets for testing on VMs

### DIFF
--- a/test/govm-centos-template.yaml
+++ b/test/govm-centos-template.yaml
@@ -1,0 +1,14 @@
+  - name: __HOST__
+    image: _work/__IMAGE__
+    cloud: true
+    flavor: medium
+    sshkey: ~/.ssh/id_rsa.pub
+    user-data: |
+      #!/bin/bash
+      echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
+      cp /home/centos/.ssh/authorized_keys /root/.ssh/authorized_keys
+      systemctl restart sshd
+    ContainerEnvVars:
+      - |
+        KVM_CPU_OPTS=
+        -m 2G,slots=2,maxmem=34G -smp 2 -machine pc

--- a/test/govm-start-centos.sh
+++ b/test/govm-start-centos.sh
@@ -1,0 +1,179 @@
+#!/bin/bash -xeu
+# let's have -x enabling tracing while we debug/develop this
+
+# Catch errors in pipelines
+set -o pipefail
+
+. $(dirname $0)/govm-start-common.sh
+# Select CentOS release and version:
+_centosrelease=7
+_centosversion=1809
+
+_imgfile=CentOS-${_centosrelease}-x86_64-GenericCloud-${_centosversion}.qcow2
+# mirror support for centos not ready yet, dont enable
+_mirror=
+_wdir=_work/centos-govm
+
+# After boot, at some point sshd becomes reconfigured to allow root login.
+# Before that, 1st stage: ssh does not work, 2nd stage: ssh works but refuses root login.
+# Then, 3rd stage is reached: root ssh is allowed. We can proceed after that.
+
+# TODO: based on Ubuntu and Centos observation, this function is almost same
+# except for user name ubuntu vs centos, so this function can potentially be common,
+# once we figure out how to make parametric user name which is inside both single and double quotes
+wait_responds_root_ssh () {
+    a=$1
+    while true; do
+        outp=`$_ssh root@$a true`
+        retv=$?
+        #echo `date` "   ret=$retv outp=[$outp]"
+        if [ $retv -eq 0 -a "$outp" != 'Please login as the user "centos" rather than the user "root".' ]; then
+	    break
+	fi
+        sleep 5
+    done
+}
+
+setup_one_node () {
+    a=$1
+    echo "============= start setup of host $a ==============="
+    set +e
+    wait_responds_root_ssh $a
+    set -e
+    [ -n "$_mirror" ] && set_yum_mirror $a
+    [ -n "${http_proxy:-}" ] && set_yum_proxy $a
+    $_ssh root@$a "yum update -y"
+    [ -n "${http_proxy:-}" ] && set_docker_proxy $a
+    set_docker_registry $a
+    # install docker after proxy and insecure setting creation, so it can run without restart
+    install_docker $a
+    init_nvdimm_labels $a
+    install_kubeadm $a
+    final_tuning $a
+}
+
+set_yum_mirror () {
+    # TODO: mirror support not added yet
+    a=$1
+    if [ -f $_wdir/govm_set_yum_mirror.$a.done ]; then
+        return 0
+    fi
+    touch $_wdir/govm_set_yum_mirror.$a.done
+}
+
+set_yum_proxy () {
+    # proxy for yum
+    a=$1
+    if [ -f $_wdir/govm_yum_proxy.$a.done ]; then
+        return 0
+    fi
+    $_ssh root@$a "cat >>/etc/yum.conf" <<EOF
+proxy=$http_proxy
+EOF
+    touch $_wdir/govm_yum_proxy.$a.done
+}
+
+install_kubeadm () {
+    # add Kubernetes key and repo. bionic,cosmic not available so we use latest=xenial
+    a=$1
+    if [ -f $_wdir/govm_install_kubeadm.$a.done ]; then
+	return 0
+    fi
+    $_ssh root@$a "cat >/etc/yum.repos.d/kubernetes.repo" <<EOF
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+    $_ssh root@$a "modprobe br_netfilter"
+    $_ssh root@$a "echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables"
+    $_ssh root@$a "yum install -y kubelet kubeadm kubectl"
+    touch $_wdir/govm_install_kubeadm.$a.done
+}
+
+install_docker () {
+    # note we also install ndctl here, reusing yum install point for convenience
+    a=$1
+    if [ -f $_wdir/govm_install_docker.$a.done ]; then
+	return 0
+    fi
+    $_ssh root@$a "yum install -y yum-utils device-mapper-persistent-data lvm2"
+    $_ssh root@$a "yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo"
+    $_ssh root@$a "yum install -y docker-ce ndctl"
+    touch $_wdir/govm_install_docker.$a.done
+}
+
+final_tuning () {
+    # some misc. operations
+    a=$1
+    if [ -f $_wdir/govm_final_tuning.$a.done ]; then
+	return 0
+    fi
+    $_ssh root@$a "setenforce 0"
+    $_ssh root@$a "sed -i --follow-symlinks 's/SELINUX=enforcing/SELINUX=disabled/g' /etc/sysconfig/selinux"
+    $_ssh root@$a "systemctl start docker && systemctl enable docker.service"
+    $_ssh root@$a "systemctl start kubelet && systemctl enable kubelet.service"
+    # silence timesync, fails to connect outside. Other way would be to configure ntp server
+    $_ssh root@$a "systemctl stop chronyd.service"
+    $_ssh root@$a "systemctl disable chronyd.service"
+    
+    touch $_wdir/govm_final_tuning.$a.done
+}
+
+########################  START   ###################################
+# get image, checking is it cached
+mkdir -p $_wdir
+if [ ! -e $_imgdir/$_imgfile ]; then
+    curl https://cloud.centos.org/centos/${_centosrelease}/images/$_imgfile -o $_imgdir/$_imgfile
+fi
+# TODO/limitation: Currently use num of any goVMs (govm list) for detecting running VMs,
+# works while no other goVMs run on same host.
+# If we want to become more flexible, we have to implement more intelligent detection of own VMs.
+
+# Current approach creates VMs, but after stopping, it can't restart those.
+# TODO: As improvement, we could detect existing but stopped instances and restart.
+# Could add a flag like "vm_compose.$a.done" marking compose stage completed.
+num_vms=`govm list -f '{{select (filterRegexp . "Name" "host-*") "IP"}}'|wc -l`
+if [ $num_vms -ne $NUM_NODES ]; then
+    # wipe all flags and host-specific logs, we start from zero state
+    rm -f $_wdir/govm_*.done $_wdir/*.out
+    # we generate yaml file which is given to "govm compose"
+    create_vmhost_manifest ${_centosrelease} govm-centos $_imgfile
+    govm compose -f $_wdir/govm-centos-${_centosrelease}.yaml
+fi
+# Sanity re-check num of VMs again
+num_vms=`govm list -f '{{select (filterRegexp . "Name" "host-*") "IP"}}'|wc -l`
+if [ $num_vms -ne $NUM_NODES ]; then
+    echo "should see $NUM_NODES running but there is $num_vms, exiting"
+    exit 1
+fi
+allnodes_ip=`govm list -f '{{select (filterRegexp . "Name" "host-*") "IP"}}'`
+master=`govm list -f '{{select (filterRegexp . "Name" "host-0") "IP"}}'`
+
+# setup nodes in parallel, wait at end for all nodes to be ready
+for ip in $allnodes_ip; do
+    setup_one_node $ip >$_wdir/$ip.out 2>&1 &
+done
+wait
+
+# This section needed only if we rebooted after setup, which is not the case now
+## wait until all respond to ssh again
+#set +e
+#for ip in $allnodes_ip; do
+#    wait_responds_root_ssh $ip
+#done
+#set -e
+
+setup_kubeadm_args
+# Kubernetes setup on master node:
+kubeadm_init
+# followed by join by other nodes:
+nodes_join
+# Copy kube config out from master to host so that kubectl becomes usable on host
+copy_kubeconfig_out
+# misc. cluster setup and driver deployment
+cluster_setup

--- a/test/govm-start-common.sh
+++ b/test/govm-start-common.sh
@@ -1,0 +1,244 @@
+. $(dirname $0)/test-config.sh
+NUM_NODES=4
+# override TEST_IP_ADDR that comes from test-config.sh (as clear-specific value) with govm value
+TEST_IP_ADDR=172.17.0
+NO_PROXY="${NO_PROXY:-},${TEST_IP_ADDR}.0/24,10.96.0.0/12,10.244.0.0/16"
+PROXY_ENV="env 'HTTP_PROXY=${http_proxy:-}' 'HTTPS_PROXY=${http_proxy:-}' 'NO_PROXY=$NO_PROXY'"
+_sshopts='-oIdentitiesOnly=yes -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=error'
+_ssh="ssh $_sshopts"
+_scp="scp $_sshopts"
+_imgdir=_work
+
+create_vmhost_manifest () {
+    _rel=$1
+    _templ=$2
+    _img=$3
+    _file=$_wdir/${_templ}-${_rel}.yaml
+    echo "---" >  $_file
+    echo "vms:" >>  $_file
+    for i in $(seq 0 $((NUM_NODES - 1))); do
+        cat $(dirname $0)/${_templ}-template.yaml \
+	    | sed "s/__HOST__/host-$i/" \
+	    | sed "s/__IMAGE__/$_img/" >> $_file
+	# add NVDIMM emulation related part on workers
+	if [ $i -ne 0 ]; then
+	    cat >> $_file <<EOF
+      - |
+        EXTRA_QEMU_OPTS=
+        -machine nvdimm=on -object memory-backend-file,id=mem1,share,mem-path=/data/nvdimm0,size=32768M -device nvdimm,memdev=mem1,id=nv1,label-size=2097152
+EOF
+	fi
+    done
+}
+
+set_docker_proxy () {
+    a=$1
+    if [ -n "${http_proxy:-}" ]; then
+        if [ -f $_wdir/govm_docker_proxy.$a.done ]; then
+	    return 0
+        fi
+        # proxy for docker
+        $_ssh root@$a mkdir -p /etc/systemd/system/docker.service.d/
+        $_ssh root@$a "cat >/etc/systemd/system/docker.service.d/proxy.conf" <<EOF
+[Service]
+Environment="HTTP_PROXY=$http_proxy" "HTTPS_PROXY=$https_proxy" "NO_PROXY=$NO_PROXY"
+EOF
+        touch $_wdir/govm_docker_proxy.$a.done
+    fi
+}
+
+set_docker_registry () {
+    a=$1
+    if [ -f $_wdir/govm_docker_registry.$a.done ]; then
+	return 0
+    fi
+    # configure insecure registry for docker
+    $_ssh root@$a "mkdir -p /etc/docker"
+    $_ssh root@$a "cat >/etc/docker/daemon.json" <<EOF
+{ "insecure-registries": ["10.237.72.78:5000"] }
+EOF
+    touch $_wdir/govm_docker_registry.$a.done
+}
+
+# kubeadm_args is used from multiple functions so we have separate function to set its value
+setup_kubeadm_args () {
+    kubeadm_args=
+# TODO: CRIO mode not tried, not complete/supported
+case $TEST_CRI in
+    docker)
+        cri_daemon=docker
+        # [ERROR SystemVerification]: unsupported docker version: 18.06.1
+        kubeadm_args="$kubeadm_args --ignore-preflight-errors=SystemVerification"
+        ;;
+    crio)
+        cri_daemon=cri-o
+        # Needed for CRI-O (https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes).
+        kubeadm_config_init="$kubeadm_config_init
+nodeRegistration:
+  criSocket: /run/crio/crio.sock"
+        ;;
+    *)
+        echo "ERROR: unsupported TEST_CRI=$TEST_CRI"
+        exit 1
+        ;;
+esac
+
+}
+
+kubeadm_init () {
+    if [ -f $_wdir/govm_kubeadm_init.done ]; then
+	return 0
+    fi
+kubeadm_args_init=
+kubeadm_config_init="apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration"
+kubeadm_config_cluster="apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration"
+kubeadm_config_kubelet="apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration"
+
+if [ ! -z ${TEST_FEATURE_GATES} ]; then
+    kubeadm_config_kubelet="$kubeadm_config_kubelet
+featureGates:
+$(IFS=","; for f in ${TEST_FEATURE_GATES};do
+echo "  $f" | sed 's/=/: /g'
+done)"
+    kubeadm_config_cluster="$kubeadm_config_cluster
+apiServer:
+  extraArgs:
+    feature-gates: ${TEST_FEATURE_GATES}"
+fi
+
+# Needed for flannel (https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes).
+kubeadm_config_cluster="$kubeadm_config_cluster
+networking:
+  podSubnet: \"10.244.0.0/16\""
+
+$_ssh root@$master "cat >/tmp/kubeadm-config.yaml" <<EOF
+$kubeadm_config_init
+---
+$kubeadm_config_kubelet
+---
+$kubeadm_config_cluster
+EOF
+
+# TODO: it is possible to set up each node in parallel, see
+# https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#automating-kubeadm
+
+kubeadm_args_init="$kubeadm_args_init --config=/tmp/kubeadm-config.yaml"
+$_ssh root@$master "$PROXY_ENV kubeadm init $kubeadm_args $kubeadm_args_init" | tee $_wdir/kubeadm.log
+$_ssh root@$master "mkdir -p .kube"
+$_ssh root@$master "cp -i /etc/kubernetes/admin.conf .kube/config"
+$_ssh root@$master "$PROXY_ENV kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml"
+
+# Install addon storage CRDs, needed if certain feature gates are enabled.
+# Only applicable to Kubernetes 1.13 and older. 1.14 will have them as builtin APIs.
+# Install temporarily for 1.14 as well, until they are not released as sidecars.
+if $_ssh root@$master "$PROXY_ENV kubectl version" | grep -q '^Server Version.*Major:"1", Minor:"1[01234]"'; then
+    if [[ "$TEST_FEATURE_GATES" == *"CSINodeInfo=true"* ]]; then
+        $_ssh root@$master "$PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.14/cluster/addons/storage-crds/csinodeinfo.yaml"
+    fi
+    if [[ "$TEST_FEATURE_GATES" == *"CSIDriverRegistry=true"* ]]; then
+        $_ssh root@$master "$PROXY_ENV kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.14/cluster/addons/storage-crds/csidriver.yaml"
+    fi
+fi
+
+touch $_wdir/govm_kubeadm_init.done
+}
+
+nodes_join () {
+# Let the other machines join the cluster.
+for a in $allnodes_ip; do
+    if [ "$a" = "$master" ]; then
+	continue
+    fi
+    if [ ! -f $_wdir/govm_join.$a.done ]; then
+        $_ssh root@$a $(sed -z 's/\\\n//g' $_wdir/kubeadm.log |grep "kubeadm join.*token" ) $kubeadm_args
+        touch $_wdir/govm_join.$a.done
+    fi
+done
+}
+
+copy_kubeconfig_out () {
+# get cluster config from master to this host so that kubectl can be used from host
+    if [ -f $_wdir/govm_copy_config_out.done ]; then
+	return 0
+    fi
+( echo "Use $(pwd)/$_wdir/kube.config as KUBECONFIG to access the running cluster." ) 2>/dev/null
+$_ssh root@$master 'cat /etc/kubernetes/admin.conf' | sed -e "s;https://.*:6443;https://${TEST_IP_ADDR}.2:6443;" >$_wdir/kube.config
+    touch $_wdir/govm_copy_config_out.done
+}
+
+init_nvdimm_labels () {
+    a=$1
+    if [ "$a" = "$master" ]; then
+	# skip nvdimm ops on master, it does not have PMEM
+	return 0
+    fi
+    if [ -f $_wdir/govm_nvdimm_labels.$a.done ]; then
+	return 0
+    fi
+    $_ssh root@$a "ndctl disable-region region0"
+    $_ssh root@$a "ndctl init-labels nmem0"
+    $_ssh root@$a "ndctl enable-region region0"
+    touch $_wdir/govm_nvdimm_labels.$a.done
+}
+
+cluster_setup () {
+    if [ -f $_wdir/govm_cluster_setup.done ]; then
+	return 0
+    fi
+    # in clear version we had this deleting label from master.
+    # But as we deal with new cluster, and we never add this label to host-0,
+    # this deletion is not needed I think. Lets just add label on worker nodes.
+    #$_ssh root@$master "kubectl label node host-0 storage-"
+
+    nodes=`govm list -f '{{select (filterRegexp . "Name" "host-*") "Name"}}'`
+    for n in $nodes; do
+        if [ "$n" = "host-0" ]; then
+	    # skip master
+	    continue
+        fi
+        $_ssh root@$master "kubectl label --overwrite node $n storage=pmem"
+    done
+    # note that we use files under $_wdir/ here
+    if ! [ -e $_wdir/govm_secrets.done ] || [ $($_ssh root@$master kubectl get secrets | grep pmem- | wc -l) -ne 2 ]; then
+        KUBECTL="$_ssh root@$master kubectl" PATH="$PWD/_work/bin/:$PATH" ./test/setup-ca-kubernetes.sh
+	touch $_wdir/govm_secrets.done
+    fi
+    $_ssh root@$master kubectl version --short | grep 'Server Version' | sed -e 's/.*: v\([0-9]*\)\.\([0-9]*\)\..*/\1.\2/' >$_wdir/kvm-kubernetes.version
+    . test/test-config.sh && \
+    if ! $_ssh root@$master kubectl get statefulset.apps/pmem-csi-controller daemonset.apps/pmem-csi >/dev/null 2>&1; then
+        $_ssh root@$master kubectl create -f - <deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-csi-${TEST_DEVICEMODE}-testing.yaml
+    fi
+    if ! $_ssh root@$master kubectl get storageclass/pmem-csi-sc-cache >/dev/null 2>&1; then
+        $_ssh root@$master kubectl create -f - <deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-storageclass-cache.yaml
+    fi
+    if ! $_ssh root@$master kubectl get storageclass/pmem-csi-sc-ext4 >/dev/null 2>&1; then
+        $_ssh root@$master kubectl create -f - <deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-storageclass-ext4.yaml
+    fi
+    if ! $_ssh root@$master kubectl get storageclass/pmem-csi-sc-xfs >/dev/null 2>&1; then
+        $_ssh root@$master kubectl create -f - <deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-storageclass-xfs.yaml
+    fi
+    echo
+    echo "The test cluster is ready. Log in with $_ssh root@$master, run kubectl once logged in."
+    echo "Alternatively, KUBECONFIG=$PWD/$_wdir/kube.config can also be used directly."
+    echo "To try out the pmem-csi driver persistent volumes:"
+    echo "   cat deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-pvc.yaml | $_ssh root@$master kubectl create -f -"
+    echo "   cat deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-app.yaml | $_ssh root@$master kubectl create -f -"
+    echo "To try out the pmem-csi driver cache volumes:"
+    echo "   cat deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-pvc-cache.yaml | $_ssh root@$master kubectl create -f -"
+    echo "   cat deploy/kubernetes-$(cat $_wdir/kvm-kubernetes.version)/pmem-app-cache.yaml | $_ssh root@$master kubectl create -f -"
+
+    # create ssh helpers
+    for i in $(seq 0 $((NUM_NODES - 1))); do
+	_helper=$_wdir/ssh.${i}
+        a=`govm list |grep host-$i |awk '{print $4}'`
+        echo "#!/bin/sh" > $_helper
+        echo "exec $_ssh root@$a \"\$@\"" >> $_helper
+        chmod 755 $_helper
+    done
+
+    touch $_wdir/govm_cluster_setup.done
+}
+

--- a/test/govm-start-ubuntu.sh
+++ b/test/govm-start-ubuntu.sh
@@ -1,0 +1,237 @@
+#!/bin/bash -xeu
+# let's have -x enabling tracing while we debug/develop this
+
+# Catch errors in pipelines
+set -o pipefail
+
+. $(dirname $0)/govm-start-common.sh
+# Select Ubuntu release: bionic=18.04 cosmic=18.10 disco=19.04
+#_ubunturelease=bionic
+#_ubunturelease=cosmic
+_ubunturelease=disco
+# TODO: should Ubuntu release be argument? If argument, we get rid of
+# switching between two lines here, but we add selecting need elsewhere.
+# If we call this from other script or Makefile, we need to code release there.
+# Here we can fall to default "disco" if value not given.
+
+# Kernel is updated separately. Here are some tried, known-to-work versions
+# Recent 4.19:
+#kver=4.19.34
+#kern1=${kver}-041934
+#kern2=201904051741
+
+# Recent 4.20:
+#kver=4.20.17
+#kern1=${kver}-042017
+#kern2=201903190933
+
+# Recent 5.0:
+kver=5.0.7
+kern1=${kver}-050007
+kern2=201904052141
+
+kurl=https://kernel.ubuntu.com/~kernel-ppa/mainline/v${kver}
+
+_imgfile=${_ubunturelease}-server-cloudimg-amd64.img
+_mirror=
+_wdir=_work/ubuntu-govm
+
+
+lk1=linux-headers-${kern1}_${kern1}.${kern2}_all.deb
+lk2=linux-headers-${kern1}-generic_${kern1}.${kern2}_amd64.deb
+lk3=linux-image-unsigned-${kern1}-generic_${kern1}.${kern2}_amd64.deb
+lk4=linux-modules-${kern1}-generic_${kern1}.${kern2}_amd64.deb
+
+fetch_kernel_files () {
+    if [ ! -f $_imgdir/$lk1 ]; then
+        curl $kurl/$lk1 -o $_imgdir/$lk1
+    fi
+    if [ ! -f $_imgdir/$lk2 ]; then
+        curl $kurl/$lk2 -o $_imgdir/$lk2
+    fi
+    if [ ! -f $_imgdir/$lk3 ]; then
+        curl $kurl/$lk3 -o $_imgdir/$lk3
+    fi
+    if [ ! -f $_imgdir/$lk4 ]; then
+        curl $kurl/$lk4 -o $_imgdir/$lk4
+    fi
+}
+
+update_kernel () {
+    a=$1
+    if [ -f $_wdir/govm_update_kernel.$a.done ]; then
+        return 0
+    fi
+    # install different kernel to get functional pmem devices, and reboot
+    $_ssh root@$a "rm -f /tmp/linux-*.deb"
+    $_scp $_imgdir/$lk1 $_imgdir/$lk2 $_imgdir/$lk3 $_imgdir/$lk4 root@$a:/tmp/
+    $_ssh root@$a "dpkg -i /tmp/linux-*.deb"
+    $_ssh root@$a "shutdown -r now"
+
+    touch $_wdir/govm_update_kernel.$a.done
+}
+
+# After boot, at some point sshd becomes reconfigured to allow root login.
+# Before that, 1st stage: ssh does not work, 2nd stage: ssh works but refuses root login.
+# Then, 3rd stage is reached: root ssh is allowed. We can proceed after that.
+wait_responds_root_ssh () {
+    a=$1
+    while true; do
+        outp=`$_ssh root@$a true`
+        retv=$?
+        #echo `date` "   ret=$retv outp=[$outp]"
+        if [ $retv -eq 0 -a "$outp" != 'Please login as the user "ubuntu" rather than the user "root".' ]; then
+	    break
+	fi
+        sleep 5
+    done
+}
+
+setup_one_node () {
+    a=$1
+    echo "============= start setup of host $a ==============="
+    set +e
+    wait_responds_root_ssh $a
+    set -e
+    [ -n "$_mirror" ] && set_apt_mirror $a
+    [ -n "${http_proxy:-}" ] && set_apt_proxy $a
+    $_ssh root@$a "apt update -y"
+    [ -n "${http_proxy:-}" ] && set_docker_proxy $a
+    set_docker_registry $a
+    # install docker after proxy and insecure setting creation, so it can run without restart
+    install_docker $a
+    init_nvdimm_labels $a
+    install_kubeadm $a
+    final_tuning $a
+    update_kernel $a
+}
+
+set_apt_mirror () {
+    # override all repos. This is called only if mirror value exists
+    a=$1
+    if [ -f $_wdir/govm_set_apt_mirror.$a.done ]; then
+        return 0
+    fi
+    $_ssh root@$a "cat > /etc/apt/sources.list" <<EOF
+deb $_mirror ${_ubunturelease} main restricted
+deb $_mirror ${_ubunturelease}-updates main restricted
+deb $_mirror ${_ubunturelease} universe
+deb $_mirror ${_ubunturelease}-updates universe
+deb $_mirror ${_ubunturelease} multiverse
+deb $_mirror ${_ubunturelease}-updates multiverse
+deb $_mirror ${_ubunturelease}-backports main restricted universe multiverse
+deb $_mirror ${_ubunturelease}-security main restricted
+deb $_mirror ${_ubunturelease}-security universe
+deb $_mirror ${_ubunturelease}-security multiverse
+EOF
+    touch $_wdir/govm_set_apt_mirror.$a.done
+}
+
+set_apt_proxy () {
+    # proxy for apt
+    a=$1
+    if [ -f $_wdir/govm_apt_proxy.$a.done ]; then
+        return 0
+    fi
+    $_ssh root@$a "cat >/etc/apt/apt.conf.d/00proxy" <<EOF
+Acquire::http::Proxy "$http_proxy";
+EOF
+    # ... with exception for mirror
+    if [ -n "$_mirror" ]; then
+        $_ssh root@$a "cat >>/etc/apt/apt.conf.d/00proxy" <<EOF
+Acquire::http::Proxy::linux-ftp.fi.intel.com  "DIRECT";
+EOF
+    fi
+    touch $_wdir/govm_apt_proxy.$a.done
+}
+
+install_kubeadm () {
+    # add Kubernetes key and repo. bionic,cosmic not available so we use latest=xenial
+    a=$1
+    if [ -f $_wdir/govm_install_kubeadm.$a.done ]; then
+	return 0
+    fi
+    $_ssh root@$a "https_proxy=${http_proxy:-} curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add"
+    $_ssh root@$a "apt-add-repository \"deb http://apt.kubernetes.io/ kubernetes-xenial main\""
+    $_ssh root@$a "apt install kubeadm -y"
+    touch $_wdir/govm_install_kubeadm.$a.done
+}
+
+install_docker () {
+    # note we also install ndctl here, reusing apt install point for convenience
+    a=$1
+    if [ -f $_wdir/govm_install_docker.$a.done ]; then
+	return 0
+    fi
+    $_ssh root@$a "apt install ndctl docker.io -y"
+    touch $_wdir/govm_install_docker.$a.done
+}
+
+final_tuning () {
+    # some misc. operations
+    a=$1
+    if [ -f $_wdir/govm_final_tuning.$a.done ]; then
+	return 0
+    fi
+    $_ssh root@$a "systemctl enable docker.service"
+    # silence timesync, fails to connect outside. Other way would be to configure ntp server
+    $_ssh root@$a "systemctl stop systemd-timesyncd"
+    $_ssh root@$a "systemctl disable systemd-timesyncd"
+    touch $_wdir/govm_final_tuning.$a.done
+}
+
+########################  START   ###################################
+# get image, checking is it cached
+mkdir -p $_wdir
+if [ ! -e $_imgdir/$_imgfile ]; then
+    curl https://cloud-images.ubuntu.com/${_ubunturelease}/current/$_imgfile -o $_imgdir/$_imgfile
+fi
+fetch_kernel_files
+# TODO/limitation: Currently use num of any goVMs (govm list) for detecting running VMs,
+# works while no other goVMs run on same host.
+# If we want to become more flexible, we have to implement more intelligent detection of own VMs.
+
+# Current approach creates VMs, but after stopping, it can't restart those.
+# TODO: As improvement, we could detect existing but stopped instances and restart.
+# Could add a flag like "vm_compose.$a.done" marking compose stage completed.
+num_vms=`govm list -f '{{select (filterRegexp . "Name" "host-*") "IP"}}'|wc -l`
+if [ $num_vms -ne $NUM_NODES ]; then
+    # wipe all flags and host-specific logs, we start from zero state
+    rm -f $_wdir/govm_*.done $_wdir/*.out
+    # we generate yaml file which is given to "govm compose",
+    # to avoid repetition at 2 levels: 1) Ubuntu releases 2) host blocks in yaml file
+    create_vmhost_manifest ${_ubunturelease} govm-ubuntu ${_imgfile}
+    govm compose -f $_wdir/govm-ubuntu-${_ubunturelease}.yaml
+fi
+# Sanity re-check num of VMs again
+num_vms=`govm list -f '{{select (filterRegexp . "Name" "host-*") "IP"}}'|wc -l`
+if [ $num_vms -ne $NUM_NODES ]; then
+    echo "should see $NUM_NODES running but there is $num_vms, exiting"
+    exit 1
+fi
+allnodes_ip=`govm list -f '{{select (filterRegexp . "Name" "host-*") "IP"}}'`
+master=`govm list -f '{{select (filterRegexp . "Name" "host-0") "IP"}}'`
+
+# setup nodes in parallel, wait at end for all nodes to be ready
+for ip in $allnodes_ip; do
+    setup_one_node $ip >$_wdir/$ip.out 2>&1 &
+done
+wait
+# here nodes got "reboot" cmd
+
+# wait until all respond to ssh again
+set +e
+for ip in $allnodes_ip; do
+    wait_responds_root_ssh $ip
+done
+set -e
+
+setup_kubeadm_args
+# Kubernetes setup on master node:
+kubeadm_init
+# followed by join by other nodes:
+nodes_join
+# Copy kube config out from master to host so that kubectl becomes usable on host
+copy_kubeconfig_out
+# misc. cluster setup and driver deployment
+cluster_setup

--- a/test/govm-ubuntu-template.yaml
+++ b/test/govm-ubuntu-template.yaml
@@ -1,0 +1,14 @@
+  - name: __HOST__
+    image: _work/__IMAGE__
+    cloud: true
+    flavor: medium
+    sshkey: ~/.ssh/id_rsa.pub
+    user-data: |
+      #!/bin/bash
+      echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
+      cp /home/ubuntu/.ssh/authorized_keys /root/.ssh/authorized_keys
+      systemctl restart sshd
+    ContainerEnvVars:
+      - |
+        KVM_CPU_OPTS=
+        -m 2G,slots=2,maxmem=34G -smp 2 -machine pc


### PR DESCRIPTION
Draft of govm-based testing.
Existing testing is so well coupled with clear deps that I considerd easier to write new scripts
than try to re-use/modify old.
The good part is, new approach does not change existing one at all.
As future work, we may want to re-group using common code from Clear side.
With current approach it should be easier to add next target,
as I tried to keep common vs. Ubuntu things separated.
Some TODOs are in there, comments, ideas welcome.
Currently docker is used and CRIO was left out.
On Ubuntu, there is one warning from docker side.
Device support on cloud-based kernel is not in good shape, so we upgrade kernel and reboot.

There is no doc part yet, and this code is not integrated with make targets currently.
To get Ubuntu-based VMs cluster up installed and running, run this in repo directory:
```
$ ./test/govm-start-ubuntu.sh
```

To get CentOS-based VMs cluster up installed and running, run this in repo directory:
```
$ ./test/govm-start-centos.sh
```

The pre-requisite is installation of govm, which has one dependency: docker.
The images and VM storage are stored under ~/vms. I did not start changing that as it would lead to additional option defining images location when govm  is used on host CLI.

Some more operating tips:
to get **all VMs** stopped and wiped away:
```
$ govm rm -a
```

The restart-idea of the creation script is similar to clear tester: "done" flags under _work enable restarting to continue interrupted setup. It does not support yet starting VMs from shutdown state, but this can be achieved via govm commands for VMs separately.
VM can be rebooted inside, it will restart.
VM can be shut down, it remains stopped, and can be started using `govm start NAME`
Creation script creates (similar to clear-based tester) ssh wrappers under _work/ for logging into VM as root.
Creation script sets up all nodes in parallel, saving output to node-specific files.

Resolves #193