### PR TITLE
Dockerfile: Fix missing image version issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ARG SWUPD_UPDATE_ARG=
 # - ndctl installed
 FROM ${CLEAR_LINUX_BASE} AS build
 
-ARG VERSION="unknown"
 ARG NDCTL_VERSION="65"
 ARG NDCTL_CONFIGFLAGS="--libdir=/usr/lib64 --disable-docs --without-systemd --without-bash"
 ARG NDCTL_BUILD_DEPS="os-core-dev devpkg-util-linux devpkg-kmod devpkg-json-c"
@@ -42,6 +41,7 @@ RUN ldconfig
 FROM build as binaries
 
 # build pmem-csi-driver
+ARG VERSION="unknown"
 ADD . /go/src/github.com/intel/pmem-csi
 ENV GOPATH=/go
 ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig/


### PR DESCRIPTION
Change 5c5f60601246865220eeb63ecb7eba7c63f3e15d introduced 3-phase image
building, in that VERSION argument spans to different(base & binaries) phases.
This makes VERSION passed via Makefile(build-arg) is not reached properly.

This change fixes this by moving the VERSION argument to appropriate phase.