### PR TITLE
failure handling

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -29,7 +29,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
 	"k8s.io/kubernetes/test/e2e/framework/podlogs"
 )
 
@@ -146,7 +145,8 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 // This function is called on each Ginkgo node in parallel mode.
 func RunE2ETests(t *testing.T) {
 	// TODO: with "ginkgo ./test/e2e" we shouldn't get verbose output, but somehow we do.
-	gomega.RegisterFailHandler(ginkgowrapper.Fail)
+	// TODO: use ginkgowrapper.Fail again after upstreaming our enhancements in wrapper.go
+	gomega.RegisterFailHandler(FailWrapper)
 	ginkgo.RunSpecs(t, "PMEM E2E suite")
 }
 

--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -358,6 +358,9 @@ var _ = Describe("sanity", func() {
 								if !success {
 									duration := time.Since(start)
 									By(fmt.Sprintf("%s: failed after %s", duration))
+
+									// Stop testing.
+									atomic.AddInt64(&volumes, int64(*numVolumes))
 								}
 							}()
 							lv.ctx = ctx

--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -280,7 +280,6 @@ var _ = Describe("sanity", func() {
 			for i := 0; i < *numWorkers; i++ {
 				i := i
 				go func() {
-
 					// Order is relevant (first-in-last-out): when returning,
 					// we first let GinkgoRecover do its job, which
 					// may include marking the test as failed, then tell the
@@ -289,6 +288,7 @@ var _ = Describe("sanity", func() {
 						By(fmt.Sprintf("worker-%d terminating", i))
 						wg.Done()
 					}()
+					defer GinkgoRecover() // must be invoked directly by defer, otherwise it doesn't see the panic
 
 					// Each worker must use its own pair of directories.
 					targetPath := fmt.Sprintf("%s/worker-%d", sc.TargetPath, i)
@@ -297,8 +297,6 @@ var _ = Describe("sanity", func() {
 					defer execOnTestNode("rmdir", targetPath)
 					execOnTestNode("mkdir", stagingPath)
 					defer execOnTestNode("rmdir", stagingPath)
-
-					defer GinkgoRecover() // must be invoked directly by defer, otherwise it doesn't see the panic
 
 					for {
 						volume := atomic.AddInt64(&volumes, 1)

--- a/test/e2e/wrapper.go
+++ b/test/e2e/wrapper.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"regexp"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+// FailurePanic is the value that will be panicked from Fail.
+type FailurePanic struct {
+	Message        string // The failure message passed to Fail
+	Filename       string // The filename that is the source of the failure
+	Line           int    // The line number of the filename that is the source of the failure
+	FullStackTrace string // A full stack trace starting at the source of the failure
+}
+
+// String makes FailurePanic look like the old Ginkgo panic when printed.
+func (FailurePanic) String() string { return ginkgo.GINKGO_PANIC }
+
+// FailWrapper wraps ginkgo.Fail so that it logs failures as they occur
+// and then panics with more useful
+// information about the failure. This function will panic with a
+// FailurePanic.
+func FailWrapper(message string, callerSkip ...int) {
+	skip := 1
+	if len(callerSkip) > 0 {
+		skip += callerSkip[0]
+	}
+
+	_, file, line, _ := runtime.Caller(skip)
+	fp := FailurePanic{
+		Message:        message,
+		Filename:       file,
+		Line:           line,
+		FullStackTrace: pruneStack(skip),
+	}
+
+	// TODO: enhance and integrate with test/e2e/framework/log/logger.go
+	fmt.Fprintf(ginkgo.GinkgoWriter, time.Now().Format(time.StampMilli)+" FAIL: %s\n%s\n", fp.Message, fp.FullStackTrace)
+
+	defer func() {
+		e := recover()
+		if e != nil {
+			panic(fp)
+		}
+	}()
+
+	ginkgo.Fail(message, skip)
+}
+
+// ginkgo adds a lot of test running infrastructure to the stack, so
+// we filter those out
+var stackSkipPattern = regexp.MustCompile(`onsi/ginkgo`)
+
+func pruneStack(skip int) string {
+	skip += 2 // one for pruneStack and one for debug.Stack
+	stack := debug.Stack()
+	scanner := bufio.NewScanner(bytes.NewBuffer(stack))
+	var prunedStack []string
+
+	// skip the top of the stack
+	for i := 0; i < 2*skip+1; i++ {
+		scanner.Scan()
+	}
+
+	for scanner.Scan() {
+		if stackSkipPattern.Match(scanner.Bytes()) {
+			scanner.Scan() // these come in pairs
+		} else {
+			prunedStack = append(prunedStack, scanner.Text())
+			scanner.Scan() // these come in pairs
+			prunedStack = append(prunedStack, scanner.Text())
+		}
+	}
+
+	return strings.Join(prunedStack, "\n")
+}


### PR DESCRIPTION
Addresses two issues seen by @okartau when testing on real hardware:
- failure not logged
- failure not captured by GinkgoRecover

The problem itself most likely was an error during directory setup or teardown. That can still happen, but now it should be visible.

The problem itself might have been the "126 = cannot execute error" that I also got in a CI run. Workaround for that also included.