### PR TITLE
better cluster filenames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,15 @@ clean:
 .PHONY: all test clean pmem-csi-driver pmem-ns-init pmem-vgm
 
 # Add support for creating and booting a cluster under QEMU.
+# All of the commands operate on a cluster stored in _work/$(CLUSTER),
+# which defaults to _work/clear-kvm. This can be changed with
+# make variables, for example:
+#   make CLUSTER=clear-kvm-28070 CLEAR_IMG_VERSION=28070 start
+#
+# All clusters called "clear-kvm[-something]" are created with
+# test/clear-kvm.make. They run inside QEMU and share the
+# same IP addresses, and thus cannot run in parallel.
+CLUSTER := clear-kvm
 include test/clear-kvm.make
 include test/start-stop.make
 include test/test.make

--- a/README.md
+++ b/README.md
@@ -637,33 +637,10 @@ is done by adding the user to the `kvm` group. The
 section in the Clear Linux documentation contains further information
 about enabling KVM and installing QEMU.
 
-To ensure that QEMU and KVM are working, run this:
-
-    make _work/clear-kvm-original.img _work/start-clear-kvm _work/OVMF.fd
-    cp _work/clear-kvm-original.img _work/clear-kvm-test.img
-    _work/start-clear-kvm _work/clear-kvm-test.img
-
-The result should be a login prompt like this:
-
-    [    0.049839] kvm: no hardware support
-    
-    clr-c3f99095d2934d76a8e26d2f6d51cb91 login: 
-
-The message about missing KVM hardware support comes from inside the
-virtual machine and indicates that nested KVM is not enabled. This message can
-be ignored because it is not needed.
-
-Now the running QEMU can be killed and the test image removed again:
-
-    killall qemu-system-x86_64 # in a separate shell
-    rm _work/clear-kvm-test.img
-    reset # Clear Linux changes terminal colors, undo that.
-
 The `clear-kvm` images are prepared automatically by the Makefile. By
 default, four different images are prepared. Each image is pre-configured with
 its own hostname and with network settings for the corresponding `tap`
-device. `clear-kvm.img` is a symlink to the `clear-kvm.0.img` where
-the Kubernetes master node will run.
+device.
 
 The images will contain the latest
 [Clear Linux OS](https://clearlinux.org/) and have the Kubernetes
@@ -690,14 +667,14 @@ The DeviceMode (lvm or direct) used in testing is selected using variable TEST_D
 
 ### Running commands on test cluster nodes over ssh
 
-`make start` generates ssh-wrappers `_work/ssh-clear-kvm.N` for each
+`make start` generates ssh-wrappers `_work/clear-kvm/ssh.N` for each
 test cluster node which are handy for running a single command or to
 start interactive shell. Examples:
 
-`_work/ssh-clear-kvm.0 kubectl get pods` runs a kubectl command on
+`_work/clear-kvm/ssh.0 kubectl get pods` runs a kubectl command on
 node-0 which is cluster master.
 
-`_work/ssh-clear-kvm.1` starts a shell on node-1.
+`_work/clear-kvm/ssh.1` starts a shell on node-1.
 
 ### Running E2E tests
 
@@ -713,7 +690,7 @@ of the test run. For example, to run just the E2E provisioning test
 (create PVC, write data in one pod, read it in another) in verbose mode:
 
 ``` sh
-$ KUBECONFIG=$(pwd)/_work/clear-kvm-kube.config REPO_ROOT=$(pwd) ginkgo -v -focus=pmem-csi.*should.provision.storage.with.defaults ./test/e2e/
+$ KUBECONFIG=$(pwd)/_work/clear-kvm/kube.config REPO_ROOT=$(pwd) ginkgo -v -focus=pmem-csi.*should.provision.storage.with.defaults ./test/e2e/
 Nov 26 11:21:28.805: INFO: The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.
 Running Suite: PMEM E2E suite
 =============================
@@ -721,7 +698,7 @@ Random Seed: 1543227683 - Will randomize all specs
 Will run 1 of 61 specs
 
 Nov 26 11:21:28.812: INFO: checking config
-Nov 26 11:21:28.812: INFO: >>> kubeConfig: /nvme/gopath/src/github.com/intel/pmem-csi/_work/clear-kvm-kube.config
+Nov 26 11:21:28.812: INFO: >>> kubeConfig: /nvme/gopath/src/github.com/intel/pmem-csi/_work/clear-kvm/kube.config
 Nov 26 11:21:28.817: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
 ...
 Ran 1 of 61 Specs in 58.465 seconds

--- a/test/clear-kvm.make
+++ b/test/clear-kvm.make
@@ -30,7 +30,7 @@
 #
 # Kubernetes does not get started by default because it might
 # not always be needed in the image, depending on the test.
-# _work/kube-clear-kvm can be used to start it.
+# _work/clear-kvm/start-kubernetes can be used to start it.
 
 # Sanitize proxy settings (accept upper and lower case, set and export upper
 # case) and add local machine to no_proxy because some tests may use a
@@ -42,11 +42,8 @@ NO_PROXY=$(shell echo "$${NO_PROXY:-$${no_proxy}},$$(ip addr | grep inet6 | grep
 export HTTP_PROXY HTTPS_PROXY NO_PROXY
 PROXY_ENV=env 'HTTP_PROXY=$(HTTP_PROXY)' 'HTTPS_PROXY=$(HTTPS_PROXY)' 'NO_PROXY=$(NO_PROXY)'
 
-_work/clear-kvm-original.img:
-	$(DOWNLOAD_CLEAR_IMG)
-
 # This picks the latest available version. Can be overriden via make CLEAR_IMG_VERSION=
-CLEAR_IMG_VERSION = $(shell curl https://download.clearlinux.org/latest)
+CLEAR_IMG_VERSION = $(shell curl --silent https://download.clearlinux.org/latest)
 
 DOWNLOAD_CLEAR_IMG = true
 DOWNLOAD_CLEAR_IMG += && mkdir -p _work
@@ -59,7 +56,7 @@ DOWNLOAD_CLEAR_IMG += && curl -O https://download.clearlinux.org/releases/$$vers
 # skipping image verification, does not work at the moment (https://github.com/clearlinux/distribution/issues/85)
 # DOWNLOAD_CLEAR_IMG += && openssl smime -verify -in clear-$$version-kvm.img.xz-SHA512SUMS.sig -inform der -content clear-$$version-kvm.img.xz-SHA512SUMS -CAfile ../test/ClearLinuxRoot.pem -out /dev/null
 DOWNLOAD_CLEAR_IMG += && sed -e 's;/.*/;;' clear-$$version-kvm.img.xz-SHA512SUMS | sha512sum -c
-DOWNLOAD_CLEAR_IMG += && unxz -c <clear-$$version-kvm.img.xz >clear-kvm-original.img
+DOWNLOAD_CLEAR_IMG += && unxz -c <clear-$$version-kvm.img.xz >clear-kvm-$$version.img
 
 # Number of nodes to be created in the virtual cluster, including master node.
 NUM_NODES = 4
@@ -71,14 +68,19 @@ NUM_NODES = 4
 # kubernetes-0/1/2/.... The first image is for the Kubernetes master node,
 # but configured so that also normal apps can run on it, i.e. no additional
 # worker nodes are needed.
-_work/clear-kvm.img: test/setup-clear-kvm.sh _work/clear-kvm-original.img _work/kube-clear-kvm _work/OVMF.fd _work/start-clear-kvm _work/id _work/passwd
-	$(PROXY_ENV) test/setup-clear-kvm.sh $(NUM_NODES)
-	ln -sf clear-kvm.0.img $@
+_work/$(CLUSTER)/created: _work/clear-kvm%/created: test/setup-clear-kvm.sh _work/clear-kvm%/start-kubernetes _work/clear-kvm%/run-qemu _work/id _work/passwd
+	if ! [ -f _work/clear-kvm-$(CLEAR_IMG_VERSION).img ]; then ( $(DOWNLOAD_CLEAR_IMG) ); fi
+	$(PROXY_ENV) test/setup-clear-kvm.sh _work/clear-kvm-$(CLEAR_IMG_VERSION).img $(@D) $(NUM_NODES)
+	touch $@
+.SECONDARY: _work/$(CLUSTER)/start-kubernetes _work/$(CLUSTER)/run-qemu
 
-_work/start-clear-kvm: test/start_qemu.sh
-	mkdir -p _work
-	cp $< $@
-	sed -i -e "s;\(OVMF.fd\);$$(pwd)/_work/\1;g" $@
+# Makes a copy of the OVMF.fd because it might be modified by the
+# running virtual machine. Strictly speaking, we want one copy per
+# virtual machine instance.
+_work/$(CLUSTER)/run-qemu: _work/clear-kvm%/run-qemu: test/start_qemu.sh _work/OVMF.fd
+	mkdir -p $(@D)
+	cp _work/OVMF.fd $(@D)
+	sed -e "s;\(OVMF.fd\);$$(pwd)/$(@D)/\1;g" $< >$@
 	chmod a+x $@
 
 # Generate a random password. Converting a random binary to hex still
@@ -107,16 +109,15 @@ _work/passwd:
 		fi; \
 	done
 
-_work/kube-clear-kvm: test/start_kubernetes.sh
-	mkdir -p _work
-	cp $< $@
-	sed -i -e "s;SSH;$$(pwd)/_work/ssh-clear-kvm;g" $@
+_work/$(CLUSTER)/start-kubernetes: _work/clear-kvm%/start-kubernetes: test/start_kubernetes.sh
+	mkdir -p $(@D)
+	sed -e "s;SSH;$$(pwd)/$(@D)/ssh;g" $< >$@
 	chmod u+x $@
 
 _work/OVMF.fd:
-	mkdir -p _work
+	mkdir -p $(@D)
 	curl -o $@ https://download.clearlinux.org/image/OVMF.fd
 
 _work/id:
-	mkdir -p _work
+	mkdir -p $(@D)
 	ssh-keygen -N '' -f $@

--- a/test/start_qemu.sh
+++ b/test/start_qemu.sh
@@ -57,7 +57,7 @@ fi
 # Same MAC address as the one used in setup-clear-kvm.sh.
 mac=DE:AD:BE:EF:01:0$VMN
 
-. $(dirname $0)/../test/test-config.sh
+. $(dirname $0)/../../test/test-config.sh
 
 # We must exec here to ensure that our caller can kill qemu by killing its child process.
 # The source of entropy for the guest is intentionally the non-blocking /dev/urandom.

--- a/test/test.make
+++ b/test/test.make
@@ -108,7 +108,7 @@ space:= $(empty) $(empty)
 # Use count=1 to avoid test results caching, does not make sense for e2e test.
 .PHONY: test_e2e
 test_e2e: start
-	KUBECONFIG=`pwd`/_work/clear-kvm-kube.config \
+	KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
 	REPO_ROOT=`pwd` \
 	go test -count=1 -timeout 0 -v ./test/e2e -ginkgo.skip='$(subst $(space),|,$(TEST_E22_SKIP))'
 


### PR DESCRIPTION
This was originally based on PR #238, but I ended up doing it differently: instead of just renaming files in `_work`, files related to a cluster installation are now in `_work/clear-kvm[-something]` sub-directories, with generic names inside that directory.

The immediate benefit is that multiple parallel clusters can prepared in parallel (but cannot run in parallel yet).

When we add alternative ways of bringing up clusters, we can just swap out the rules which set up the cluster, while code using the cluster just needs to know the directory name and then can use the generic files inside it for whatever operation it needs to do (to be decided).
