### PR TITLE
Better alignment handling

### DIFF
--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -188,10 +188,9 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 		ways := uint64(C.ndctl_region_get_interleave_ways(ndr))
 		align := opts.Align * ways
 		if opts.Size%align != 0 {
-			// force-align down to block boundary. More sensible would be to align up, but then it may fail because we ask more then there is left
-			opts.Size /= align
-			opts.Size *= align
-			glog.Warningf("%s: namespace size must align to interleave-width:%d * alignment:%d, force-align to %d",
+			// Round up size to align with next block boundary.
+			opts.Size = (opts.Size/align + 1) * align
+			glog.V(4).Infof("%s: namespace size must align to interleave-width:%d * alignment:%d, force-align to %d",
 				regionName, ways, opts.Align, opts.Size)
 		}
 	}

--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -83,6 +83,11 @@ func (r *Region) Readonly() bool {
 	return C.ndctl_region_get_ro(ndr) != 0
 }
 
+func (r *Region) InterleaveWays() uint64 {
+	ndr := (*C.struct_ndctl_region)(r)
+	return uint64(C.ndctl_region_get_interleave_ways(ndr))
+}
+
 //ActiveNamespaces returns all active namespaces in the region
 func (r *Region) ActiveNamespaces() []*Namespace {
 	return r.namespaces(true)

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -174,12 +174,6 @@ func (cs *nodeControllerServer) CreateVolume(ctx context.Context, req *csi.Creat
 	}
 
 	asked := req.GetCapacityRange().GetRequiredBytes()
-	// Required==zero means unspecified by CSI spec, we create a small 4 Mbyte volume
-	// as lvcreate does not allow zero size (csi-sanity creates zero-sized volumes)
-	// FIXME(avalluri): This check should be handled by LvmDeviceManager??
-	if asked <= 0 {
-		asked = 4 * 1024 * 1024
-	}
 
 	if vol = cs.getVolumeByName(req.Name); vol != nil {
 		// Check if the size of existing volume can cover the new request

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -110,6 +110,11 @@ func (lvm *pmemLvm) CreateDevice(name string, size uint64, nsmode string) error 
 	// Division by 1M should not result in smaller-than-asked here
 	// as lvcreate will round up to next 4MB boundary.
 	sizeM := int(size / (1024 * 1024))
+	// Asked==zero means unspecified by CSI spec, we create a small 4 Mbyte volume
+	// as lvcreate does not allow zero size (csi-sanity creates zero-sized volumes)
+	if sizeM <= 0 {
+		sizeM = 4
+	}
 	strSz := strconv.Itoa(sizeM)
 
 	for _, vg := range vgs {

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -90,11 +90,13 @@ func (pmem *pmemNdctl) CreateDevice(name string, size uint64, nsmode string) err
 		glog.V(4).Infof("Device with name: %s already exists, refuse to create another", name)
 		return fmt.Errorf("CreateDevice: Failed: namespace with that name exists")
 	}
-	// align up by 1 GB, also compensate for libndctl giving us 1 GB less than we ask
-	var align uint64 = 1024 * 1024 * 1024
-	size /= align
-	size += 2
-	size *= align
+	// Increase to minimum size supported by libndctl.
+	const minsize uint64 = 2 * 1024 * 1024 * 1024
+	if size < minsize {
+		size = minsize
+	}
+	// use align by 1 GB in creation request
+	const align uint64 = 1024 * 1024 * 1024
 	ns, err := pmem.ctx.CreateNamespace(ndctl.CreateNamespaceOpts{
 		Name:  name,
 		Size:  size,


### PR DESCRIPTION
Stop doing aligning on 2 layers, only do it in ndctl
and align rounding up there. In pmem-device-manager
layer make sure that size what we ask is at least 2GB.

Adding "get interleve ways" function in ndctl layer so that
namespace creation function can adjust to real alignment value.

Resolves #348