### PR TITLE
setup-ca-kubernetes.sh: Handle no pmem nodes case

### DIFF
--- a/test/setup-ca-kubernetes.sh
+++ b/test/setup-ca-kubernetes.sh
@@ -8,13 +8,19 @@
 
 # Directory to use for storing intermediate files
 WORKDIR=${WORKDIR:-$(mktemp -d -u -t pmem-XXXX)}
-mkdir -p $WORKDIR
-cd $WORKDIR
 
 cfssl_found=1
 (command -v cfssl 2>&1 >/dev/null && command -v cfssljson 2>&1 >/dev/null) || cfssl_found=0
 if [ $cfssl_found -eq 0 ]; then
     echo "cfssl tools not found, Please install cfssl, cfssljson."
+    exit 1
+fi
+
+# Find the nodes for which we need to create node certificates
+NODES=$($KUBECTL get no -l storage=pmem -o name | sed  -e 's;.*/;;')
+if [ -z "$NODES" ]; then
+    echo "No nodes found in the cluster with 'storage=pmem' label. Probably, you missed labeling of nodes."
+    echo "Rerun '$0' script after labeling the cluster nodes that provide persistent memory."
     exit 1
 fi
 
@@ -57,14 +63,23 @@ EOF
     echo "Created: $CSR_NAME.crt"
 }
 
-echo "Generating certificates: $WORKDIR"
+mkdir -p $WORKDIR 2> /dev/null && cd $WORKDIR
+trap cleaup INT
+cleanup()
+{
+    echo "Cleaning up..."
+    cd .. && rm -rf $WORKDIR 2> /dev/null
+}
 
-# Generate PMEM registry server certificate signing request
-generate_csr "pmem-registry"
+echo "Generating certificate files in: $WORKDIR"
 
-$KUBECTL delete secret "pmem-csi-registry-secrets" 2> /dev/null || true
-#store the approved registry certificate and key inside kubernetes secrets
-$KUBECTL create -f - <<EOF
+if [ -z "$($KUBECTL get secret pmem-csi-registry-secrets 2> /dev/null)" ]; then
+    # Generate PMEM registry server certificate signing request
+    generate_csr "pmem-registry"
+
+    $KUBECTL delete secret "pmem-csi-registry-secrets" 2> /dev/null || true
+    #store the approved registry certificate and key inside kubernetes secrets
+    $KUBECTL create -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
@@ -75,24 +90,48 @@ data:
     tls.key: $(base64 -w 0 pmem-registry-key.pem)
 EOF
 
-# Find the nodes for which we need to create node certificates
-NODES=$($KUBECTL get no -l storage=pmem -o name | sed  -e 's;.*/;;')
+fi
+
+existing_secrets=
+existing_nodes=""
+# Get existing node certificates if any
+if [ -n "$($KUBECTL get secret pmem-csi-node-secrets 2> /dev/null)" ]; then
+    # Retrieve existing node certificates
+    existing_secrets=$($KUBECTL get secret pmem-csi-node-secrets -o go-template="'"'{{range $key, $value := .data}}  {{$key}}: {{$value}}{{"\n"}}{{end}}'"'")
+    existing_nodes=$(echo "$existing_secrets" | cut -f1 -d':' | sed -e 's;.key;;' -e 's;.crt;;' | uniq)
+fi
+
+echo "$existing_secrets"
+echo "$existing_nodes"
+
+FINAL_NODES=
 for node in $NODES; do
-    generate_csr "pmem-node-controller" "$node"
+    if [ -z $(echo "$existing_nodes" | grep $node) ]; then
+        create_node_secret=1
+        FINAL_NODES="$FINAL_NODES $node"
+        generate_csr "pmem-node-controller" "$node"
+    else
+        echo "Secrets for '$node' already found in 'pmem-csi-node-secrets'"
+    fi
 done
 
-# Store all node certificates into kubernetes secrets
-echo "Generating node secrets: pmem-node-secrets."
-$KUBECTL delete secret "pmem-csi-node-secrets" 2> /dev/null || true
-$KUBECTL create -f - <<EOF
+if [ -n "$FINAL_NODES" ]; then
+    # Store all node certificates into kubernetes secrets
+    echo "Generating node secrets: pmem-csi-node-secrets."
+    $KUBECTL delete secret "pmem-csi-node-secrets" 2> /dev/null || true
+    $KUBECTL create -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
   name: pmem-csi-node-secrets
 type: Opaque
 data:
-$(for name in ${NODES}; do
-    echo "  $name.crt: $(base64 -w 0 $name.crt)"
-    echo "  $name.key: $(base64 -w 0 $name-key.pem)"
+$(echo "$existing_secrets")
+$(for name in ${FINAL_NODES}; do
+echo "  $name.crt: $(base64 -w 0 $name.crt)"
+echo "  $name.key: $(base64 -w 0 $name-key.pem)"
 done)
 EOF
+fi
+
+[ "$(ls -A $WORKDIR)" ] || cleanup


### PR DESCRIPTION
Add check to throw a warning and exit in case of no nodes with "storage=pmem"
label.

Took the opportunity to improve the script, such that now it generates secrets
only for newly added nodes. First, it retrieves existing node secrets and
filters out those nodes from all pmem nodes and generates certificates for
leftover nodes.

Now one can add new pmem node(node with storage=pmem label) and rerun the script
for generating secrets for that new node, ever after deploying the driver.

Fixes: #272