### PR TITLE
Change NamespaceCreation opts.Align to be 64-bit value

### DIFF
--- a/pkg/ndctl/ndctl.go
+++ b/pkg/ndctl/ndctl.go
@@ -27,7 +27,7 @@ type CreateNamespaceOpts struct {
 	Name       string
 	Size       uint64
 	SectorSize uint64
-	Align      uint32
+	Align      uint64
 	Type       NamespaceType
 	Mode       NamespaceMode
 	Location   MapLocation

--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -174,19 +174,19 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 			resource := uint64(C.ndctl_region_get_resource(ndr))
 			if resource < uint64(C.ULLONG_MAX) && resource&(mib2-1) != 0 {
 				glog.Infof("%s: falling back to a 4K alignment", regionName)
-				opts.Align = uint32(kib4)
+				opts.Align = kib4
 			}
-			if opts.Align != uint32(kib4) && opts.Align != uint32(mib2) && opts.Align != uint32(gib) {
+			if opts.Align != kib4 && opts.Align != mib2 && opts.Align != gib {
 				return nil, fmt.Errorf("unsupported alignment: %v", opts.Align)
 			}
 		}
 	} else {
-		opts.Align = uint32(defaultAlign)
+		opts.Align = defaultAlign
 	}
 
 	if opts.Size != 0 {
-		ways := uint32(C.ndctl_region_get_interleave_ways(ndr))
-		align := uint64(opts.Align * ways)
+		ways := uint64(C.ndctl_region_get_interleave_ways(ndr))
+		align := opts.Align * ways
 		if opts.Size%align != 0 {
 			// force-align down to block boundary. More sensible would be to align up, but then it may fail because we ask more then there is left
 			opts.Size /= align
@@ -230,10 +230,10 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 		switch opts.Mode {
 		case FsdaxMode:
 			glog.Infof("setting pfn")
-			err = ns.setPfnSeed(opts.Location, uint64(opts.Align))
+			err = ns.setPfnSeed(opts.Location, opts.Align)
 		case DaxMode:
 			glog.Infof("setting dax")
-			err = ns.setDaxSeed(opts.Location, uint64(opts.Align))
+			err = ns.setDaxSeed(opts.Location, opts.Align)
 		case SectorMode:
 			glog.Infof("setting btt")
 			err = ns.setBttSeed(opts.SectorSize)

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -85,7 +85,7 @@ func (pmem *pmemNdctl) CreateDevice(name string, size uint64, nsmode string) err
 	ns, err := pmem.ctx.CreateNamespace(ndctl.CreateNamespaceOpts{
 		Name:  name,
 		Size:  size,
-		Align: uint32(align),
+		Align: align,
 		Mode:  ndctl.NamespaceMode(nsmode),
 	})
 	if err != nil {


### PR DESCRIPTION
This simplifies the use of Align variable, as most
of it's use, including use in downward API to libndctl,
uses 64 bit value, so we can get rid of many typecasts.
This also avoids integer overflow error that is caused
by using 32-bit value in intermediate variable.

Resolves #244