### PR TITLE
test: set up cluster with additional insecure registries

### DIFF
--- a/test/setup-clear-kvm.sh
+++ b/test/setup-clear-kvm.sh
@@ -88,6 +88,17 @@ kill_process_tree () {
     fi
 }
 
+# Prints the list of insecure registries for inclusion in a daemon.json
+# registry.conf file.
+insecure_registries () {
+    echo -n '['
+    echo -n "\"${TEST_IP_ADDR}.1:5000\""
+    for i in $TEST_INSECURE_REGISTRIES; do
+        echo -n ",\"$i\""
+    done
+    echo -n ']'
+}
+
 # Creates a virtual machine and enables SSH for it. Must be started
 # in a sub-shell. The virtual machine is kept running until this
 # sub-shell is killed.
@@ -216,13 +227,13 @@ EOF
     # will fail to pull images from it.
     $TARGET/ssh.$imagenum "mkdir -p /etc/containers && cat >/etc/containers/registries.conf" <<EOF
 [registries.insecure]
-registries = [ '${TEST_IP_ADDR}.1:5000' ]
+registries = $(insecure_registries)
 EOF
 
     # The same for Docker.
     $TARGET/ssh.$imagenum mkdir -p /etc/docker
     $TARGET/ssh.$imagenum "cat >/etc/docker/daemon.json" <<EOF
-{ "insecure-registries": ["${TEST_IP_ADDR}.1:5000"] }
+{ "insecure-registries": $(insecure_registries) }
 EOF
 
     # Proxy settings for Docker.

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -22,6 +22,10 @@ TEST_IP_ADDR=192.168.8
 # from systemd-network).
 TEST_DNS_SERVERS=
 
+# Additional insecure registries (for example, my-registry:5000),
+# separated by spaces.
+TEST_INSECURE_REGISTRIES=
+
 # Additional Clear Linux bundles.
 TEST_CLEAR_LINUX_BUNDLES="storage-utils"
 


### PR DESCRIPTION
This is useful when there are additional local registries that don't
have an SSL certificate that Clear Linux trusts out-of-the-box.