### PR TITLE
test: sync filesystem before starting restart tests

### DIFF
--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -64,6 +64,7 @@ var _ = Describe("sanity", func() {
 
 	f := framework.NewDefaultFramework("pmem")
 	f.SkipNamespaceCreation = true // We don't need a per-test namespace and skipping it makes the tests run faster.
+	var execOnTestNode func(args ...string) string
 
 	BeforeEach(func() {
 		cs := f.ClientSet
@@ -89,7 +90,7 @@ var _ = Describe("sanity", func() {
 		// any node, what matters is the service port.
 		config.ControllerAddress = fmt.Sprintf("dns:///%s:%d", host, getServicePort(cs, "pmem-csi-controller-testing"))
 
-		exec := func(args ...string) string {
+		execOnTestNode = func(args ...string) string {
 			// Wait for socat pod on that node. We need it for
 			// creating directories.  We could use the PMEM-CSI
 			// node container, but that then forces us to have
@@ -112,10 +113,10 @@ var _ = Describe("sanity", func() {
 			return stdout
 		}
 		mkdir := func(path string) (string, error) {
-			return exec("mktemp", "-d", path), nil
+			return execOnTestNode("mktemp", "-d", path), nil
 		}
 		rmdir := func(path string) error {
-			exec("rmdir", path)
+			execOnTestNode("rmdir", path)
 			return nil
 		}
 
@@ -162,6 +163,7 @@ var _ = Describe("sanity", func() {
 		})
 
 		It("stores state across reboots for single volume", func() {
+			execOnTestNode("sync")
 			namePrefix := "state-volume"
 
 			// We intentionally check the state of the controller on the node here.
@@ -186,6 +188,7 @@ var _ = Describe("sanity", func() {
 		})
 
 		It("can mount again after reboot", func() {
+			execOnTestNode("sync")
 			namePrefix := "mount-volume"
 
 			name, vol := createVolume(cc, sc, cl, namePrefix, 22*1024*1024, nodeID)
@@ -211,6 +214,7 @@ var _ = Describe("sanity", func() {
 		})
 
 		It("capacity is restored after controller restart", func() {
+			execOnTestNode("sync")
 			capacity, err := cc.GetCapacity(context.Background(), &csi.GetCapacityRequest{})
 			framework.ExpectNoError(err, "get capacity before restart")
 


### PR DESCRIPTION
The following error occurred randomly:

  rmdir: '/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pmem-sanity-target.ECDAPN': No such file or directory

Most recently it was observed in the teardown after an otherwise
successful node restart test. One possible reason is that the
directory was created before the test ran, but never got flushed to
disk, so when the node came back up, the directory was lost.

We may be able to avoid that by explicitly syncing. This is done only
in those tests which need it and at the very beginning, so changes
made by the driver still need to be synced by the driver itself.