### PR TITLE
pmem-csi-driver: fix race condition in registry server

### DIFF
--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -19,6 +19,7 @@ import (
 	pmdmanager "github.com/intel/pmem-csi/pkg/pmem-device-manager"
 	pmemgrpc "github.com/intel/pmem-csi/pkg/pmem-grpc"
 	registry "github.com/intel/pmem-csi/pkg/pmem-registry"
+	"github.com/intel/pmem-csi/pkg/registryserver"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -154,7 +155,7 @@ func (pmemd *pmemDriver) Run() error {
 	}()
 
 	if pmemd.cfg.Mode == Controller {
-		rs := NewRegistryServer(pmemd.clientTLSConfig)
+		rs := registryserver.New(pmemd.clientTLSConfig)
 		cs := NewMasterControllerServer(rs)
 
 		if pmemd.cfg.Endpoint != pmemd.cfg.RegistryEndpoint {

--- a/pkg/registryserver/registryserver_test.go
+++ b/pkg/registryserver/registryserver_test.go
@@ -1,4 +1,4 @@
-package pmemcsidriver_test
+package registryserver_test
 
 import (
 	"crypto/tls"
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	pmemcsidriver "github.com/intel/pmem-csi/pkg/pmem-csi-driver"
+	"github.com/intel/pmem-csi/pkg/pmem-csi-driver"
 	pmemgrpc "github.com/intel/pmem-csi/pkg/pmem-grpc"
 	registry "github.com/intel/pmem-csi/pkg/pmem-registry"
+	"github.com/intel/pmem-csi/pkg/registryserver"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -45,7 +46,7 @@ var _ = Describe("pmem registry", func() {
 		nbServer           *pmemcsidriver.NonBlockingGRPCServer
 		registryClientConn *grpc.ClientConn
 		registryClient     registry.RegistryClient
-		registryServer     = pmemcsidriver.NewRegistryServer(nil)
+		registryServer     = registryserver.New(nil)
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
When nodes register, there is a race condition around the concurrent
modifications and/or usage of the node info map by the master
controller. All accesses to that field have to be protected by a
mutex.

To enforce this, the RegistryServer implementation gets moved into its
own package with only those methods exported which do proper
locking.

Fixes: https://github.com/intel/pmem-CSI/issues/226