### PR TITLE
WIP: Testing: Reduce clear specific naming and hard-coded entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,14 +690,14 @@ The DeviceMode (lvm or direct) used in testing is selected using variable TEST_D
 
 ### Running commands on test cluster nodes over ssh
 
-`make start` generates ssh-wrappers `_work/ssh-clear-kvm.N` for each
+`make start` generates ssh-wrappers `_work/ssh-kvm.N` for each
 test cluster node which are handy for running a single command or to
 start interactive shell. Examples:
 
-`_work/ssh-clear-kvm.0 kubectl get pods` runs a kubectl command on
+`_work/ssh-kvm.0 kubectl get pods` runs a kubectl command on
 node-0 which is cluster master.
 
-`_work/ssh-clear-kvm.1` starts a shell on node-1.
+`_work/ssh-kvm.1` starts a shell on node-1.
 
 ### Running E2E tests
 

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ of the test run. For example, to run just the E2E provisioning test
 (create PVC, write data in one pod, read it in another) in verbose mode:
 
 ``` sh
-$ KUBECONFIG=$(pwd)/_work/clear-kvm-kube.config REPO_ROOT=$(pwd) ginkgo -v -focus=pmem-csi.*should.provision.storage.with.defaults ./test/e2e/
+$ KUBECONFIG=$(pwd)/_work/kvm-kube.config REPO_ROOT=$(pwd) ginkgo -v -focus=pmem-csi.*should.provision.storage.with.defaults ./test/e2e/
 Nov 26 11:21:28.805: INFO: The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.
 Running Suite: PMEM E2E suite
 =============================
@@ -721,7 +721,7 @@ Random Seed: 1543227683 - Will randomize all specs
 Will run 1 of 61 specs
 
 Nov 26 11:21:28.812: INFO: checking config
-Nov 26 11:21:28.812: INFO: >>> kubeConfig: /nvme/gopath/src/github.com/intel/pmem-csi/_work/clear-kvm-kube.config
+Nov 26 11:21:28.812: INFO: >>> kubeConfig: /nvme/gopath/src/github.com/intel/pmem-csi/_work/kvm-kube.config
 Nov 26 11:21:28.817: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
 ...
 Ran 1 of 61 Specs in 58.465 seconds

--- a/test/clear-kvm.make
+++ b/test/clear-kvm.make
@@ -110,7 +110,7 @@ _work/passwd:
 _work/kube-clear-kvm: test/start_kubernetes.sh
 	mkdir -p _work
 	cp $< $@
-	sed -i -e "s;SSH;$$(pwd)/_work/ssh-clear-kvm;g" $@
+	sed -i -e "s;SSH;$$(pwd)/_work/ssh-kvm;g" $@
 	chmod u+x $@
 
 _work/OVMF.fd:

--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -132,7 +132,7 @@ var _ = Describe("sanity", func() {
 })
 
 func ssh(args ...string) string {
-	sshWrapper := os.ExpandEnv("${REPO_ROOT}/_work/ssh-clear-kvm.1")
+	sshWrapper := os.ExpandEnv("${REPO_ROOT}/_work/ssh-kvm.1")
 	cmd := exec.Command(sshWrapper, args...)
 	out, err := cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), "%s %s failed with error %s: %s", sshWrapper, args, err, out)

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	sshWrapper = os.ExpandEnv("${REPO_ROOT}/_work/ssh-clear-kvm.1")
+	sshWrapper = os.ExpandEnv("${REPO_ROOT}/_work/ssh-kvm.1")
 	binaries   = []string{
 		"pmem-csi-driver",
 		// Not used at the moment, see below.

--- a/test/setup-clear-kvm.sh
+++ b/test/setup-clear-kvm.sh
@@ -349,8 +349,8 @@ _work/ssh-kvm.0 mkdir -p .kube
 _work/ssh-kvm.0 cp -i /etc/kubernetes/admin.conf .kube/config
 
 # Done.
-( echo "Use $(pwd)/clear-kvm-kube.config as KUBECONFIG to access the running cluster." ) 2>/dev/null
-_work/ssh-kvm.0 'cat /etc/kubernetes/admin.conf' | sed -e "s;https://.*:6443;https://${TEST_IP_ADDR}.2:6443;" >_work/clear-kvm-kube.config
+( echo "Use $(pwd)/kvm-kube.config as KUBECONFIG to access the running cluster." ) 2>/dev/null
+_work/ssh-kvm.0 'cat /etc/kubernetes/admin.conf' | sed -e "s;https://.*:6443;https://${TEST_IP_ADDR}.2:6443;" >_work/kvm-kube.config
 
 # Verify that Kubernetes works by starting it and then listing pods.
 # We also wait for the node to become ready, which can take a while because
@@ -368,7 +368,7 @@ _work/ssh-kvm.0 kubectl get pods --all-namespaces
 
 # Doing the same locally only works if we have kubectl.
 if command -v kubectl >/dev/null; then
-    kubectl --kubeconfig _work/clear-kvm-kube.config get pods --all-namespaces
+    kubectl --kubeconfig _work/kvm-kube.config get pods --all-namespaces
 fi
 
 # Run additional commands specified in config.

--- a/test/start-stop.make
+++ b/test/start-stop.make
@@ -55,7 +55,7 @@ start: _work/clear-kvm.img _work/kube-clear-kvm _work/start-clear-kvm _work/ssh-
 	fi
 	@ echo
 	@ echo "The test cluster is ready. Log in with _work/ssh-kvm, run kubectl once logged in."
-	@ echo "Alternatively, KUBECONFIG=$$(pwd)/_work/clear-kvm-kube.config can also be used directly."
+	@ echo "Alternatively, KUBECONFIG=$$(pwd)/_work/kvm-kube.config can also be used directly."
 	@ echo "To try out the pmem-csi driver persistent volumes:"
 	@ echo "   cat deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-pvc.yaml | _work/ssh-kvm kubectl create -f -"
 	@ echo "   cat deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-app.yaml | _work/ssh-kvm kubectl create -f -"

--- a/test/start-stop.make
+++ b/test/start-stop.make
@@ -39,29 +39,29 @@ start: _work/clear-kvm.img _work/kube-clear-kvm _work/start-clear-kvm _work/ssh-
 		KUBECTL="$(PWD)/_work/ssh-kvm kubectl" PATH='$(PWD)/_work/bin/:$(PATH)' ./test/setup-ca-kubernetes.sh && \
 		touch _work/clear-kvm.secretsdone; \
 	fi
-	_work/ssh-kvm kubectl version --short | grep 'Server Version' | sed -e 's/.*: v\([0-9]*\)\.\([0-9]*\)\..*/\1.\2/' >_work/clear-kvm-kubernetes.version
+	_work/ssh-kvm kubectl version --short | grep 'Server Version' | sed -e 's/.*: v\([0-9]*\)\.\([0-9]*\)\..*/\1.\2/' >_work/kvm-kubernetes.version
 	. test/test-config.sh && \
 	if ! _work/ssh-kvm kubectl get statefulset.apps/pmem-csi-controller daemonset.apps/pmem-csi >/dev/null 2>&1; then \
-		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-csi-$${TEST_DEVICEMODE}.yaml; \
+		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-csi-$${TEST_DEVICEMODE}.yaml; \
 	fi
 	if ! _work/ssh-kvm kubectl get storageclass/pmem-csi-sc-ext4 >/dev/null 2>&1; then \
-		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-storageclass-ext4.yaml; \
+		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-storageclass-ext4.yaml; \
 	fi
 	if ! _work/ssh-kvm kubectl get storageclass/pmem-csi-sc-xfs >/dev/null 2>&1; then \
-		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-storageclass-xfs.yaml; \
+		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-storageclass-xfs.yaml; \
 	fi
 	if ! _work/ssh-kvm kubectl get storageclass/pmem-csi-sc-cache >/dev/null 2>&1; then \
-		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-storageclass-cache.yaml; \
+		_work/ssh-kvm kubectl create -f - <deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-storageclass-cache.yaml; \
 	fi
 	@ echo
 	@ echo "The test cluster is ready. Log in with _work/ssh-kvm, run kubectl once logged in."
 	@ echo "Alternatively, KUBECONFIG=$$(pwd)/_work/clear-kvm-kube.config can also be used directly."
 	@ echo "To try out the pmem-csi driver persistent volumes:"
-	@ echo "   cat deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-pvc.yaml | _work/ssh-kvm kubectl create -f -"
-	@ echo "   cat deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-app.yaml | _work/ssh-kvm kubectl create -f -"
+	@ echo "   cat deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-pvc.yaml | _work/ssh-kvm kubectl create -f -"
+	@ echo "   cat deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-app.yaml | _work/ssh-kvm kubectl create -f -"
 	@ echo "To try out the pmem-csi driver cache volumes:"
-	@ echo "   cat deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-pvc-cache.yaml | _work/ssh-kvm kubectl create -f -"
-	@ echo "   cat deploy/kubernetes-$$(cat _work/clear-kvm-kubernetes.version)/pmem-app-cache.yaml | _work/ssh-kvm kubectl create -f -"
+	@ echo "   cat deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-pvc-cache.yaml | _work/ssh-kvm kubectl create -f -"
+	@ echo "   cat deploy/kubernetes-$$(cat _work/kvm-kubernetes.version)/pmem-app-cache.yaml | _work/ssh-kvm kubectl create -f -"
 
 stop:
 	for i in $$(seq 0 $$(($(NUM_NODES) - 1))); do \

--- a/test/test.make
+++ b/test/test.make
@@ -99,7 +99,7 @@ RUNTIME_DEPS += LC_ALL=C LANG=C sort -u
 test_e2e: start
 	. test/test-config.sh && \
 	TEST_DEVICEMODE=$$TEST_DEVICEMODE \
-	KUBECONFIG=`pwd`/_work/clear-kvm-kube.config \
+	KUBECONFIG=`pwd`/_work/kvm-kube.config \
 	REPO_ROOT=`pwd` \
 	go test -count=1 -timeout 0 -v ./test/e2e
 


### PR DESCRIPTION
There are some file names that have `clear` in name but which are not clear-specific otherwise,
and using same functionality in another distro based testing creates situation where we
have to rename to keep the naming consistent.
By selecting distro-neutral names, we can unify these parts better and reduce diff.

Note that I created separate commits for separate names, but these could (hopefully) get combined
if we want to.