### PR TITLE
deploy: Do not use kubelet plugins location for driver socket

### DIFF
--- a/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
@@ -240,14 +240,14 @@ spec:
       - args:
         - -s
         - tcp-listen:9735,fork,reuseaddr
-        - unix-connect:/csi/csi.sock
+        - unix-connect:/pmem-csi/csi.sock
         image: alpine/socat:1.0.3
         name: socat
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: plugin-state-dir
         - mountPath: /var/lib/kubelet/pods
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -257,13 +257,9 @@ spec:
       hostNetwork: true
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
+          path: /var/lib/pmem-csi.intel.com/
           type: DirectoryOrCreate
-        name: plugin-socket-dir
-      - hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: DirectoryOrCreate
-        name: registration-dir
+        name: plugin-state-dir
       - hostPath:
           path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
           type: DirectoryOrCreate
@@ -305,7 +301,7 @@ spec:
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -325,8 +321,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -345,25 +339,21 @@ spec:
           name: coverage-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         - -v=5
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -222,7 +222,7 @@ spec:
         - -statePath=/var/lib/pmem-csi.intel.com
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -242,8 +242,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -260,24 +258,20 @@ spec:
           name: sys-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
@@ -240,14 +240,14 @@ spec:
       - args:
         - -s
         - tcp-listen:9735,fork,reuseaddr
-        - unix-connect:/csi/csi.sock
+        - unix-connect:/pmem-csi/csi.sock
         image: alpine/socat:1.0.3
         name: socat
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: plugin-state-dir
         - mountPath: /var/lib/kubelet/pods
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -257,13 +257,9 @@ spec:
       hostNetwork: true
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
+          path: /var/lib/pmem-csi.intel.com/
           type: DirectoryOrCreate
-        name: plugin-socket-dir
-      - hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: DirectoryOrCreate
-        name: registration-dir
+        name: plugin-state-dir
       - hostPath:
           path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
           type: DirectoryOrCreate
@@ -305,7 +301,7 @@ spec:
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -325,8 +321,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -343,15 +337,15 @@ spec:
           name: coverage-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         - -v=5
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
@@ -397,10 +391,6 @@ spec:
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -222,7 +222,7 @@ spec:
         - -statePath=/var/lib/pmem-csi.intel.com
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -242,8 +242,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -258,14 +256,14 @@ spec:
           name: pmem-state-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
@@ -302,10 +300,6 @@ spec:
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -261,14 +261,14 @@ spec:
       - args:
         - -s
         - tcp-listen:9735,fork,reuseaddr
-        - unix-connect:/csi/csi.sock
+        - unix-connect:/pmem-csi/csi.sock
         image: alpine/socat:1.0.3
         name: socat
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: plugin-state-dir
         - mountPath: /var/lib/kubelet/pods
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -278,13 +278,9 @@ spec:
       hostNetwork: true
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
+          path: /var/lib/pmem-csi.intel.com/
           type: DirectoryOrCreate
-        name: plugin-socket-dir
-      - hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: DirectoryOrCreate
-        name: registration-dir
+        name: plugin-state-dir
       - hostPath:
           path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
           type: DirectoryOrCreate
@@ -326,7 +322,7 @@ spec:
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -346,8 +342,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -366,25 +360,21 @@ spec:
           name: coverage-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         - -v=5
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kubernetes-1.14/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct.yaml
@@ -243,7 +243,7 @@ spec:
         - -statePath=/var/lib/pmem-csi.intel.com
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -263,8 +263,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -281,24 +279,20 @@ spec:
           name: sys-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -261,14 +261,14 @@ spec:
       - args:
         - -s
         - tcp-listen:9735,fork,reuseaddr
-        - unix-connect:/csi/csi.sock
+        - unix-connect:/pmem-csi/csi.sock
         image: alpine/socat:1.0.3
         name: socat
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: plugin-state-dir
         - mountPath: /var/lib/kubelet/pods
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -278,13 +278,9 @@ spec:
       hostNetwork: true
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
+          path: /var/lib/pmem-csi.intel.com/
           type: DirectoryOrCreate
-        name: plugin-socket-dir
-      - hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: DirectoryOrCreate
-        name: registration-dir
+        name: plugin-state-dir
       - hostPath:
           path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
           type: DirectoryOrCreate
@@ -326,7 +322,7 @@ spec:
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -346,8 +342,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -364,15 +358,15 @@ spec:
           name: coverage-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         - -v=5
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
@@ -418,10 +412,6 @@ spec:
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -243,7 +243,7 @@ spec:
         - -statePath=/var/lib/pmem-csi.intel.com
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -263,8 +263,6 @@ spec:
           privileged: true
         terminationMessagePath: /tmp/termination-log
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
         - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
           name: mountpoint-dir
@@ -279,14 +277,14 @@ spec:
           name: pmem-state-dir
       - args:
         - -v=3
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock
-        - --csi-address=/csi/csi.sock
+        - --kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock
+        - --csi-address=/pmem-csi/csi.sock
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
         imagePullPolicy: Always
         name: driver-registrar
         volumeMounts:
-        - mountPath: /csi
-          name: plugin-socket-dir
+        - mountPath: /pmem-csi
+          name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
       hostNetwork: true
@@ -323,10 +321,6 @@ spec:
       nodeSelector:
         storage: pmem
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-          type: DirectoryOrCreate
-        name: plugin-socket-dir
       - hostPath:
           path: /var/lib/kubelet/plugins_registry/
           type: DirectoryOrCreate

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -123,7 +123,7 @@ spec:
           privileged: true
         env:
         - name: CSI_ENDPOINT
-          value: unix:///csi/csi.sock
+          value: unix:///var/lib/pmem-csi.intel.com/csi.sock
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -137,8 +137,6 @@ spec:
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
         volumeMounts:
-        - name: plugin-socket-dir
-          mountPath: /csi
         - name: mountpoint-dir
           mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
           mountPropagation: Bidirectional
@@ -155,18 +153,17 @@ spec:
         imagePullPolicy: Always
         image: quay.io/k8scsi/csi-node-driver-registrar:v1.X.Y
         args: [ "-v=3",
-            "--kubelet-registration-path=/var/lib/kubelet/plugins/pmem-csi.intel.com/csi.sock",
-            "--csi-address=/csi/csi.sock" ]
+            "--kubelet-registration-path=/var/lib/pmem-csi.intel.com/csi.sock",
+            "--csi-address=/pmem-csi/csi.sock" ]
         volumeMounts:
-        - name: plugin-socket-dir
-          mountPath: /csi
+        - name: pmem-state-dir
+          mountPath: /pmem-csi
+        # node-driver-registrar uses /registration(hard-coded path) to keep its listening socket
+        # The socket path is used by kubelet for plugin registration
+        # so, we should make sure the appropriate host path available.
         - name: registration-dir
           mountPath: /registration
       volumes:
-        - name: plugin-socket-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
-            type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/

--- a/deploy/kustomize/testing/socat.yaml
+++ b/deploy/kustomize/testing/socat.yaml
@@ -29,12 +29,12 @@ spec:
         args:
         - -s
         - tcp-listen:9735,fork,reuseaddr # port 9735 *on the host*
-        - unix-connect:/csi/csi.sock
+        - unix-connect:/pmem-csi/csi.sock
         securityContext:
           privileged: true
         volumeMounts:
-        - name: plugin-socket-dir
-          mountPath: /csi
+        - name: plugin-state-dir
+          mountPath: /pmem-csi
         # mountpoint-dir and staging-dir are needed for creating directories during sanity testing.
         - name: mountpoint-dir
           mountPath: /var/lib/kubelet/pods
@@ -44,13 +44,9 @@ spec:
           mountPropagation: Bidirectional
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/pmem-csi.intel.com/
+          path: /var/lib/pmem-csi.intel.com/
           type: DirectoryOrCreate
-        name: plugin-socket-dir
-      - hostPath:
-          path: /var/lib/kubelet/plugins_registry/
-          type: DirectoryOrCreate
-        name: registration-dir
+        name: plugin-state-dir
       - hostPath:
           path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
           type: DirectoryOrCreate


### PR DESCRIPTION
/var/lib/kubelet/{plugins,plugins_registry} is the location for plugins which
are supposed to implement kubelet's plugin registration API. This is implemented
by node-driver-registrar sidecar container in case of a CSI driver.

So PMEM-CSI should not use these locations for creating its listening socket.
No we use plugin state directory(/var/lib/pmem-csi.intel.com) for this.

Fixes: #394