### PR TITLE
test: fix image verification error

### DIFF
--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -88,7 +88,7 @@ function download_image() (
                          -inform DER \
                          -content "${CLOUD_IMAGE}-SHA512SUMS" \
                          -CAfile "ClearLinuxRoot.pem"; then
-                        cat <<EOF
+                        cat >&2 <<EOF
 Image verification failed, see error above.
 
 "unsupported certificate purpose" is a known issue caused by an incompatible openssl


### PR DESCRIPTION
The download_image function is called with redirected stdout because
that's where it reports the image to be used. That means that error
messages must be sent to stderr (which is good practice anyway),
otherwise they are not visible to the user.