### PR TITLE
Advance csi-node-driver-registrar version to 1.1.0

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
@@ -416,7 +416,7 @@ spec:
         - --v=5
         - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
         - --csi-address=/csi/csi.sock
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -348,7 +348,7 @@ spec:
         - --v=5
         - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
         - --csi-address=/csi/csi.sock
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:

--- a/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
@@ -411,7 +411,7 @@ spec:
         - --v=5
         - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
         - --csi-address=/csi/csi.sock
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -343,7 +343,7 @@ spec:
         - --v=5
         - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
         - --csi-address=/csi/csi.sock
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+        image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:

--- a/deploy/kustomize/kubernetes-1.13/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13/kustomization.yaml
@@ -12,4 +12,4 @@ images:
 - name: quay.io/k8scsi/csi-attacher
   newTag: v1.0.1
 - name: quay.io/k8scsi/csi-node-driver-registrar
-  newTag: v1.0.2
+  newTag: v1.1.0


### PR DESCRIPTION
One deployment trial case shows that driver deployment fails with version 1.0.2 but succeeds with 1.1.0.
In failing case, node-driver-registrar fails in getting connection to local csi socket, times out in 60s, and causes pod to exit and CrashLoop. For some reason (still not explained), this scenario repeats multiple times.
There is explanation why connection can take longer time 1st time, because node driver is in turn waiting to register with controller, and controller is still in starting stage.
But such wait should not happen on 2nd start of node pod.
In 1.1.0 the timeout and exit was removed and driver-registrar keeps trying. That seems to help
in the current deployment case.