### PR TITLE
automated release updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ARG SWUPD_UPDATE_ARG=
 # - up-to-date Clear Linux
 # - ndctl installed
 FROM ${CLEAR_LINUX_BASE} AS build
+ARG CLEAR_LINUX_BASE
 ARG SWUPD_UPDATE_ARG
 
 ARG NDCTL_VERSION="66"
@@ -21,6 +22,7 @@ ARG GO_VERSION="1.12.9"
 
 #pull dependencies required for downloading and building libndctl
 ARG CACHEBUST
+RUN echo "Updating build image from ${CLEAR_LINUX_BASE} to ${SWUPD_UPDATE_ARG:-the latest release}."
 RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} c-basic && rm -rf /var/lib/swupd /var/tmp/swupd
 RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar -zxf - -C / && \
     mkdir -p /usr/local/bin/ && \
@@ -55,6 +57,7 @@ RUN ldconfig
 
 # Clean image for deploying PMEM-CSI.
 FROM ${CLEAR_LINUX_BASE} as runtime
+ARG CLEAR_LINUX_BASE
 ARG SWUPD_UPDATE_ARG
 LABEL maintainers="Intel"
 LABEL description="PMEM CSI Driver"
@@ -64,6 +67,7 @@ LABEL description="PMEM CSI Driver"
 # xfsprogs - XFS filesystem utilities
 # storge-utils - for lvm2 and ext4(e2fsprogs) utilities
 ARG CACHEBUST
+RUN echo "Updating runtime image from ${CLEAR_LINUX_BASE} to ${SWUPD_UPDATE_ARG:-the latest release}."
 RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add file xfsprogs storage-utils && rm -rf /var/lib/swupd /var/tmp/swupd
 # Workaround for "pkg-config: error while loading shared libraries" when using older Docker
 # (see https://github.com/clearlinux/distribution/issues/831)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG GO_VERSION="1.12.9"
 
 #pull dependencies required for downloading and building libndctl
 ARG CACHEBUST
-RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} c-basic && rm -rf /var/lib/swupd
+RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} c-basic && rm -rf /var/lib/swupd /var/tmp/swupd
 RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar -zxf - -C / && \
     mkdir -p /usr/local/bin/ && \
     for i in /go/bin/*; do ln -s $i /usr/local/bin/; done
@@ -64,7 +64,7 @@ LABEL description="PMEM CSI Driver"
 # xfsprogs - XFS filesystem utilities
 # storge-utils - for lvm2 and ext4(e2fsprogs) utilities
 ARG CACHEBUST
-RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add file xfsprogs storage-utils && rm -rf /var/lib/swupd
+RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add file xfsprogs storage-utils && rm -rf /var/lib/swupd /var/tmp/swupd
 # Workaround for "pkg-config: error while loading shared libraries" when using older Docker
 # (see https://github.com/clearlinux/distribution/issues/831)
 RUN ldconfig

--- a/hack/create-new-release.sh
+++ b/hack/create-new-release.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Copyright 2019 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script is meant to be called by the CI to refresh the container
+# images on a release branch. Preconditions:
+# - Docker is usable (needed by update-clear-linux-base.sh)
+# - the current user can commit and push to GitHub
+
+# Repository that we push to.
+: ${REPO:=origin}
+
+die () {
+    echo "ERROR: $@"
+    exit 1
+}
+
+# Sanity check: ensure that the current branch is unmodified
+# and that we have a branch.
+git diff --exit-code || die "Invoke this script in a clean pmem-csi repository."
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Determine current version. We bump the last digit, because the only
+# change is in the base image and that is considered bug fixing.
+version=$(make print-image-version) || die "Cannot determine image version."
+if [ ! "$version" ] || [ "$version" = "canary" ]; then
+    die "This script must be invoked on a release branch where the version has been locked."
+fi
+minor=$(echo "$version" | sed -e 's/.*\.//')
+minor=$(expr $minor + 1)
+version=$(echo "$version" | sed -e "s/\(.*\.\).*/\1$minor/")
+
+# Update the base image. Might not change anything.
+oldrev=$(git rev-parse HEAD)
+hack/update-clear-linux-base.sh || die "Failed to update base image."
+newrev=$(git rev-parse HEAD)
+if [ "$oldrev" = "$newrev" ]; then
+    exit 0
+fi
+
+# Bump version.
+hack/set-version.sh "$version" || die "Failed to set new version $version."
+
+# Commit and tag.
+clearversion=$(grep 'SWUPD_UPDATE_ARG="--version' Dockerfile | sed -e 's/.*version=\(.*\)"/\1/')
+git commit --file - --all <<EOF
+$version
+
+Update to Clear Linux $clearversion.
+EOF
+git tag --annotate -m "update to Clear Linux $clearversion" "$version"
+
+# And now push current branch.
+git push ${REPO} "$branch" "$version"

--- a/hack/update-clear-linux-base.sh
+++ b/hack/update-clear-linux-base.sh
@@ -9,11 +9,29 @@
 # will bump up the CLEAR_LINUX_BASE and SWUPD_UPDATE_ARG
 # parameters in the Dockerfile such that they pick the
 # current version of Clear Linux.
+#
+# If the version bump leads to relevant changes in the content
+# of the images, then the updated Dockerfile is committed.
 
 die () {
     echo "ERROR: $@"
     exit 1
 }
+
+# Sanity check: ensure that current Dockerfile is unmodified.
+git diff --exit-code Dockerfile || die "Invoke this script in a clean pmem-csi repository."
+
+# If invoked on a branch where the base is not locked down, we skip the
+# comparison because we always want to lock down.
+oldversion=$(grep '^ARG SWUPD_UPDATE_ARG="--version=' Dockerfile | sed -e 's/.*=\(.*\)"/\1/')
+if [ "$oldversion" != "latest" ]; then
+    # Build the two kinds of images which are derived from Clear Linux. We
+    # compare against those later. CACHEBUST is intentionally not set because
+    # this script is intended to be invoked on a release branch where the base
+    # is locked, so we don't need to rebuild if the image is already cached.
+    docker build --target build -t pmem-csi-build . || die "failed to build the 'build' image"
+    docker build --target runtime -t pmem-csi-runtime . || "failed to build the 'runtime' image"
+fi
 
 docker image pull clearlinux:latest || die "pulling clearlinux:latest failed"
 base=$(docker inspect --format='{{index .RepoDigests 0}}' clearlinux:latest) || die "failed to inspect clearlinux:latest"
@@ -45,6 +63,60 @@ docker run "$base" swupd update --version=$version || die "failed to update"
 sed -i -e 's;^\(ARG CLEAR_LINUX_BASE=\).*;\1'"$base"';' -e 's;^\(ARG SWUPD_UPDATE_ARG=\).*;\1"--version='"$version"'";' Dockerfile || die "failed to patch Dockerfile"
 
 # Show the modification
+if git diff --exit-code Dockerfile; then
+    echo "No new version, exiting now."
+    exit 0
+fi
+
+no_image_changes () (
+    image="$1"
+    tmpdir=$(mktemp -d)
+    container1=
+    container2=
+    trap 'rm -rf $tmpdir; for id in $container1 $container2; do docker rm $id; done' EXIT
+
+    # We exclude certain irrelevant files by not even unpacking them.
+    # We could also delete some of them from the layer in the first place.
+    cat >"$tmpdir/exclude" <<EOF
+usr/share/locale/**
+usr/share/debuginfo/**
+usr/share/info/**
+usr/share/man/**
+usr/share/doc/**
+var/cache/man/**
+usr/share/package-licenses/**
+*.pyc
+etc/os-release
+lib/os-release
+usr/lib/os-release
+EOF
+
+    # We only compare file content. uid/gid, timestamp and permission changes
+    # could theoretically be the only changes, but that seems unlikely.
+    # Should that ever be the only change, we'll still update eventually
+    # once a later update changes a file.
+    container1=$(docker create $image)
+    container2=$(docker create $image-updated)
+    mkdir "$tmpdir/$oldversion"
+    mkdir "$tmpdir/$version"
+    docker export $container1 | tar -C "$tmpdir/$version" -xf - --exclude-from="$tmpdir/exclude"
+    docker export $container2 | tar -C "$tmpdir/$oldversion" -xf -  --exclude-from="$tmpdir/exclude"
+    diff --brief -r --exclude-from=- "$tmpdir/$oldversion" "$tmpdir/$version" <<EOF
+$tmpdir/$oldversion/usr/share/locale/**
+EOF
+)
+
+if [ "$oldversion" != "latest" ]; then
+    # Build images again with updated Dockerfile.
+    if ( docker build --target build -t pmem-csi-build-updated . || die "failed to build the 'build' image" ) &&
+           no_image_changes pmem-csi-build &&
+           ( docker build --target runtime -t pmem-csi-runtime-updated . || die "failed to build the 'runtime' image" ) &&
+           no_image_changes pmem-csi-runtime; then
+        echo "Nothing relevant has changed in the image content, no need to update."
+        git checkout Dockerfile
+        exit 0
+    fi
+fi
+
+git commit -m "Clear Linux $version" Dockerfile || die "failed to commit modified Dockerfile"
 echo "Done."
-git status Dockerfile
-git diff Dockerfile


### PR DESCRIPTION
This is the first step towards automatically refreshing release branches. The second step is to modify Jenkins such that it runs this automatically.

Right now, `./hack/create-new-release.sh` still needs to be invoked manually. Use `REPO=<your repo> ./hack/create-new-release.sh` to test it.

Fixes: #378 