### PR TITLE
Devicemanager enhancements

### DIFF
--- a/pkg/ndctl/namespace.go
+++ b/pkg/ndctl/namespace.go
@@ -10,6 +10,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+
 	/* needed for nullify
 	"os"
 	"syscall"*/
@@ -184,6 +185,12 @@ func (ns *Namespace) Type() NamespaceType {
 	}
 
 	return UnknownType
+}
+
+//NumaNode returns numa node number attached to this namespace
+func (ns *Namespace) NumaNode() int {
+	ndns := (*C.struct_ndctl_namespace)(ns)
+	return int(C.ndctl_namespace_get_numa_node(ndns))
 }
 
 //Enabled return if namespace is enabled

--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -67,6 +67,12 @@ func (r *Region) Type() RegionType {
 	return UnknownRegion
 }
 
+//NumaNode returns numa node number attached to this region
+func (r *Region) NumaNode() int {
+	ndr := (*C.struct_ndctl_region)(r)
+	return int(C.ndctl_region_get_numa_node(ndr))
+}
+
 //TypeName returns region type
 func (r *Region) TypeName() string {
 	ndr := (*C.struct_ndctl_region)(r)

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -17,7 +17,7 @@ type pmemLvm struct {
 }
 
 var _ PmemDeviceManager = &pmemLvm{}
-var lvsArgs = []string{"--noheadings", "--nosuffix", "-o", "lv_name,lv_path,lv_size", "--units", "B"}
+var lvsArgs = []string{"--noheadings", "--nosuffix", "-o", "lv_name,lv_path,lv_size,vg_tags", "--units", "B"}
 var vgsArgs = []string{"--noheadings", "--nosuffix", "-o", "vg_name,vg_size,vg_free,vg_tags", "--units", "B"}
 
 // mutex to synchronize all LVM calls
@@ -243,6 +243,7 @@ func parseLVSOuput(output string) (map[string]PmemDeviceInfo, error) {
 		dev.Name = fields[0]
 		dev.Path = fields[1]
 		dev.Size, _ = strconv.ParseUint(fields[2], 10, 64)
+		dev.Mode = fields[3] //vg_tags
 
 		devices[dev.Name] = dev
 	}

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -8,6 +8,8 @@ type PmemDeviceInfo struct {
 	Path string
 	//Size size allocated for block device
 	Size uint64
+	//Mode device namespace mode
+	Mode string
 }
 
 //PmemDeviceManager interface to manage the PMEM block devices

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -10,6 +10,8 @@ type PmemDeviceInfo struct {
 	Size uint64
 	//Mode device namespace mode
 	Mode string
+	//NumaNode attached numa node number
+	NumaNode int
 }
 
 //PmemDeviceManager interface to manage the PMEM block devices

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -195,5 +195,6 @@ func namespaceToPmemInfo(ns *ndctl.Namespace) PmemDeviceInfo {
 		Name: ns.Name(),
 		Path: "/dev/" + ns.BlockDeviceName(),
 		Size: ns.Size(),
+		Mode: string(ns.Mode()),
 	}
 }

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -192,9 +192,10 @@ func (pmem *pmemNdctl) getDevice(name string) (PmemDeviceInfo, error) {
 
 func namespaceToPmemInfo(ns *ndctl.Namespace) PmemDeviceInfo {
 	return PmemDeviceInfo{
-		Name: ns.Name(),
-		Path: "/dev/" + ns.BlockDeviceName(),
-		Size: ns.Size(),
-		Mode: string(ns.Mode()),
+		Name:     ns.Name(),
+		Path:     "/dev/" + ns.BlockDeviceName(),
+		Size:     ns.Size(),
+		Mode:     string(ns.Mode()),
+		NumaNode: ns.NumaNode(),
 	}
 }

--- a/pkg/pmem-vgm/main.go
+++ b/pkg/pmem-vgm/main.go
@@ -3,13 +3,14 @@ package pmemvgm
 import (
 	"flag"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/klog"
 	"k8s.io/klog/glog"
 
 	"github.com/intel/pmem-csi/pkg/ndctl"
-	"github.com/intel/pmem-csi/pkg/pmem-common"
+	pmemcommon "github.com/intel/pmem-csi/pkg/pmem-common"
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
 )
 
@@ -107,7 +108,8 @@ func createVolumesForRegion(r *ndctl.Region, vgName string, nsmode ndctl.Namespa
 	if err != nil {
 		return err
 	}
+
 	// Tag add works without error if repeated, so it is safe to run without checking for existing
-	_, err = pmemexec.RunCommand("vgchange", "--addtag", string(nsmode), vgName)
+	_, err = pmemexec.RunCommand("vgchange", "--addtag", "nsmode="+string(nsmode), "--addtag", "numanode="+strconv.Itoa(r.NumaNode()))
 	return err
 }


### PR DESCRIPTION
Added two new fields to PmemDeviceInfo structure:
 - Mode : holds the device namespace mode 
 - NumaNode: hods the numa node to which the device attached to

In LVM mode we use the volume group tags for storing these details.