### PR TITLE
CI: automatic update of master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,6 +241,27 @@ pipeline {
             }
         }
 
+        stage('Update master branch') {
+            // This stage runs each time "devel" is rebuilt after a merge.
+            when {
+                environment name: 'BUILD_TARGET', value: 'devel'
+                environment name: 'JOB_BASE_NAME', value: 'pmem-csi'
+            }
+
+            steps{
+                sshagent(['9b2359bb-540b-4df3-a4b7-d304a426b2db']) {
+                    // All tests have passed on the "devel" branch, we can now fast-forward "master" to it.
+                    sh '''
+head=$(git rev-parse HEAD) &&
+git fetch origin master &&
+git checkout FETCH_HEAD &&
+git merge --ff-only $head &&
+git push origin HEAD:master
+'''
+                }
+            }
+        }
+
         stage('Push images') {
             when {
                 not { changeRequest() }


### PR DESCRIPTION
This implements the policy described in
https://github.com/intel/pmem-csi/blob/devel/DEVELOPMENT.md#branching:
each time full testing of the "devel" branch has succeeded, "master"
gets moved forward to it.