### PR TITLE
DEBUG: Controller: check for capability.access_type

### DIFF
--- a/pkg/pmem-csi-driver/controllerserver-master.go
+++ b/pkg/pmem-csi-driver/controllerserver-master.go
@@ -151,6 +151,12 @@ func (cs *masterController) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, "Name missing in request")
 	}
 
+	for _, cap := range req.VolumeCapabilities {
+		if cap.GetBlock() != nil {
+			return nil, status.Error(codes.Unimplemented, "VolumeCapability access_type:block unimplemented")
+		}
+	}
+
 	asked := req.GetCapacityRange().GetRequiredBytes()
 
 	outTopology := []*csi.Topology{}
@@ -331,6 +337,12 @@ func (cs *masterController) ValidateVolumeCapabilities(ctx context.Context, req 
 			return &csi.ValidateVolumeCapabilitiesResponse{
 				Confirmed: nil,
 				Message:   "Driver does not support '" + cap.AccessMode.Mode.String() + "' mode",
+			}, nil
+		}
+		if cap.GetBlock() != nil {
+			return &csi.ValidateVolumeCapabilitiesResponse{
+				Confirmed: nil,
+				Message:   "Driver does not support access type: block",
 			}, nil
 		}
 	}


### PR DESCRIPTION
Refuse to create volume if access_type==block.
Check same in Validate.

This is picked isolated commit from #313 which fixes the hole we now have: we dont check for access_type==block in code. 
This PR is for checking does this code change pass CI, without tests set changed