### PR TITLE
Dockerfiles: invalidate cache before "swupd update"

### DIFF
--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -6,6 +6,7 @@ ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
 
 #pull dependencies required for downloading and building libndctl
+ARG CACHEBUST
 RUN swupd update && swupd bundle-add ${NDCTL_BUILD_DEPS} go-basic-dev && rm -rf /var/lib/swupd
 
 WORKDIR /
@@ -34,6 +35,7 @@ LABEL description="PMEM CSI Driver"
 # file - driver uses file utility to determine filesystem type
 # xfsprogs - XFS filesystem utilities
 # storge-utils - for lvm2 and ext4(e2fsprogs) utilities
+ARG CACHEBUST
 RUN swupd update && swupd bundle-add file xfsprogs storage-utils && rm -rf /var/lib/swupd
 
 # move required binaries and libraries to clean container

--- a/cmd/pmem-csi-driver/Dockerfile
+++ b/cmd/pmem-csi-driver/Dockerfile
@@ -29,7 +29,8 @@ RUN mv ./_output/pmem-csi-driver /go/bin/
 FROM clearlinux:base
 LABEL maintainers="Intel"
 LABEL description="PMEM CSI Driver"
-# update and install needed bunles:
+
+# update and install needed bundles:
 # file - driver uses file utility to determine filesystem type
 # xfsprogs - XFS filesystem utilities
 # storge-utils - for lvm2 and ext4(e2fsprogs) utilities

--- a/cmd/pmem-ns-init/Dockerfile
+++ b/cmd/pmem-ns-init/Dockerfile
@@ -6,6 +6,7 @@ ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
 
 #pull dependencies required for downloading and building libndctl
+ARG CACHEBUST
 RUN swupd update && swupd bundle-add ${NDCTL_BUILD_DEPS} go-basic-dev && rm -rf /var/lib/swupd
 
 WORKDIR /
@@ -27,6 +28,7 @@ RUN mv ./_output/pmem-ns-init /go/bin/
 
 # build clean container
 FROM clearlinux:base
+ARG CACHEBUST
 RUN swupd update && rm -rf /var/lib/swupd
 
 LABEL maintainers="Intel"

--- a/cmd/pmem-vgm/Dockerfile
+++ b/cmd/pmem-vgm/Dockerfile
@@ -6,6 +6,7 @@ ARG NDCTL_CONFIGFLAGS
 ARG NDCTL_BUILD_DEPS
 
 #pull dependencies required for downloading and building libndctl
+ARG CACHEBUST
 RUN swupd update && swupd bundle-add ${NDCTL_BUILD_DEPS} go-basic-dev && rm -rf /var/lib/swupd
 
 WORKDIR /
@@ -28,6 +29,7 @@ RUN mv ./_output/pmem-vgm /go/bin/
 # build clean container
 FROM clearlinux:base
 
+ARG CACHEBUST
 RUN swupd update && swupd bundle-add storage-utils && rm -rf /var/lib/swupd
 
 LABEL maintainers="Intel"


### PR DESCRIPTION
Dockerfiles: invalidate cache before "swupd update"
 
Docker caches previous build results and skips commands that it has
executed in the same context before. The result is that the "swupd
update" command may get skipped during a build:
```    
    Step 6/33 : RUN swupd update && swupd bundle-add ${NDCTL_BUILD_DEPS} go-basic-dev && rm -rf /var/lib/swupd
     ---> Using cache
     ---> 229de2b1ee2e
``` 
That caching defeats the purpose of the command, which is to ensure
that all the latest updates for the base image are getting applied.
    
On the other hand, not using a cache at all (= "docker build
--no-cache") would slow down developers a lot (> 20min build times).
    
The solution is to invalidate the cache right before the "swupd
update" command by injecting an unused "CACHEBUST" variable, as
described in http://dev.im-bot.com/docker-select-caching/. The default
is to invalidate the cache once per day. A CI build can invalidate it
for each build.
    
In the Makefile, the variable is called BUILD_IMAGE_ID because that's
what it is; "busting the cache" is simply what it is currently used
for.
