### PR TITLE
Wait for device to appear after creation before Flush

### DIFF
--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -121,6 +121,10 @@ func (lvm *pmemLvm) CreateDevice(name string, size uint64, nsmode string) error 
 				if err != nil {
 					return err
 				}
+				err = WaitDeviceAppears(device)
+				if err != nil {
+					return err
+				}
 				err = ClearDevice(device, false)
 				if err != nil {
 					return err


### PR DESCRIPTION
In the LVM mode, there seems to be
time window when device is not accessible yet.