### PR TITLE
Refuse to clear mounted device

### DIFF
--- a/pkg/pmem-device-manager/pmd-util.go
+++ b/pkg/pmem-device-manager/pmd-util.go
@@ -9,6 +9,7 @@ import (
 
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
 	"k8s.io/klog/glog"
+	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/utils/keymutex"
 )
 
@@ -57,6 +58,13 @@ func FlushDevice(dev PmemDeviceInfo, blocks uint64) error {
 	if (fileinfo.Mode() & os.ModeDevice) == 0 {
 		glog.Errorf("FlushDevice: %s is not device", dev.Path)
 		return fmt.Errorf("%s is not device", dev.Path)
+	}
+	devOpen, err := mount.New("").DeviceOpened(dev.Path)
+	if err != nil {
+		return err
+	}
+	if devOpen == true {
+		return fmt.Errorf("%s is in use", dev.Path)
 	}
 	if blocks == 0 {
 		glog.V(5).Infof("Wiping entire device: %s", dev.Path)


### PR DESCRIPTION
There is code path where a volume that remained mounted, gets
erased by shred. This has happened for various reasons, like
incorrect paths use by tester code.
Detect that the device is opened, and return error before
performing shred, avoiding unnecessary destruction that
would show as garbage remaining mounted as file system.

Resolves: #317
Resolves: #338