### PR TITLE
runtime deps: Go and Kubernetes updates

### DIFF
--- a/runtime-deps.csv
+++ b/runtime-deps.csv
@@ -1,7 +1,6 @@
-Go,https://github.com/golang/go
-github.com/kubernetes-csi/csi-lib-utils
+Go,https://github.com/golang/go,9051
 golang-protobuf,https://github.com/golang/protobuf
 google uuid,https://github.com/google/uuid
 grpc-go,https://github.com/grpc/grpc-go
-kubernetes,https://github.com/kubernetes/kubernetes
+kubernetes,https://github.com/kubernetes/kubernetes,9641
 pkg/errors,https://github.com/pkg/errors

--- a/test/test.make
+++ b/test/test.make
@@ -83,8 +83,8 @@ RUNTIME_DEPS += sed \
 	-e 's;github.com/golang/glog;glog,https://github.com/golang/glog;' \
 	-e 's;github.com/pkg/errors;pkg/errors,https://github.com/pkg/errors;' \
 	-e 's;github.com/vgough/grpc-proxy;grpc-proxy,https://github.com/vgough/grpc-proxy;' \
-	-e 's;golang.org/x/.*;Go,https://github.com/golang/go;' \
-	-e 's;k8s.io/.*;kubernetes,https://github.com/kubernetes/kubernetes;' \
+	-e 's;golang.org/x/.*;Go,https://github.com/golang/go,9051;' \
+	-e 's;k8s.io/.*\|github.com/kubernetes-csi/.*;kubernetes,https://github.com/kubernetes/kubernetes,9641;' \
 	-e 's;gopkg.in/fsnotify.*;golang-github-fsnotify-fsnotify,https://github.com/fsnotify/fsnotify;' \
 	| cat |
 


### PR DESCRIPTION
The additional IDs for Go and Kubernetes help when checking the status
of these projects in the Intel-internal tooling. Kubernetes-CSI can be
considered part of Kubernetes and doesn't need an extra entry.