### PR TITLE
Bugfix setup-ca-kubernetes.sh script

### DIFF
--- a/test/setup-ca-kubernetes.sh
+++ b/test/setup-ca-kubernetes.sh
@@ -97,7 +97,7 @@ existing_nodes=""
 # Get existing node certificates if any
 if [ -n "$($KUBECTL get secret pmem-csi-node-secrets 2> /dev/null)" ]; then
     # Retrieve existing node certificates
-    existing_secrets=$($KUBECTL get secret pmem-csi-node-secrets -o go-template="'"'{{range $key, $value := .data}}  {{$key}}: {{$value}}{{"\n"}}{{end}}'"'")
+    existing_secrets=$($KUBECTL get secret pmem-csi-node-secrets -o go-template=""'{{range $key, $value := .data}}{{$key}}: {{$value}}{{"\n"}}{{end}}'"")
     existing_nodes=$(echo "$existing_secrets" | cut -f1 -d':' | sed -e 's;.key;;' -e 's;.crt;;' | uniq)
 fi
 


### PR DESCRIPTION
The the format for the existing_secrets variable was not right, caused
to not find the nodes with the pmem-csi-node-secrets correctly. Removed
unnecesary quotes and whitespaces.

Signed-off-by: Gabriel Briones <gabriel.briones.sayeg@intel.com>