### PR TITLE
(I propose not to merge) pkg/ndctl/region.go: Avoid integer overflow in align

### DIFF
--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -185,8 +185,8 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 	}
 
 	if opts.Size != 0 {
-		ways := uint32(C.ndctl_region_get_interleave_ways(ndr))
-		align := uint64(opts.Align * ways)
+		ways := uint64(C.ndctl_region_get_interleave_ways(ndr))
+		align := uint64(opts.Align) * ways
 		if opts.Size%align != 0 {
 			// force-align down to block boundary. More sensible would be to align up, but then it may fail because we ask more then there is left
 			opts.Size /= align


### PR DESCRIPTION
With interleave_ways=4 and opts.Align=1GB, code gets
divide-by-zero error because align gets calculated
as 32bit unsigned value were multiplying 1GB by ways=4
overflows 32-bit value, leaving zero value, which is then
converted to 64-bit zero value. We fix this making ways
to be 64-bit, thus multiplication happens to 64-bit value.