### PR TITLE
QEMU: enhance documentation and check for /dev/kvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,17 @@ Note that cloud providers often don't offer KVM support on their
 regular machines. Search for "nested virtualization" for your provider
 to determine whether and how it supports KVM.
 
+Nested virtualization is also needed when using Kata Containers inside
+the cluster. On Intel-based machines it can be enabled by loading the
+`kvm_intel` module with `nested=1` (see
+https://wiki.archlinux.org/index.php/KVM#Nested_virtualization). At
+this time, Kata Containers up to and including 1.9.1 is [not
+compatible with
+PMEM-CSI](https://github.com/intel/pmem-csi/issues/303) because
+volumes are not passed in as PMEM, but Kata Containers [can be
+installed](https://github.com/kata-containers/packaging/tree/master/kata-deploy#kubernetes-quick-start)
+and used for applications that are not using PMEM.
+
 The `clear-cloud` image is downloaded automatically. By default,
 four different virtual machines are prepared. Each image is pre-configured
 with its own hostname and with network.

--- a/README.md
+++ b/README.md
@@ -821,11 +821,14 @@ available.
 E2E testing is known to work on a Linux development host system. The user
 must be allowed to use Docker.
 
-KVM must be enabled and the user must be allowed to use it. Usually this
-is done by adding the user to the `kvm` group. The
-["Install QEMU-KVM"](https://clearlinux.org/documentation/clear-linux/get-started/virtual-machine-install/kvm)
-section in the Clear Linux documentation contains further information
-about enabling KVM.
+KVM must be enabled. Usually this is the case when `/dev/kvm` exists.
+The current user does not need the privileges to use KVM and QEMU
+doesn't have to be installed because GoVM will run QEMU inside a
+container with root privileges.
+
+Note that cloud providers often don't offer KVM support on their
+regular machines. Search for "nested virtualization" for your provider
+to determine whether and how it supports KVM.
 
 The `clear-cloud` image is downloaded automatically. By default,
 four different virtual machines are prepared. Each image is pre-configured

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -476,6 +476,11 @@ function check_status() { # intentionally a composite command, so "exit" will ex
             exit 0
         fi
     fi
+
+    if [ ! -e /dev/kvm ]; then
+        echo "ERROR: /dev/kvm does not exist. KVM has to be enabled before starting the virtual cluster."
+        exit 1
+    fi
 }
 
 FAILED=true

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -23,14 +23,18 @@ CLOUD="${CLOUD:-true}"
 FLAVOR="${FLAVOR:-medium}" # actual memory size and CPUs selected below
 SSH_KEY="${SSH_KEY:-${RESOURCES_DIRECTORY}/id_rsa}"
 SSH_PUBLIC_KEY="${SSH_KEY}.pub"
+# -cpu host enables nested virtualization (required for Kata Containers).
+# The build host must have the kvm_intel module loaded with
+# nested=1 (see https://wiki.archlinux.org/index.php/KVM#Nested_virtualization).
 KVM_CPU_OPTS="${KVM_CPU_OPTS:-\
  -m ${TEST_NORMAL_MEM_SIZE}M,slots=${TEST_MEM_SLOTS},maxmem=$((${TEST_NORMAL_MEM_SIZE} + ${TEST_PMEM_MEM_SIZE}))M -smp ${TEST_NUM_CPUS} \
+ -cpu host \
  -machine pc,accel=kvm,nvdimm=on}"
 EXTRA_QEMU_OPTS="${EXTRA_QWEMU_OPTS:-\
  -object memory-backend-file,id=mem1,share=${TEST_PMEM_SHARE},\
 mem-path=/data/nvdimm0,size=${TEST_PMEM_MEM_SIZE}M \
  -device nvdimm,id=nvdimm1,memdev=mem1,label-size=${TEST_PMEM_LABEL_SIZE} \
- -machine pc,nvdimm}"
+}"
 EXTRA_MASTER_ETCD_VOLUME=
 INIT_CLUSTER=${INIT_CLUSTER:-true}
 TEST_INIT_REGION=${TEST_INIT_REGION:-true}


### PR DESCRIPTION
Not having KVM enabled in a GCE machine is a real issue that a user
ran into. Error handling in this case is poor, GoVM doesn't print any
error and all that the user gets is an error about timing out waiting
for ssh.

The updated README.md explains the real requirements better and warns
about this pitfall. The script itself checks very early for /dev/kvm
and bails out with an error message when it is missing.