### PR TITLE
CI caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ IMAGE_VERSION?=canary
 IMAGE_TAG=$(REGISTRY_NAME)/pmem-csi-driver$*:$(IMAGE_VERSION)
 # Pass proxy config via --build-arg only if these are set,
 # enabling proxy config other way, like ~/.docker/config.json
-BUILD_ARGS=
+BUILD_ARGS?=
 ifneq ($(HTTP_PROXY),)
 	BUILD_ARGS:=${BUILD_ARGS} --build-arg http_proxy=${HTTP_PROXY}
 endif


### PR DESCRIPTION
This idea originally came up when the private registry was introduced
and a search then showed that this has indeed been done before
(https://andrewlock.net/caching-docker-layers-on-serverless-build-hosts-with-multi-stage-builds---target,-and---cache-from/):
with `--cache-from` we can use existing images to warm up the Docker
build cache. This keeps the Dockerfile and thus normal developer
workflow simple (no need to manually build base images first) while
making the CI faster.
    
The we get the most benefit out of caching the build image, but
pulling the PMEM-CSI driver image is also worthwhile. When doing both
and nothing changed, the two image build stages take ~8min instead of
~19min.
    
Only the non-PR jobs push build images. PR jobs pick up those images
and use the same cachbust value. Besides faster build times this also
has the advantage that PR jobs cannot break if Clear Linux changes,
because they will always use a Clear Linux version that was used
successfully before.
