### PR TITLE
Delete provisioner= option from external-provisioner deployment

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
@@ -238,7 +238,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.0.1

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -227,7 +227,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.0.1

--- a/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
@@ -238,7 +238,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.0.1

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -227,7 +227,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.0.1

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -269,7 +269,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.1.0

--- a/deploy/kubernetes-1.14/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct.yaml
@@ -258,7 +258,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.1.0

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -269,7 +269,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.1.0

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -258,7 +258,6 @@ spec:
       containers:
       - args:
         - --v=5
-        - --provisioner=pmem-csi.intel.com
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.1.0

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -37,7 +37,7 @@ spec:
       - name: external-provisioner
         imagePullPolicy: Always
         image: quay.io/k8scsi/csi-provisioner:v1.X.Y
-        args: [ "--v=5", "--provisioner=pmem-csi.intel.com", "--csi-address=/csi/csi-controller.sock", "--feature-gates=Topology=true" ]
+        args: [ "--v=5", "--csi-address=/csi/csi-controller.sock", "--feature-gates=Topology=true" ]
         volumeMounts:
         - name: plugin-socket-dir
           mountPath: /csi


### PR DESCRIPTION
This option has been deprecated and has no effect.