### PR TITLE
Makefile: properly set version string in production binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test: build
 
 # Build production binaries.
 $(CMDS):
-	GOOS=linux go build -ldflags '-X main.version=${VERSION}' -a -o ${OUTPUT_DIR}/$@ ./cmd/$@
+	GOOS=linux go build -ldflags '-X github.com/intel/pmem-csi/pkg/$@.version=${VERSION}' -a -o ${OUTPUT_DIR}/$@ ./cmd/$@
 
 # Build a test binary that can be used instead of the normal one with
 # additional "-run" parameters. In contrast to the normal it then also


### PR DESCRIPTION
Some previous change moved the location of the version string from the
"main" package into "pkg/<binary>". The build rules were adapted for
the testing variant of the binaries, but not the production variant.