### PR TITLE
build: limit Docker context to files that are needed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
-_output
-_work
+*
+! **/*.make
+! Makefile
+! cmd/**
+! pkg/**
+! test/test-config.d/**
+! test/test-config.sh
+! vendor/**

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ _work/kustomize-$(KUSTOMIZE_VERSION):
 # in the git repo because not all users will have kustomize or it
 # might be an unsuitable version. When any file changes, update the
 # output.
-KUSTOMIZE_INPUT := $(shell find deploy/kustomize -type f)
+KUSTOMIZE_INPUT := $(shell [ ! -d deploy/kustomize ] || find deploy/kustomize -type f)
 
 # Output files and their corresponding kustomize target.
 # The "testing" flavor of the generated files contains both


### PR DESCRIPTION
In our Dockerfile we only need the Go source code, make rules and
configuration files. By explicitly selecting those we can cut down the
amount of data sent to the Docker daemon from 120MB to 56MB.

Another advantage is that changes to other files no longer invalidate
the Docker cache for "ADD ." because the modified files are not
included.