### PR TITLE
Dockerfile: Provide defaults for build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM clearlinux:base AS build
 
-ARG VERSION
-ARG NDCTL_VERSION
-ARG NDCTL_CONFIGFLAGS
-ARG NDCTL_BUILD_DEPS
+ARG VERSION="unknown"
+ARG NDCTL_VERSION="64.1"
+ARG NDCTL_CONFIGFLAGS="--libdir=/usr/lib --disable-docs --without-systemd --without-bash"
+ARG NDCTL_BUILD_DEPS="os-core-dev devpkg-util-linux devpkg-kmod devpkg-json-c"
 
 #pull dependencies required for downloading and building libndctl
 ARG CACHEBUST
 RUN swupd update && swupd bundle-add ${NDCTL_BUILD_DEPS} go-basic-dev && rm -rf /var/lib/swupd
 
 WORKDIR /
-RUN curl --location --remote-name https://github.com/pmem/ndctl/archive/v${NDCTL_VERSION}.tar.gz
+RUN curl --fail --location --remote-name https://github.com/pmem/ndctl/archive/v${NDCTL_VERSION}.tar.gz
 RUN tar zxvf v${NDCTL_VERSION}.tar.gz && mv ndctl-${NDCTL_VERSION} ndctl
 WORKDIR /ndctl
 RUN ./autogen.sh

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ endif
 REGISTRY_NAME=localhost:5000
 IMAGE_VERSION=canary
 IMAGE_TAG=$(REGISTRY_NAME)/pmem-csi-driver$*:$(IMAGE_VERSION)
-IMAGE_BUILD_ARGS=--build-arg NDCTL_VERSION=64.1 --build-arg NDCTL_CONFIGFLAGS='--libdir=/usr/lib --disable-docs --without-systemd --without-bash' \
---build-arg NDCTL_BUILD_DEPS='os-core-dev devpkg-util-linux devpkg-kmod devpkg-json-c file'
 # Pass proxy config via --build-arg only if these are set,
 # enabling proxy config other way, like ~/.docker/config.json
 BUILD_ARGS=
@@ -79,7 +77,7 @@ BUILD_IMAGE_ID=$(shell date +%Y-%m-%d)
 build-images: build-image build-test-image
 push-images: push-image push-test-image
 build-image build-test-image: build%-image:
-	docker build --pull --build-arg CACHEBUST=$(BUILD_IMAGE_ID) --build-arg BIN_SUFFIX=$(findstring -test,$*) $(BUILD_ARGS) $(IMAGE_BUILD_ARGS) -t $(IMAGE_TAG) -f ./Dockerfile . --label revision=$(VERSION)
+	docker build --pull --build-arg CACHEBUST=$(BUILD_IMAGE_ID) --build-arg BIN_SUFFIX=$(findstring -test,$*) $(BUILD_ARGS) -t $(IMAGE_TAG) -f ./Dockerfile . --label revision=$(VERSION)
 push-image push-test-image: push%-image: build%-image
 	docker push $(IMAGE_TAG)
 


### PR DESCRIPTION
Docker image building might fail if one tries to build directly without using
our defined make targets. In this case, as the mandatory NDCTL* build args have
no default values that result in unexpected build failures.

With this change, Dockerfile is self-contained and uses these defaults defined
in Dockerfile.