### PR TITLE
Deployment: add explicit /sys mount in pmem-ns-init in LVM mode

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -361,6 +361,9 @@ spec:
         name: pmem-ns-init
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /sys
+          name: sys-dir
       - args:
         - -v=5
         image: 192.168.8.1:5000/pmem-vgm:canary
@@ -390,6 +393,10 @@ spec:
       - name: registry-cert
         secret:
           secretName: pmem-csi-node-secrets
+      - hostPath:
+          path: /sys
+          type: DirectoryOrCreate
+        name: sys-dir
 ---
 apiVersion: csi.storage.k8s.io/v1alpha1
 kind: CSIDriver

--- a/deploy/kustomize/kubernetes-1.13-lvm/lvm-patch.yaml
+++ b/deploy/kustomize/kubernetes-1.13-lvm/lvm-patch.yaml
@@ -13,9 +13,21 @@
     args: [ "-v=5", "-namespacesize=9" ]
     securityContext:
       privileged: true
+    volumeMounts:
+    - name: sys-dir
+      mountPath: /sys
   - name: pmem-vgm
     imagePullPolicy: Always
     image: 192.168.8.1:5000/pmem-vgm:canary
     args: [ "-v=5" ]
     securityContext:
       privileged: true
+
+# /sys explicit mount added to get around read-only mount
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: sys-dir
+    hostPath:
+      path: /sys
+      type: DirectoryOrCreate


### PR DESCRIPTION
Deployment failed in CRIO case in LVM mode because of
read-only /sys. This change makes it work.