### PR TITLE
Fix kustomize-generated parts to be in sync again

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
@@ -429,6 +429,9 @@ spec:
         name: pmem-ns-init
         securityContext:
           privileged: true
+        volumeMounts:
+        - mountPath: /sys
+          name: sys-dir
       - args:
         - -v=5
         image: 192.168.8.1:5000/pmem-vgm:canary
@@ -458,6 +461,10 @@ spec:
       - name: registry-cert
         secret:
           secretName: pmem-csi-node-secrets
+      - hostPath:
+          path: /sys
+          type: DirectoryOrCreate
+        name: sys-dir
 ---
 apiVersion: csi.storage.k8s.io/v1alpha1
 kind: CSIDriver


### PR DESCRIPTION
With some changes applied from commits in a branch
while kustomized changed came in another, generated
parts ended up out of sync. This make them up-to-date.