### PR TITLE
cleaned alignment code, unified naming to use VolumeID more

### DIFF
--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -206,7 +206,12 @@ func (cs *nodeControllerServer) CreateVolume(ctx context.Context, req *csi.Creat
 				}
 			}(volumeID)
 		}
-
+		if asked <= 0 {
+			// Allocating volumes of zero size isn't supported.
+			// We use some arbitrary small minimum size instead.
+			// It will get rounded up by below layer to meet the alignment.
+			asked = 1
+		}
 		if err := cs.dm.CreateDevice(volumeID, uint64(asked), nsmode); err != nil {
 			return nil, status.Errorf(codes.Internal, "Node CreateVolume: failed to create volume: %s", err.Error())
 		}

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -95,7 +95,7 @@ func NewNodeControllerServer(nodeID string, dm pmdmanager.PmemDeviceManager, sm 
 		err = sm.GetAll(v, func(id string) bool {
 			// See if the device data stored at StateManager is still valid
 			for _, devInfo := range devices {
-				if devInfo.Name == id {
+				if devInfo.VolumeId == id {
 					ncs.pmemVolumes[id] = v.Copy()
 					return true
 				}

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -2,8 +2,8 @@ package pmdmanager
 
 //PmemDeviceInfo represents a block device
 type PmemDeviceInfo struct {
-	//Name name of the block device
-	Name string
+	//VolumeId is name of the block device
+	VolumeId string
 	//Path actual device path
 	Path string
 	//Size size allocated for block device


### PR DESCRIPTION
pmd-lvm.go: Delete old irrelevant comments about selection strategy.
LVM uses byte-aligned size arg instead or MB

In CSI spec, Name and VolumeID are different things.
In PMEM-CSI we use VolumeID for naming volumes and namespaces,
so let's stick to the style and use VolumeID in code,
otherwise it may be confusing why we suddenly switch back to "Name"
when code gets down to device-manager level.