### PR TITLE
Makefile: fix "make test-kustomize" dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,5 +166,5 @@ clean-kustomize:
 .PHONY: test-kustomize $(addprefix test-kustomize-,$(KUSTOMIZE_OUTPUT))
 test: test-kustomize
 test-kustomize: $(addprefix test-kustomize-,$(KUSTOMIZE_OUTPUT))
-$(addprefix test-kustomize-,$(KUSTOMIZE_OUTPUT)): test-kustomize-%: _work/kustomize
+$(addprefix test-kustomize-,$(KUSTOMIZE_OUTPUT)): test-kustomize-%: _work/kustomize-$(KUSTOMIZE_VERSION)
 	@ if ! diff <($< build --load_restrictor none $(KUSTOMIZATION_$*)) $*; then echo "$* was modified manually" && false; fi


### PR DESCRIPTION
On a clean checkout or after "make clean", "make test" failed with:

make: *** No rule to make target '_work/kustomize', needed by
'test-kustomize-deploy/kubernetes-1.13/pmem-csi-direct.yaml'.  Stop.

That's the result of changing how the kustomize binary is built and
then not adapting all dependencies on it.