### PR TITLE
Write termination message to TERMINATION_MESSAGE_PATH

### DIFF
--- a/cmd/pmem-csi-driver/main.go
+++ b/cmd/pmem-csi-driver/main.go
@@ -10,6 +10,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"k8s.io/klog"
@@ -66,12 +67,24 @@ func main() {
 		Version:            version,
 	})
 	if err != nil {
-		fmt.Printf("Failed to Initialized driver: %s", err.Error())
-		os.Exit(1)
+		errorexit("Failed to initialize driver:", err)
 	}
 
 	if err = driver.Run(); err != nil {
-		fmt.Printf("Failed to run driver: %s", err.Error())
-		os.Exit(1)
+		errorexit("Failed to run driver:", err)
 	}
+}
+
+func errorexit(msg string, e error) {
+	str := msg + e.Error()
+	fmt.Println(str)
+	terminationMsgPath := os.Getenv("TERMINATION_LOG_PATH")
+	if terminationMsgPath != "" {
+		err := ioutil.WriteFile(terminationMsgPath, []byte(str), os.FileMode(0644))
+		if err != nil {
+			fmt.Println("Can not create termination log file:" + terminationMsgPath)
+		}
+	}
+
+	os.Exit(1)
 }

--- a/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
@@ -272,11 +272,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -391,6 +394,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -261,11 +261,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -323,6 +326,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver

--- a/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
@@ -272,11 +272,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -391,11 +394,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /csi
           name: plugin-socket-dir

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -261,11 +261,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -323,11 +326,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /csi
           name: plugin-socket-dir

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -303,11 +303,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -422,6 +425,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver

--- a/deploy/kubernetes-1.14/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct.yaml
@@ -292,11 +292,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -354,6 +357,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -303,11 +303,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -422,11 +425,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /csi
           name: plugin-socket-dir

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -292,11 +292,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /certs/
           name: registry-cert
@@ -354,11 +357,14 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         image: 192.168.8.1:5000/pmem-csi-driver:canary
         imagePullPolicy: Always
         name: pmem-driver
         securityContext:
           privileged: true
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - mountPath: /csi
           name: plugin-socket-dir

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -61,6 +61,9 @@ spec:
                  "-certFile=/certs/pmem-csi-registry.crt",
                  "-keyFile=/certs/pmem-csi-registry.key"
                ]
+        # Passing /dev to container may cause container creation error because
+        # termination-log is located on /dev/ by default, re-locate to /tmp
+        terminationMessagePath: /tmp/termination-log
         volumeMounts:
         - name: registry-cert
           mountPath: /certs/
@@ -72,6 +75,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         securityContext:
           privileged: true
       volumes:
@@ -117,6 +122,9 @@ spec:
                   "-certFile=/certs/$(KUBE_NODE_NAME).crt",
                   "-keyFile=/certs/$(KUBE_NODE_NAME).key"
               ]
+        # Passing /dev to container may cause container creation error because
+        # termination-log is located on /dev/ by default, re-locate to /tmp
+        terminationMessagePath: /tmp/termination-log
         securityContext:
           privileged: true
         env:
@@ -132,6 +140,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
+        - name: TERMINATION_LOG_PATH
+          value: /tmp/termination-log
         volumeMounts:
         - name: plugin-socket-dir
           mountPath: /csi

--- a/deploy/kustomize/patches/direct-patch.yaml
+++ b/deploy/kustomize/patches/direct-patch.yaml
@@ -28,9 +28,3 @@
     hostPath:
       path: /sys
       type: DirectoryOrCreate
-
-# Passing /dev to container may cause container creation error because termination-log is located on /dev/ by default.
-# Adding this clause works around failure, although it's bogus as this file is not actually used.
-- op: add
-  path: /spec/template/spec/containers/0/terminationMessagePath
-  value: /tmp/termination-log

--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -243,5 +243,5 @@ func newDeviceManager(dmType string) (pmdmanager.PmemDeviceManager, error) {
 	case "ndctl":
 		return pmdmanager.NewPmemDeviceManagerNdctl()
 	}
-	return nil, fmt.Errorf("Unsupported device manager type '%s", dmType)
+	return nil, fmt.Errorf("Unsupported device manager type '%s'", dmType)
 }


### PR DESCRIPTION
Write termination message to TERMINATION_MESSAGE_PATH
   
The path is different from default /dev/termination-log
because we need to pass /dev/ explicitly to containers,
and that is known to cause container creation failure
if combined with termination-log located on /dev.
So we relocate termination log to /tmp.
We define env.var that we pass into container so that
container knows where to create the termination message.

Resolves #233