### PR TITLE
add args unit tests for pmem-ns-init, other minor unit testing improvements 

### DIFF
--- a/cmd/pmem-ns-init/main_test.go
+++ b/cmd/pmem-ns-init/main_test.go
@@ -1,0 +1,72 @@
+package main_test
+
+import (
+	"flag"
+	"testing"
+
+	pmemnsinit "github.com/intel/pmem-csi/cmd/pmem-ns-init"
+	"k8s.io/klog"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func init() {
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+}
+
+func TestPmemNSInit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NSInit Suite")
+}
+
+/*
+var _ = BeforeSuite(func() {
+	var err error
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+})*/
+
+var _ = Describe("pmem-ns-init", func() {
+	Context("Check arguments", func() {
+		type cases struct {
+			name                                     string
+			namespacesize, useforfsdax, useforsector int
+		}
+		goodcases := []cases{
+			{"namespacesize ok", 32, 0, 0},
+			{"useforfsdax ok", 32, 50, 0},
+			{"useforsector ok", 32, 0, 50},
+			{"useforfsdax and useforsector combined 100", 32, 70, 30},
+			{"useforfsdax and useforsector combined less than 100", 32, 40, 30},
+		}
+		badcases := []cases{
+			{"namespacesize negative", -1, 0, 0},
+			{"namespacesize too small", 1, 0, 0},
+			{"useforfsdax negative", 32, -1, 0},
+			{"useforsector negative", 32, 0, -1},
+			{"useforfsdax too large", 32, 101, 0},
+			{"useforsector too large", 32, 0, 101},
+			{"useforfsdax and useforsector combined too large", 32, 51, 51},
+		}
+
+		for _, c := range goodcases {
+			c := c
+			It(c.name, func() {
+				err := pmemnsinit.CheckArgs(c.namespacesize, c.useforfsdax, c.useforsector)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+		for _, c := range badcases {
+			c := c
+			It(c.name, func() {
+				err := pmemnsinit.CheckArgs(c.namespacesize, c.useforfsdax, c.useforsector)
+				Expect(err).To(HaveOccurred())
+			})
+		}
+	})
+})

--- a/pkg/pmem-csi-driver/registryserver_test.go
+++ b/pkg/pmem-csi-driver/registryserver_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/container-storage-interface/spec/lib/go/csi"
 	pmemcsidriver "github.com/intel/pmem-csi/pkg/pmem-csi-driver"
 	pmemgrpc "github.com/intel/pmem-csi/pkg/pmem-grpc"
 	registry "github.com/intel/pmem-csi/pkg/pmem-registry"
@@ -25,17 +24,6 @@ func init() {
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
-}
-
-type mockNodeController struct {
-}
-
-func (m *mockNodeController) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	return &csi.ControllerPublishVolumeResponse{}, nil
-}
-
-func (m *mockNodeController) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
 func TestPmemRegistry(t *testing.T) {
@@ -173,7 +161,7 @@ var _ = Describe("pmem registry", func() {
 			evilKey  = os.ExpandEnv("${TEST_WORK}/evil-ca/pmem-node-controller-key.pem")
 		)
 
-		// This covers different scenarios for connections to the OIM registry.
+		// This covers different scenarios for connections to the registry.
 		cases := []struct {
 			name, ca, cert, key, peerName, errorText string
 		}{

--- a/test/test.make
+++ b/test/test.make
@@ -1,5 +1,5 @@
 TEST_CMD=go test
-TEST_ARGS=$(IMPORT_PATH)/pkg/...
+TEST_ARGS=$(IMPORT_PATH)/cmd/... $(IMPORT_PATH)/pkg/...
 
 .PHONY: vet
 test: vet
@@ -114,7 +114,7 @@ test_e2e: start
 
 .PHONY: run_tests
 test: run_tests
-run_tests: pmem-csi-driver _work/pmem-ca/.ca-stamp _work/evil-ca/.ca-stamp
+run_tests: all _work/pmem-ca/.ca-stamp _work/evil-ca/.ca-stamp
 	TEST_WORK=$(abspath _work) \
 	$(TEST_CMD) $(shell go list $(TEST_ARGS) | sed -e 's;$(IMPORT_PATH);.;')
 


### PR DESCRIPTION
Instead of setting sane values if out-of-bounds values found,
return error and fail the program with error msg.

Work in progress, dont merge yet.
Unit testing of argument values can be added here in same PR.

Resolves #223