### PR TITLE
test: reduce sanity stress test size of direct mode

### DIFF
--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -297,7 +297,18 @@ var _ = Describe("sanity", func() {
 
 		var (
 			numWorkers = flag.Int("pmem.sanity.workers", 10, "number of worker creating volumes in parallel and thus also the maximum number of volumes at any time")
-			numVolumes = flag.Int("pmem.sanity.volumes", 100, "number of total volumes to create")
+			numVolumes = flag.Int("pmem.sanity.volumes",
+				func() int {
+					switch os.Getenv("TEST_DEVICEMODE") {
+					case "direct":
+						// The minimum volume size in direct mode is 2GB, which makes
+						// testing a lot slower than in LVM mode. Therefore we create less
+						// volumes.
+						return 20
+					default:
+						return 100
+					}
+				}(), "number of total volumes to create")
 			volumeSize = flag.String("pmem.sanity.volume-size", "15Mi", "size of each volume")
 		)
 		It("stress test", func() {

--- a/test/test.make
+++ b/test/test.make
@@ -111,6 +111,7 @@ RUN_E2E = KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
 	REPO_ROOT=`pwd` \
 	CLUSTER=$(CLUSTER) \
 	TEST_DEPLOYMENTMODE=$(shell source test/test-config.sh; echo $$TEST_DEPLOYMENTMODE) \
+	TEST_DEVICEMODE=$(shell source test/test-config.sh; echo $$TEST_DEVICEMODE) \
 	go test -count=1 -timeout 0 -v ./test/e2e -ginkgo.skip='$(subst $(space),|,$(TEST_E22_SKIP))'
 test_e2e: start
 	$(RUN_E2E)


### PR DESCRIPTION
The small volume size gets rounded up considerably, which makes test
execution noticably slower than for LVM mode. To get back to acceptable
execution times we create less volumes.