### PR TITLE
DeviceManager/ndctl: Fix deadlocking

### DIFF
--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -16,6 +16,9 @@ var _ PmemDeviceManager = &pmemNdctl{}
 
 //NewPmemDeviceManagerNdctl Instantiates a new ndctl based pmem device manager
 func NewPmemDeviceManagerNdctl() (PmemDeviceManager, error) {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
+
 	ctx, err := ndctl.NewContext()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize pmem context: %s", err.Error())
@@ -44,6 +47,9 @@ func NewPmemDeviceManagerNdctl() (PmemDeviceManager, error) {
 }
 
 func (pmem *pmemNdctl) GetCapacity() (map[string]uint64, error) {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
+
 	Capacity := map[string]uint64{}
 	nsmodes := []ndctl.NamespaceMode{ndctl.FsdaxMode, ndctl.SectorMode}
 	var capacity uint64
@@ -72,7 +78,7 @@ func (pmem *pmemNdctl) CreateDevice(name string, size uint64, nsmode string) err
 	// this function is asked to create new devices repeatedly, forcing running out of space.
 	// Avoid device filling with garbage entries by returning error.
 	// Overall, no point having more than one namespace with same name.
-	_, err := pmem.GetDevice(name)
+	_, err := pmem.getDevice(name)
 	if err == nil {
 		glog.V(4).Infof("Device with name: %s already exists, refuse to create another", name)
 		return fmt.Errorf("CreateDevice: Failed: namespace with that name exists")
@@ -94,7 +100,7 @@ func (pmem *pmemNdctl) CreateDevice(name string, size uint64, nsmode string) err
 	data, _ := ns.MarshalJSON() //nolint: gosec
 	glog.V(3).Infof("Namespace created: %s", data)
 	// clear start of device to avoid old data being recognized as file system
-	device, err := pmem.GetDevice(name)
+	device, err := pmem.getDevice(name)
 	if err != nil {
 		return err
 	}
@@ -107,9 +113,10 @@ func (pmem *pmemNdctl) CreateDevice(name string, size uint64, nsmode string) err
 }
 
 func (pmem *pmemNdctl) DeleteDevice(name string, flush bool) error {
-	volumeMutex.LockKey(name)
-	defer volumeMutex.UnlockKey(name)
-	device, err := pmem.GetDevice(name)
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
+
+	device, err := pmem.getDevice(name)
 	if err != nil {
 		return err
 	}
@@ -121,9 +128,10 @@ func (pmem *pmemNdctl) DeleteDevice(name string, flush bool) error {
 }
 
 func (pmem *pmemNdctl) FlushDeviceData(name string) error {
-	volumeMutex.LockKey(name)
-	defer volumeMutex.UnlockKey(name)
-	device, err := pmem.GetDevice(name)
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
+
+	device, err := pmem.getDevice(name)
 	if err != nil {
 		return err
 	}
@@ -131,20 +139,30 @@ func (pmem *pmemNdctl) FlushDeviceData(name string) error {
 }
 
 func (pmem *pmemNdctl) GetDevice(name string) (PmemDeviceInfo, error) {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
+
+	return pmem.getDevice(name)
+}
+
+func (pmem *pmemNdctl) ListDevices() ([]PmemDeviceInfo, error) {
+	devicemutex.Lock()
+	defer devicemutex.Unlock()
+
+	devices := []PmemDeviceInfo{}
+	for _, ns := range pmem.ctx.GetActiveNamespaces() {
+		devices = append(devices, namespaceToPmemInfo(ns))
+	}
+	return devices, nil
+}
+
+func (pmem *pmemNdctl) getDevice(name string) (PmemDeviceInfo, error) {
 	ns, err := pmem.ctx.GetNamespaceByName(name)
 	if err != nil {
 		return PmemDeviceInfo{}, err
 	}
 
 	return namespaceToPmemInfo(ns), nil
-}
-
-func (pmem *pmemNdctl) ListDevices() ([]PmemDeviceInfo, error) {
-	devices := []PmemDeviceInfo{}
-	for _, ns := range pmem.ctx.GetActiveNamespaces() {
-		devices = append(devices, namespaceToPmemInfo(ns))
-	}
-	return devices, nil
 }
 
 func namespaceToPmemInfo(ns *ndctl.Namespace) PmemDeviceInfo {

--- a/pkg/pmem-device-manager/pmd-util.go
+++ b/pkg/pmem-device-manager/pmd-util.go
@@ -4,35 +4,16 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
 	"k8s.io/klog/glog"
 	"k8s.io/kubernetes/pkg/util/mount"
-	"k8s.io/utils/keymutex"
 )
 
 const (
 	retryStatTimeout time.Duration = 100 * time.Millisecond
 )
-
-// Two mutexes protecting device and volumes concurrent access.
-// Create, Delete, Flush may operate on same phys.device from parallel threads.
-// The mutexes defined here are used by different device managers.
-// Ndctl manager would crash without Creation mutex protection
-// in 2-volume creation scenario on same Node.
-// For LVM manager, situation is likely not that risky,
-// but we use similar protection in LVM Manager for clarity and unified style,
-// as LVM state is also single instance for a Node.
-
-// All-device mutex i.e. global in driver context:
-var devicemutex = &sync.Mutex{}
-
-// flushVolumeMutex is used to avoid concurrent calls to flush a device.
-// this is internal to FlushDevice(), so device managers are not allowed to
-// access this mutex.
-var flushVolumeMutex = keymutex.NewHashed(-1)
 
 func ClearDevice(device PmemDeviceInfo, flush bool) error {
 	glog.V(4).Infof("ClearDevice: path: %v flush:%v", device.Path, flush)
@@ -46,8 +27,6 @@ func ClearDevice(device PmemDeviceInfo, flush bool) error {
 }
 
 func FlushDevice(dev PmemDeviceInfo, blocks uint64) error {
-	flushVolumeMutex.LockKey(dev.Name)
-	defer flushVolumeMutex.UnlockKey(dev.Name)
 	// erase data on block device.
 	// zero number of blocks causes overwriting whole device with random data.
 	// nonzero number of blocks clears blocks*1024 bytes.


### PR DESCRIPTION
With recent change #6a8d1ee6b9ee4ba371730a23e363ad7589c11908 FlushDevice()
itself handles the mutex(volumeMutex) locking and unlocking, so
callers(LVM,ndctl) should not lock explicitly while calling this utility method.