### PR TITLE
build: use fixed Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ARG NDCTL_BUILD_DEPS="os-core-dev devpkg-util-linux devpkg-kmod devpkg-json-c"
 
 #pull dependencies required for downloading and building libndctl
 ARG CACHEBUST
+# TODO: download Go from https://golang.org/dl/
 RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} go-basic-dev && rm -rf /var/lib/swupd
 # Workaround for "pkg-config: error while loading shared libraries" when using older Docker
 # (see https://github.com/clearlinux/distribution/issues/831)


### PR DESCRIPTION
Clear Linux switched to Go 1.13, which currently fails during "make
test" with:

  go test -run none ./pkg/... ./test/e2e
  ...
  flag provided but not defined: -test.testlogfile

  Usage of /tmp/go-build240487305/b265/e2e.test:
  [no -test flags here]

That Go updates depend on code changes is not unusual, it happened
before for example because "go fmt" changed how code gets
formatted. Therefore the version of Go must depend on the PMEM-CSI
code, not the version of Clear Linux.

This can be achieved by downloading the toolchain. As a side effect
the download might be faster.