### PR TITLE
test direct mode and LVM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,6 @@ pipeline {
                 }
 
                 stage('testing 1.14 direct') {
-                    when { not { changeRequest() } }
                     options {
                         timeout(time: 180, unit: "MINUTES")
                         retry(2)
@@ -210,6 +209,7 @@ pipeline {
                 }
 
                 stage('testing 1.13 LVM') {
+                    when { not { changeRequest() } }
                     options {
                         timeout(time: 90, unit: "MINUTES")
                         retry(2)

--- a/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
@@ -186,6 +186,7 @@ spec:
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
       - args:
+        - --connection-timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -170,6 +170,7 @@ spec:
         - mountPath: /csi
           name: plugin-socket-dir
       - args:
+        - --connection-timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
@@ -186,6 +186,7 @@ spec:
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
       - args:
+        - --connection-timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -170,6 +170,7 @@ spec:
         - mountPath: /csi
           name: plugin-socket-dir
       - args:
+        - --connection-timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -206,6 +206,7 @@ spec:
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
       - args:
+        - --timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kubernetes-1.14/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct.yaml
@@ -190,6 +190,7 @@ spec:
         - mountPath: /csi
           name: plugin-socket-dir
       - args:
+        - --timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -206,6 +206,7 @@ spec:
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
       - args:
+        - --timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -190,6 +190,7 @@ spec:
         - mountPath: /csi
           name: plugin-socket-dir
       - args:
+        - --timeout=5m
         - --v=3
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true

--- a/deploy/kustomize/kubernetes-1.13/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13/kustomization.yaml
@@ -11,3 +11,13 @@ images:
   newTag: v1.0.1
 - name: quay.io/k8scsi/csi-node-driver-registrar
   newTag: v1.1.0
+
+# How to increase the external-provisioner timeout also depends on the
+# version.
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../patches/external-provisioner-connection-timeout-patch.yaml

--- a/deploy/kustomize/kubernetes-1.14/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.14/kustomization.yaml
@@ -12,6 +12,12 @@ patchesJson6902:
     kind: StatefulSet
     name: pmem-csi-controller
   path: ../patches/strict-topology-patch.yaml
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../patches/external-provisioner-timeout-patch.yaml
 
 # The RBAC files must match the image versions.
 images:

--- a/deploy/kustomize/patches/external-provisioner-connection-timeout-patch.yaml
+++ b/deploy/kustomize/patches/external-provisioner-connection-timeout-patch.yaml
@@ -1,0 +1,4 @@
+# Add -connection-timeout to external-controller in second container.
+- op: add
+  path: /spec/template/spec/containers/1/args/0
+  value: "--connection-timeout=5m"

--- a/deploy/kustomize/patches/external-provisioner-timeout-patch.yaml
+++ b/deploy/kustomize/patches/external-provisioner-timeout-patch.yaml
@@ -1,0 +1,4 @@
+# Add -timeout to external-controller in second container.
+- op: add
+  path: /spec/template/spec/containers/1/args/0
+  value: "--timeout=5m"

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -17,15 +17,14 @@ LOCKFILE="${LOCKFILE:-${REPO_DIRECTORY}/_work/start-kubernetes.exclusivelock}"
 LOCKDELAY="${LOCKDELAY:-300}" # seconds
 NODES=( $DEPLOYMENT_ID-master
         $DEPLOYMENT_ID-worker1
-        $DEPLOYMENT_ID-worker2
-        $DEPLOYMENT_ID-worker3)
+        $DEPLOYMENT_ID-worker2)
 CLOUD="${CLOUD:-true}"
 FLAVOR="${FLAVOR:-medium}"
 SSH_KEY="${SSH_KEY:-${RESOURCES_DIRECTORY}/id_rsa}"
 SSH_PUBLIC_KEY="${SSH_KEY}.pub"
 EFI="${EFI:-true}"
 KVM_CPU_OPTS="${KVM_CPU_OPTS:-\
- -m 2G,slots=${TEST_MEM_SLOTS:-2},maxmem=34G -smp 4\
+ -m 2G,slots=${TEST_MEM_SLOTS:-2},maxmem=34G -smp 2\
  -machine pc,accel=kvm,nvdimm=on}"
 EXTRA_QEMU_OPTS="${EXTRA_QWEMU_OPTS:-\
  -object memory-backend-file,id=mem1,share=${TEST_PMEM_SHARE:-on},\


### PR DESCRIPTION
This changes the test setup such that the CI covers LVM and direct mode on Kubernetes 1.14.