### PR TITLE
Dockerfile: Remove deprecated option from comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # CLEARLINUX_BASE and SWUPD_UPDATE_ARG can be used to make the build reproducible
-# by choosing an image by its hash and updating to a certain version with -m:
+# by choosing an image by its hash and updating to a certain version with -V:
 # CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# SWUPD_UPDATE_ARG=-m 29970
+# SWUPD_UPDATE_ARG=-V 29970
 #
 # This is used on release branches before tagging a stable version. The master and devel
 # branches default to using the latest Clear Linux.


### PR DESCRIPTION
Replace deprecated swupd '-m' option in SWUPD_UPDATE_ARG comments section.

FIXES: #379