### PR TITLE
Devicemanager: New error codes + Device Manager unit tests and few other fixes.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,6 +159,26 @@ pipeline {
             }
         }
 
+        stage('make dm-test') {
+            options {
+                timeout(time: 30, unit: "MINUTES")
+            }
+
+            steps {
+                sh "docker run --rm ${DockerBuildArgs()} \
+                               --privileged=true \
+                               -e TEST_CHECK_SIGNED_FILES=false \
+                               -e TEST_DISTRO=clear \
+                               -e TEST_DISTRO_VERSION=${env.CLEAR_LINUX_VERSION_1_15} \
+                               -v `pwd`:`pwd`:rshared \
+                               -w `pwd` \
+                               ${env.BUILD_IMAGE} bash -c 'set -x; \
+                                   swupd bundle-add openssh-client && \
+                                   make run_dm_tests; \
+                                   make stop'"
+            }
+        }
+
         stage('Build test image') {
             options {
                 timeout(time: 60, unit: "MINUTES")

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	go.uber.org/zap v1.11.0 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20191027233614-53de4c7853b5
-	golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd // indirect
+	golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.24.0
+	gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.4.0 // indirect
 	k8s.io/api v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -622,6 +622,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124 h1:aPcd9iBdqpFyYkoGRQbQd+asp162GIRDvAVB0FhLxhc=
+gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124/go.mod h1:6LXpUYtVsrx91XiupFRJ8jVKOqLZf5PrbEVSGHta/84=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.0 h1:0HIbH907iBTAntm+88IJV2qmJALDAh8sPekI9Vc1fm0=

--- a/pkg/ndctl/ndctl.go
+++ b/pkg/ndctl/ndctl.go
@@ -8,10 +8,9 @@ package ndctl
 import "C"
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
-	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
 
@@ -22,6 +21,10 @@ const (
 	mib2 uint64 = mib * 2
 	gib  uint64 = mib * 1024
 	tib  uint64 = gib * 1024
+)
+
+var (
+	ErrNotExist = errors.New("namespace not found")
 )
 
 //CreateNamespaceOpts options to create a namespace
@@ -81,7 +84,7 @@ func (ctx *Context) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error
 			}
 		}
 	}
-	return nil, errors.Wrap(err, "failed to create namespace")
+	return nil, err
 }
 
 //DestroyNamespaceByName deletes namespace with given name
@@ -106,7 +109,7 @@ func (ctx *Context) GetNamespaceByName(name string) (*Namespace, error) {
 			}
 		}
 	}
-	return nil, errors.Wrapf(os.ErrNotExist, "namespace '%s' not found", name)
+	return nil, ErrNotExist
 }
 
 //GetActiveNamespaces returns list of all active namespaces in all regions

--- a/pkg/pmem-csi-driver/controllerserver-master.go
+++ b/pkg/pmem-csi-driver/controllerserver-master.go
@@ -305,7 +305,7 @@ func (cs *masterController) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			defer conn.Close() // nolint:errcheck
 			klog.V(4).Infof("Asking node %s to delete volume name:%s id:%s", node, vol.name, vol.id)
 			if _, err := csi.NewControllerClient(conn).DeleteVolume(ctx, req); err != nil {
-				return nil, status.Error(codes.Internal, "Failed to delete volume name:"+vol.name+" id:"+vol.id+" on "+node+": "+err.Error())
+				return nil, err
 			}
 		}
 		cs.mutex.Lock()

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -9,6 +9,7 @@ package pmemcsidriver
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -273,6 +274,9 @@ func (cs *nodeControllerServer) DeleteVolume(ctx context.Context, req *csi.Delet
 	}
 
 	if err := cs.dm.DeleteDevice(req.VolumeId, eraseafter); err != nil {
+		if errors.Is(err, pmdmanager.ErrDeviceInUse) {
+			return nil, status.Errorf(codes.FailedPrecondition, err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "Failed to delete volume: %s", err.Error())
 	}
 	if cs.sm != nil {

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -131,11 +131,11 @@ func (lvm *pmemLvm) CreateDevice(volumeId string, size uint64, nsmode string) er
 				if err != nil {
 					return err
 				}
-				err = WaitDeviceAppears(device)
+				err = waitDeviceAppears(device)
 				if err != nil {
 					return err
 				}
-				err = ClearDevice(device, false)
+				err = clearDevice(device, false)
 				if err != nil {
 					return err
 				}
@@ -157,7 +157,7 @@ func (lvm *pmemLvm) DeleteDevice(volumeId string, flush bool) error {
 	if err != nil {
 		return err
 	}
-	if err := ClearDevice(device, flush); err != nil {
+	if err := clearDevice(device, flush); err != nil {
 		return err
 	}
 
@@ -169,18 +169,6 @@ func (lvm *pmemLvm) DeleteDevice(volumeId string, flush bool) error {
 	delete(lvm.devices, volumeId)
 
 	return nil
-}
-
-func (lvm *pmemLvm) FlushDeviceData(volumeId string) error {
-	lvmMutex.Lock()
-	defer lvmMutex.Unlock()
-
-	device, err := lvm.getDevice(volumeId)
-	if err != nil {
-		return err
-	}
-
-	return ClearDevice(device, true)
 }
 
 func (lvm *pmemLvm) ListDevices() ([]*PmemDeviceInfo, error) {

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -60,6 +60,10 @@ func NewPmemDeviceManagerLVM() (PmemDeviceManager, error) {
 	}
 	ctx.Free()
 
+	return NewPmemDeviceManagerLVMForVGs(volumeGroups)
+}
+
+func NewPmemDeviceManagerLVMForVGs(volumeGroups []string) (PmemDeviceManager, error) {
 	devices, err := listDevices(volumeGroups...)
 	if err != nil {
 		return nil, err

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -2,14 +2,12 @@ package pmdmanager
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/intel/pmem-csi/pkg/ndctl"
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
-	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
 
@@ -43,7 +41,7 @@ func NewPmemDeviceManagerLVM() (PmemDeviceManager, error) {
 
 	ctx, err := ndctl.NewContext()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize pmem context: %s", err.Error())
+		return nil, err
 	}
 	volumeGroups := []string{}
 	for _, bus := range ctx.GetBuses() {
@@ -88,7 +86,7 @@ func (lvm *pmemLvm) GetCapacity() (map[string]uint64, error) {
 // nsmode is expected to be either "fsdax" or "sector"
 func (lvm *pmemLvm) CreateDevice(volumeId string, size uint64, nsmode string) error {
 	if nsmode != string(ndctl.FsdaxMode) && nsmode != string(ndctl.SectorMode) {
-		return fmt.Errorf("Unknown nsmode(%v)", nsmode)
+		return fmt.Errorf("unknown namespace mode %q: %w", nsmode, ErrInvalid)
 	}
 	lvmMutex.Lock()
 	defer lvmMutex.Unlock()
@@ -97,9 +95,8 @@ func (lvm *pmemLvm) CreateDevice(volumeId string, size uint64, nsmode string) er
 	// this function is asked to create new devices repeatedly, forcing running out of space.
 	// Avoid device filling with garbage entries by returning error.
 	// Overall, no point having more than one namespace with same volumeId.
-	_, err := lvm.getDevice(volumeId)
-	if err == nil {
-		return fmt.Errorf("CreateDevice: Failed: volume with that name '%s' exists", volumeId)
+	if _, err := lvm.getDevice(volumeId); err == nil {
+		return ErrDeviceExists
 	}
 	vgs, err := getVolumeGroups(lvm.volumeGroups, nsmode)
 	if err != nil {
@@ -131,13 +128,11 @@ func (lvm *pmemLvm) CreateDevice(volumeId string, size uint64, nsmode string) er
 				if err != nil {
 					return err
 				}
-				err = waitDeviceAppears(device)
-				if err != nil {
+				if err := waitDeviceAppears(device); err != nil {
 					return err
 				}
-				err = clearDevice(device, false)
-				if err != nil {
-					return err
+				if err := clearDevice(device, false); err != nil {
+					return fmt.Errorf("clear device %q: %v", volumeId, err)
 				}
 
 				lvm.devices[device.VolumeId] = device
@@ -146,7 +141,7 @@ func (lvm *pmemLvm) CreateDevice(volumeId string, size uint64, nsmode string) er
 			}
 		}
 	}
-	return fmt.Errorf("No region is having enough space required(%v)", size)
+	return ErrNotEnoughSpace
 }
 
 func (lvm *pmemLvm) DeleteDevice(volumeId string, flush bool) error {
@@ -195,7 +190,7 @@ func (lvm *pmemLvm) getDevice(volumeId string) (*PmemDeviceInfo, error) {
 		return dev, nil
 	}
 
-	return nil, errors.Wrapf(os.ErrNotExist, "no device found with id '%s'", volumeId)
+	return nil, ErrDeviceNotFound
 }
 
 func getUncachedDevice(volumeId string, volumeGroup string) (*PmemDeviceInfo, error) {
@@ -207,7 +202,8 @@ func getUncachedDevice(volumeId string, volumeGroup string) (*PmemDeviceInfo, er
 	if dev, ok := devices[volumeId]; ok {
 		return dev, nil
 	}
-	return nil, errors.Wrapf(os.ErrNotExist, "no device found with id '%s' in group '%s'", volumeId, volumeGroup)
+
+	return nil, ErrDeviceNotFound
 }
 
 // listDevices Lists available logical devices in given volume groups
@@ -215,9 +211,9 @@ func listDevices(volumeGroups ...string) (map[string]*PmemDeviceInfo, error) {
 	args := append(lvsArgs, volumeGroups...)
 	output, err := pmemexec.RunCommand("lvs", args...)
 	if err != nil {
-		return nil, fmt.Errorf("list volumes failed : %s(lvs output: %s)", err.Error(), output)
+		return nil, fmt.Errorf("lvs failure : %v", err)
 	}
-	return parseLVSOuput(output)
+	return parseLVSOutput(output)
 }
 
 func vgName(bus *ndctl.Bus, region *ndctl.Region, nsmode ndctl.NamespaceMode) string {
@@ -225,9 +221,9 @@ func vgName(bus *ndctl.Bus, region *ndctl.Region, nsmode ndctl.NamespaceMode) st
 }
 
 //lvs options "lv_name,lv_path,lv_size,lv_free"
-func parseLVSOuput(output string) (map[string]*PmemDeviceInfo, error) {
+func parseLVSOutput(output string) (map[string]*PmemDeviceInfo, error) {
 	devices := map[string]*PmemDeviceInfo{}
-	lines := strings.Split(string(output), "\n")
+	lines := strings.Split(output, "\n")
 	for _, line := range lines {
 		fields := strings.Fields(strings.TrimSpace(line))
 		if len(fields) != 3 {
@@ -269,12 +265,12 @@ func getVolumeGroups(groups []string, wantedTag string) ([]vgInfo, error) {
 	args := append(vgsArgs, groups...)
 	output, err := pmemexec.RunCommand("vgs", args...)
 	if err != nil {
-		return vgs, fmt.Errorf("vgs failure: %s", err.Error())
+		return vgs, fmt.Errorf("vgs failure: %v", err)
 	}
 	for _, line := range strings.SplitN(output, "\n", len(groups)) {
 		fields := strings.Fields(strings.TrimSpace(line))
 		if len(fields) != 4 {
-			return vgs, fmt.Errorf("Failed to parse vgs output line: %s", line)
+			return vgs, fmt.Errorf("failed to parse vgs output: %q", line)
 		}
 		tag := fields[3]
 		if tag == wantedTag {

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -25,9 +25,6 @@ type PmemDeviceManager interface {
 	// If 'flush' is 'true', then the device data is zerod beofore deleting the device
 	DeleteDevice(name string, flush bool) error
 
-	//FlushDeviceData zeros all blocks in the blocke device with given name
-	FlushDeviceData(name string) error
-
 	//ListDevices returns all the block devices information that was created by this device manager
 	ListDevices() ([]*PmemDeviceInfo, error)
 }

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -1,5 +1,33 @@
 package pmdmanager
 
+import (
+	"errors"
+	"os"
+)
+
+var (
+	// ErrInvalid invalid argument passed
+	ErrInvalid = os.ErrInvalid
+
+	// ErrPermission no permission to complete the task
+	ErrPermission = os.ErrPermission
+
+	// ErrDeviceExists device with given id already exists
+	ErrDeviceExists = errors.New("device exists")
+
+	// ErrDeviceNotFound device does not exists
+	ErrDeviceNotFound = errors.New("device not found")
+
+	// ErrDeviceInUse device is in use
+	ErrDeviceInUse = errors.New("device in use")
+
+	// ErrDeviceNotReady device not ready yet
+	ErrDeviceNotReady = errors.New("device not ready")
+
+	// ErrNotEnoughSpace no space to create the device
+	ErrNotEnoughSpace = errors.New("not enough space")
+)
+
 //PmemDeviceInfo represents a block device
 type PmemDeviceInfo struct {
 	//VolumeId is name of the block device
@@ -12,19 +40,22 @@ type PmemDeviceInfo struct {
 
 //PmemDeviceManager interface to manage the PMEM block devices
 type PmemDeviceManager interface {
-	//GetCapacity returns the available maximum capacity that can be assigned to a Device/Volume
+	// GetCapacity returns the available maximum capacity that can be assigned to a Device/Volume
 	GetCapacity() (map[string]uint64, error)
 
-	//CreateDevice creates a new block device with give name, size and namespace mode
+	// CreateDevice creates a new block device with give name, size and namespace mode
+	// Possible errors: ErrNotEnoughSpace, ErrInvalid, ErrDeviceExists
 	CreateDevice(name string, size uint64, nsmode string) error
 
-	//GetDevice returns the block device information for given name
+	// GetDevice returns the block device information for given name
+	// Possible errors: ErrDeviceNotFound
 	GetDevice(name string) (*PmemDeviceInfo, error)
 
-	//DeleteDevice deletes an existing block device with give name.
-	// If 'flush' is 'true', then the device data is zerod beofore deleting the device
+	// DeleteDevice deletes an existing block device with give name.
+	// If 'flush' is 'true', then the device data is zeroed before deleting the device
+	// Possible errors: ErrDeviceInUse, ErrPermission
 	DeleteDevice(name string, flush bool) error
 
-	//ListDevices returns all the block devices information that was created by this device manager
+	// ListDevices returns all the block devices information that was created by this device manager
 	ListDevices() ([]*PmemDeviceInfo, error)
 }

--- a/pkg/pmem-device-manager/pmd-manager_test.go
+++ b/pkg/pmem-device-manager/pmd-manager_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2019  Intel Corporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package pmdmanager
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+
+	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	losetup "gopkg.in/freddierice/go-losetup.v1"
+)
+
+const (
+	vgname = "test-group"
+	nsmode = "fsdax"
+	vgsize = uint64(1) * 1024 * 1024 * 1024 // 1Gb
+
+	ModeLVM    = "lvm"
+	ModeDirect = "direct"
+)
+
+func TestMain(m *testing.M) {
+	RegisterFailHandler(Fail)
+
+	os.Exit(m.Run())
+}
+
+func TestPmd(t *testing.T) {
+	RunSpecs(t, "PMEM Device manager Suite")
+}
+
+var _ = Describe("DeviceManager", func() {
+	Context(ModeLVM, func() { runTests(ModeLVM) })
+	Context(ModeDirect, func() { runTests(ModeDirect) })
+})
+
+func runTests(mode string) {
+	var dm PmemDeviceManager
+	var vg *testVGS
+	var cleanupList map[string]bool
+	var err error
+
+	BeforeEach(func() {
+		precheck()
+
+		cleanupList = map[string]bool{}
+
+		if mode == ModeLVM {
+			vg, err = createTestVGS(vgname, nsmode, vgsize)
+			Expect(err).Should(BeNil(), "Failed to create volume group")
+
+			dm, err = NewPmemDeviceManagerLVMForVGs([]string{vg.name})
+		} else {
+			dm, err = NewPmemDeviceManagerNdctl()
+		}
+		Expect(err).Should(BeNil(), "Failed to create LVM device manager")
+
+	})
+
+	AfterEach(func() {
+		for devName, ok := range cleanupList {
+			if !ok {
+				continue
+			}
+			By("Cleaning up device: " + devName)
+			dm.DeleteDevice(devName, false)
+		}
+		if mode == ModeLVM {
+			err := vg.Clean()
+			Expect(err).Should(BeNil(), "Failed to create LVM device manager")
+		}
+	})
+
+	It("Should create a new device", func() {
+		name := "test-dev-new"
+		size := uint64(2) * 1024 * 1024 // 2Mb
+		err := dm.CreateDevice(name, size, nsmode)
+		Expect(err).Should(BeNil(), "Failed to create new device")
+
+		cleanupList[name] = true
+
+		dev, err := dm.GetDevice(name)
+		Expect(err).Should(BeNil(), "Failed to retrieve device info")
+		Expect(dev.VolumeId).Should(Equal(name), "Name mismatch")
+		Expect(dev.Size >= size).Should(BeTrue(), "Size mismatch")
+		Expect(dev.Path).ShouldNot(BeNil(), "Null device path")
+	})
+
+	It("Should fail to retrieve non-existent device", func() {
+		dev, err := dm.GetDevice("unknown")
+		Expect(err).ShouldNot(BeNil(), "Error expected")
+		Expect(errors.Is(err, ErrDeviceNotFound)).Should(BeTrue(), "expected error is device not found error")
+		Expect(dev).Should(BeNil(), "returned device should be nil")
+	})
+
+	It("Should list devices", func() {
+		max_devices := 4
+		max_deletes := 2
+		sizes := map[string]uint64{}
+
+		list, err := dm.ListDevices()
+		Expect(err).Should(BeNil(), "Failed to list devices")
+		Expect(len(list)).Should(BeEquivalentTo(0), "count mismatch")
+
+		for i := 1; i <= max_devices; i++ {
+			name := fmt.Sprintf("list-dev-%d", i)
+			sizes[name] = rand.Uint64() % 16 * 1024 * 1024
+			err := dm.CreateDevice(name, sizes[name], nsmode)
+			Expect(err).Should(BeNil(), "Failed to create new device")
+			cleanupList[name] = true
+		}
+		list, err = dm.ListDevices()
+		Expect(err).Should(BeNil(), "Failed to list devices")
+		Expect(len(list)).Should(BeEquivalentTo(max_devices), "count mismatch")
+		for _, dev := range list {
+			size, ok := sizes[dev.VolumeId]
+			Expect(ok).Should(BeTrue(), "Unexpected device name:"+dev.VolumeId)
+			Expect(dev.Size >= size).Should(BeTrue(), "Device size mismatch")
+		}
+
+		for i := 1; i <= max_deletes; i++ {
+			name := fmt.Sprintf("list-dev-%d", i)
+			delete(sizes, name)
+			err = dm.DeleteDevice(name, false)
+			Expect(err).Should(BeNil(), "Error while deleting device '"+name+"'")
+			cleanupList[name] = false
+		}
+
+		// List device after deleting a device
+		list, err = dm.ListDevices()
+		Expect(err).Should(BeNil(), "Failed to list devices")
+		Expect(len(list)).Should(BeEquivalentTo(max_devices-max_deletes), "count mismatch")
+		for _, dev := range list {
+			size, ok := sizes[dev.VolumeId]
+			Expect(ok).Should(BeTrue(), "Unexpected device name:"+dev.VolumeId)
+			Expect(dev.Size >= size).Should(BeTrue(), "Device size mismatch")
+		}
+	})
+
+	It("Should delete devices", func() {
+		name := "delete-dev"
+		size := uint64(2) * 1024 * 1024 // 2Mb
+		err := dm.CreateDevice(name, size, nsmode)
+		Expect(err).Should(BeNil(), "Failed to create new device")
+		cleanupList[name] = true
+
+		dev, err := dm.GetDevice(name)
+		Expect(err).Should(BeNil(), "Failed to retrieve device info")
+		Expect(dev.VolumeId).Should(Equal(name), "Name mismatch")
+		Expect(dev.Size >= size).Should(BeTrue(), "Size mismatch")
+		Expect(dev.Path).ShouldNot(BeNil(), "Null device path")
+
+		mountPath, err := mountDevice(dev)
+		Expect(err).Should(BeNil(), "Failed to create mount path: %s", mountPath)
+
+		defer unmount(mountPath)
+
+		// Delete should fail as the device is in use
+		err = dm.DeleteDevice(name, true)
+		Expect(err).ShouldNot(BeNil(), "Error expected when deleting device in use: %s", dev.VolumeId)
+		Expect(errors.Is(err, ErrDeviceInUse)).Should(BeTrue(), "Expected device busy error: %s", dev.VolumeId)
+		cleanupList[name] = false
+
+		err = unmount(mountPath)
+		Expect(err).Should(BeNil(), "Failed to unmount the device: %s", dev.VolumeId)
+
+		// Delete should succeed
+		err = dm.DeleteDevice(name, true)
+		Expect(err).Should(BeNil(), "Failed to delete device")
+
+		dev, err = dm.GetDevice(name)
+		Expect(err).ShouldNot(BeNil(), "GetDevice() should fail on deleted device")
+		Expect(errors.Is(err, ErrDeviceNotFound)).Should(BeTrue(), "expected error is os.ErrNotExist")
+		Expect(dev).Should(BeNil(), "returned device should be nil")
+
+		// Delete call should not return any error on non-existing device
+		err = dm.DeleteDevice(name, true)
+		Expect(err).Should(BeNil(), "DeleteDevice() is not idempotent")
+	})
+}
+
+func precheck() {
+	if os.Geteuid() != 0 {
+		Skip("Root privileges are required to run these tests", 1)
+	}
+
+	info, err := os.Stat(losetup.LoopControlPath)
+	if err != nil {
+		Skip(fmt.Sprintf("Stat(%s) failure: %s", losetup.LoopControlPath, err.Error()), 1)
+	}
+	if isDev := info.Mode()&os.ModeDevice != 0; !isDev {
+		Skip(fmt.Sprintf("%s is not a loop device file", losetup.LoopControlPath), 1)
+	}
+}
+
+type testVGS struct {
+	name       string
+	loopDev    losetup.Device
+	backedFile string
+}
+
+func createTestVGS(vgname, nsmode string, size uint64) (*testVGS, error) {
+	var err error
+	var file *os.File
+	var dev losetup.Device
+	var out string
+
+	By("Creating temporary file")
+	if file, err = ioutil.TempFile("", "test-lvm-dev"); err != nil {
+		By("Cleaning temporary file")
+		return nil, fmt.Errorf("Fail to create temporary file : %s", err.Error())
+	}
+
+	defer func() {
+		if err != nil && file != nil {
+			By("Removing tmp file due to failure")
+			os.Remove(file.Name())
+		}
+	}()
+
+	By("Closing file")
+	if err = file.Close(); err != nil {
+		return nil, fmt.Errorf("Fail to close file: %s", err.Error())
+	}
+
+	By("File truncating")
+	if err = os.Truncate(file.Name(), int64(size)); err != nil {
+		return nil, fmt.Errorf("Fail to truncate file: %s", err.Error())
+	}
+
+	By("losetup.Attach")
+	dev, err = losetup.Attach(file.Name(), 0, false)
+	if err != nil {
+		return nil, fmt.Errorf("losetup failure: %s", err.Error())
+	}
+
+	defer func() {
+		if err != nil {
+			By("losetup.Detach due to failure")
+			dev.Detach() // nolint errcheck
+		}
+	}()
+
+	if err = waitDeviceAppears(&PmemDeviceInfo{Path: dev.Path()}); err != nil {
+		return nil, fmt.Errorf("created loop device not appeared: %s", err.Error())
+	}
+
+	By("Creating physical volume")
+	// TODO: reuse vgm code
+	cmdArgs := []string{"--force", dev.Path()}
+	if out, err = pmemexec.RunCommand("pvcreate", cmdArgs...); err != nil { // nolint gosec
+		return nil, fmt.Errorf("pvcreate failure(output:%s): %s", out, err.Error())
+	}
+
+	By("Creating volume group")
+	cmdArgs = []string{"--force", vgname, dev.Path()}
+	if out, err = pmemexec.RunCommand("vgcreate", cmdArgs...); err != nil { // nolint gosec
+		return nil, fmt.Errorf("vgcreate failure(output:%s): %s", out, err.Error())
+	}
+
+	defer func() {
+		if err != nil {
+			By("Removing volume group due to failure")
+			pmemexec.RunCommand("vgremove", "--force", vgname)
+		}
+	}()
+
+	By("Append tag(s) to volume group")
+	if out, err = pmemexec.RunCommand("vgchange", "--addtag", string(nsmode), vgname); err != nil {
+		return nil, fmt.Errorf("vgchange failure(output:%s): %s", out, err.Error())
+	}
+
+	return &testVGS{
+		name:       vgname,
+		loopDev:    dev,
+		backedFile: file.Name(),
+	}, nil
+}
+
+func (vg *testVGS) Clean() error {
+	By("Removing volume group")
+	if out, err := pmemexec.RunCommand("vgremove", "--force", vg.name); err != nil {
+		return fmt.Errorf("Fail to remove volume group(output:%s): %s", out, err.Error())
+	}
+
+	By("losetup.Detach()")
+	if err := vg.loopDev.Detach(); err != nil {
+		return fmt.Errorf("Fail detatch loop device: %s", err.Error())
+	}
+
+	By("Removing temp file")
+	if err := os.Remove(vg.backedFile); err != nil {
+		return fmt.Errorf("Fail remove temporary file: %s", err.Error())
+	}
+
+	return nil
+}
+
+func mountDevice(device *PmemDeviceInfo) (string, error) {
+	targetPath, err := ioutil.TempDir("/tmp", "lmv-mnt-path-")
+	if err != nil {
+		return "", err
+	}
+
+	cmd := "mkfs.ext4"
+	args := []string{"-b 4096", "-F", device.Path}
+
+	if _, err := pmemexec.RunCommand(cmd, args...); err != nil {
+		os.Remove(targetPath)
+		return "", err
+	}
+
+	cmd = "mount"
+	args = []string{"-c", device.Path, targetPath}
+
+	if _, err := pmemexec.RunCommand(cmd, args...); err != nil {
+		os.Remove(targetPath)
+		return "", err
+	}
+
+	return targetPath, nil
+}
+
+func unmount(path string) error {
+	args := []string{path}
+	if _, err := pmemexec.RunCommand("umount", args...); err != nil {
+		return err
+	}
+	return os.Remove(path)
+}

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -1,6 +1,7 @@
 package pmdmanager
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -34,20 +35,19 @@ func NewPmemDeviceManagerNdctl() (PmemDeviceManager, error) {
 
 	ctx, err := ndctl.NewContext()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize pmem context: %s", err.Error())
+		return nil, err
 	}
 	// Check is /sys writable. If not then there is no point starting
-	mounter := mount.New("")
-	mounts, err := mounter.List()
-	for i := range mounts {
+	mounts, _ := mount.New("").List()
+	for _, mnt := range mounts {
 		klog.V(5).Infof("NewPmemDeviceManagerNdctl: Check mounts: device=%s path=%s opts=%s",
-			mounts[i].Device, mounts[i].Path, mounts[i].Opts)
-		if mounts[i].Device == "sysfs" && mounts[i].Path == "/sys" {
-			for _, opt := range mounts[i].Opts {
+			mnt.Device, mnt.Path, mnt.Opts)
+		if mnt.Device == "sysfs" && mnt.Path == "/sys" {
+			for _, opt := range mnt.Opts {
 				if opt == "rw" {
 					klog.V(4).Infof("NewPmemDeviceManagerNdctl: /sys mounted read-write, good")
 				} else if opt == "ro" {
-					return nil, fmt.Errorf("FATAL: /sys mounted read-only, can not operate\n")
+					return nil, fmt.Errorf("FATAL: /sys mounted read-only, can not operate")
 				}
 			}
 			break
@@ -97,10 +97,8 @@ func (pmem *pmemNdctl) CreateDevice(volumeId string, size uint64, nsmode string)
 	// this function is asked to create new devices repeatedly, forcing running out of space.
 	// Avoid device filling with garbage entries by returning error.
 	// Overall, no point having more than one namespace with same name.
-	_, err := pmem.getDevice(volumeId)
-	if err == nil {
-		klog.V(4).Infof("Device with name: %s already exists, refuse to create another", volumeId)
-		return fmt.Errorf("CreateDevice: Failed: namespace with that name exists")
+	if _, err := pmem.getDevice(volumeId); err == nil {
+		return ErrDeviceExists
 	}
 	// libndctl needs to store meta data and will use some of the allocated
 	// space for that (https://github.com/pmem/ndctl/issues/79).
@@ -126,9 +124,8 @@ func (pmem *pmemNdctl) CreateDevice(volumeId string, size uint64, nsmode string)
 	if err != nil {
 		return err
 	}
-	err = clearDevice(device, false)
-	if err != nil {
-		return err
+	if err := clearDevice(device, false); err != nil {
+		return fmt.Errorf("clear device %q: %v", volumeId, err)
 	}
 
 	return nil
@@ -142,8 +139,7 @@ func (pmem *pmemNdctl) DeleteDevice(volumeId string, flush bool) error {
 	if err != nil {
 		return err
 	}
-	err = clearDevice(device, flush)
-	if err != nil {
+	if err := clearDevice(device, flush); err != nil {
 		return err
 	}
 	return pmem.ctx.DestroyNamespaceByName(volumeId)
@@ -170,7 +166,10 @@ func (pmem *pmemNdctl) ListDevices() ([]*PmemDeviceInfo, error) {
 func (pmem *pmemNdctl) getDevice(volumeId string) (*PmemDeviceInfo, error) {
 	ns, err := pmem.ctx.GetNamespaceByName(volumeId)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, ndctl.ErrNotExist) {
+			return nil, ErrDeviceNotFound
+		}
+		return nil, fmt.Errorf("error getting device %q: %v", volumeId, err)
 	}
 
 	return namespaceToPmemInfo(ns), nil

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -163,7 +163,7 @@ func (pmem *pmemNdctl) ListDevices() ([]*PmemDeviceInfo, error) {
 	defer ndctlMutex.Unlock()
 
 	devices := []*PmemDeviceInfo{}
-	for _, ns := range pmem.ctx.GetActiveNamespaces() {
+	for _, ns := range pmem.ctx.GetAllNamespaces() {
 		devices = append(devices, namespaceToPmemInfo(ns))
 	}
 	return devices, nil

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -137,9 +137,15 @@ func (pmem *pmemNdctl) DeleteDevice(volumeId string, flush bool) error {
 
 	device, err := pmem.getDevice(volumeId)
 	if err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			return nil
+		}
 		return err
 	}
 	if err := clearDevice(device, flush); err != nil {
+		if errors.Is(err, ErrDeviceNotFound) {
+			return nil
+		}
 		return err
 	}
 	return pmem.ctx.DestroyNamespaceByName(volumeId)

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -126,7 +126,7 @@ func (pmem *pmemNdctl) CreateDevice(volumeId string, size uint64, nsmode string)
 	if err != nil {
 		return err
 	}
-	err = ClearDevice(device, false)
+	err = clearDevice(device, false)
 	if err != nil {
 		return err
 	}
@@ -142,22 +142,11 @@ func (pmem *pmemNdctl) DeleteDevice(volumeId string, flush bool) error {
 	if err != nil {
 		return err
 	}
-	err = ClearDevice(device, flush)
+	err = clearDevice(device, flush)
 	if err != nil {
 		return err
 	}
 	return pmem.ctx.DestroyNamespaceByName(volumeId)
-}
-
-func (pmem *pmemNdctl) FlushDeviceData(volumeId string) error {
-	ndctlMutex.Lock()
-	defer ndctlMutex.Unlock()
-
-	device, err := pmem.getDevice(volumeId)
-	if err != nil {
-		return err
-	}
-	return ClearDevice(device, true)
 }
 
 func (pmem *pmemNdctl) GetDevice(volumeId string) (*PmemDeviceInfo, error) {

--- a/pkg/pmem-device-manager/pmd-util.go
+++ b/pkg/pmem-device-manager/pmd-util.go
@@ -15,29 +15,26 @@ const (
 	retryStatTimeout time.Duration = 100 * time.Millisecond
 )
 
-func ClearDevice(device *PmemDeviceInfo, flush bool) error {
-	klog.V(4).Infof("ClearDevice: path: %v flush:%v", device.Path, flush)
+func clearDevice(dev *PmemDeviceInfo, flush bool) error {
+	klog.V(4).Infof("ClearDevice: path: %v flush:%v", dev.Path, flush)
 	// by default, clear 4 kbytes to avoid recognizing file system by next volume seeing data area
 	var blocks uint64 = 4
 	if flush {
 		// clear all data if "erase all" asked specifically
 		blocks = 0
 	}
-	return FlushDevice(device, blocks)
-}
 
-func FlushDevice(dev *PmemDeviceInfo, blocks uint64) error {
 	// erase data on block device.
 	// zero number of blocks causes overwriting whole device with random data.
 	// nonzero number of blocks clears blocks*1024 bytes.
 	// Before action, check that dev.Path exists and is device
 	fileinfo, err := os.Stat(dev.Path)
 	if err != nil {
-		klog.Errorf("FlushDevice: %s does not exist", dev.Path)
+		klog.Errorf("clearDevice: %s does not exist", dev.Path)
 		return err
 	}
 	if (fileinfo.Mode() & os.ModeDevice) == 0 {
-		klog.Errorf("FlushDevice: %s is not device", dev.Path)
+		klog.Errorf("clearDevice: %s is not device", dev.Path)
 		return fmt.Errorf("%s is not device", dev.Path)
 	}
 	devOpen, err := hostutil.NewHostUtil().DeviceOpened(dev.Path)
@@ -68,16 +65,15 @@ func FlushDevice(dev *PmemDeviceInfo, blocks uint64) error {
 	return nil
 }
 
-func WaitDeviceAppears(dev *PmemDeviceInfo) error {
+func waitDeviceAppears(dev *PmemDeviceInfo) error {
 	for i := 0; i < 10; i++ {
-		_, err := os.Stat(dev.Path)
-		if err == nil {
+		if _, err := os.Stat(dev.Path); err == nil {
 			return nil
-		} else {
-			klog.Warningf("WaitDeviceAppears[%d]: %s does not exist, sleep %v and retry",
-				i, dev.Path, retryStatTimeout)
-			time.Sleep(retryStatTimeout)
 		}
+
+		klog.Warningf("waitDeviceAppears[%d]: %s does not exist, sleep %v and retry",
+			i, dev.Path, retryStatTimeout)
+		time.Sleep(retryStatTimeout)
 	}
 	return fmt.Errorf("device %s did not appear after multiple retries", dev.Path)
 }

--- a/test/setup-clear-govm.sh
+++ b/test/setup-clear-govm.sh
@@ -10,17 +10,21 @@ set -x
 set -o errexit # TODO: replace with explicit error checking and error messages.
 set -o pipefail
 
+: ${INIT_KUBERNETES:=true}
 HOSTNAME=${HOSTNAME:-$1}
 IPADDR=${IPADDR:-127.0.0.1}
-BUNDLES="cloud-native-basic containers-basic ${TEST_CLEAR_LINUX_BUNDLES}"
+BUNDLES=" ${TEST_CLEAR_LINUX_BUNDLES}"
+if ${INIT_KUBERNETES}; then
+    BUNDLES="${BUNDLES} cloud-native-basic containers-basic"
+fi
 
 function error_handler(){
     local line="${1}"
     echo >&2 "ERROR: the command '${BASH_COMMAND}' at $0:${line} failed"
 }
+trap 'error_handler ${LINENO}' ERR
 
-function install_kubernetes(){
-    trap 'error_handler ${LINENO}' ERR
+function install_bundles(){
     # Setup clearlinux environment
     # Disable swupd autoupdate service
     swupd autoupdate --disable
@@ -54,100 +58,102 @@ EOF
     fi
     swapoff -a
 
-    # We put config changes in place for both runtimes, even though only one of them will
-    # be used by Kubernetes, just in case that someone wants to use them manually.
+    if ${INIT_KUBERNETES}; then
+        # We put config changes in place for both runtimes, even though only one of them will
+        # be used by Kubernetes, just in case that someone wants to use them manually.
 
-    # Proxy settings for CRI-O.
-    mkdir /etc/systemd/system/crio.service.d
-    cat >/etc/systemd/system/crio.service.d/proxy.conf <<EOF
+        # Proxy settings for CRI-O.
+        mkdir /etc/systemd/system/crio.service.d
+        cat >/etc/systemd/system/crio.service.d/proxy.conf <<EOF
 [Service]
 Environment="HTTP_PROXY=${HTTP_PROXY}" "HTTPS_PROXY=${HTTPS_PROXY}" "NO_PROXY=${NO_PROXY}"
 EOF
 
-    # Testing may involve a Docker registry running on the build host (see
-    # TEST_LOCAL_REGISTRY and TEST_PMEM_REGISTRY). We need to trust that
-    # registry, otherwise CRI-O will fail to pull images from it.
+        # Testing may involve a Docker registry running on the build host (see
+        # TEST_LOCAL_REGISTRY and TEST_PMEM_REGISTRY). We need to trust that
+        # registry, otherwise CRI-O will fail to pull images from it.
 
-    mkdir -p /etc/containers
-    cat >/etc/containers/registries.conf <<EOF
+        mkdir -p /etc/containers
+        cat >/etc/containers/registries.conf <<EOF
 [registries.insecure]
 registries = [ $(echo $INSECURE_REGISTRIES | sed 's|^|"|g;s| |", "|g;s|$|"|') ]
 EOF
 
-    # The same for Docker.
-    mkdir -p /etc/docker
-    cat >/etc/docker/daemon.json <<EOF
+        # The same for Docker.
+        mkdir -p /etc/docker
+        cat >/etc/docker/daemon.json <<EOF
 { "insecure-registries": [ $(echo $INSECURE_REGISTRIES | sed 's|^|"|g;s| |", "|g;s|$|"|') ] }
 EOF
 
-    # Proxy settings for Docker.
-    mkdir -p /etc/systemd/system/docker.service.d/
-    cat >/etc/systemd/system/docker.service.d/proxy.conf <<EOF
+        # Proxy settings for Docker.
+        mkdir -p /etc/systemd/system/docker.service.d/
+        cat >/etc/systemd/system/docker.service.d/proxy.conf <<EOF
 [Service]
 Environment="HTTP_PROXY=$HTTP_PROXY" "HTTPS_PROXY=$HTTPS_PROXY" "NO_PROXY=$NO_PROXY"
 EOF
 
-    # Disable the use of Kata containers as default runtime in Docker.
-    # The Kubernetes control plan (apiserver, etc.) fails to run otherwise
-    # ("Host networking requested, not supported by runtime").
+        # Disable the use of Kata containers as default runtime in Docker.
+        # The Kubernetes control plan (apiserver, etc.) fails to run otherwise
+        # ("Host networking requested, not supported by runtime").
 
-    cat >/etc/systemd/system/docker.service.d/51-runtime.conf <<EOF
+        cat >/etc/systemd/system/docker.service.d/51-runtime.conf <<EOF
 [Service]
 Environment="DOCKER_DEFAULT_RUNTIME=--default-runtime runc"
 EOF
-    mkdir -p /etc/systemd/system/kubelet.service.d/
-    case $TEST_CRI in
-        docker)
-	    cri_daemon=docker
-	    # Choose Docker by disabling the use of CRI-O in KUBELET_EXTRA_ARGS.
-	    cat >/etc/systemd/system/kubelet.service.d/10-kubeadm.conf <<EOF
+    
+        mkdir -p /etc/systemd/system/kubelet.service.d/
+        case $TEST_CRI in
+            docker)
+	        cri_daemon=docker
+	        # Choose Docker by disabling the use of CRI-O in KUBELET_EXTRA_ARGS.
+	        cat >/etc/systemd/system/kubelet.service.d/10-kubeadm.conf <<EOF
 [Service]
 Environment="KUBELET_EXTRA_ARGS="
 EOF
-	    ;;
-        crio)
-	    cri_daemon=cri-o
-	    ;;
-        *)
-	    echo "ERROR: unsupported TEST_CRI=$TEST_CRI"
-	    exit 1
-	    ;;
-    esac
+	        ;;
+            crio)
+	        cri_daemon=cri-o
+	        ;;
+            *)
+	        echo "ERROR: unsupported TEST_CRI=$TEST_CRI"
+	        exit 1
+	        ;;
+        esac
 
-    # kubelet must start after the container runtime that it depends on.
-    # This is not currently configured in Clear Linux (https://github.com/clearlinux/distribution/issues/1004).
-    cat >/etc/systemd/system/kubelet.service.d/10-cri.conf <<EOF
+        # kubelet must start after the container runtime that it depends on.
+        # This is not currently configured in Clear Linux (https://github.com/clearlinux/distribution/issues/1004).
+        cat >/etc/systemd/system/kubelet.service.d/10-cri.conf <<EOF
 [Unit]
 After=$cri_daemon.service
 EOF
+        # flannel + CRI-O + Kata Containers needs a crio.conf change (https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes):
+        #    If you are using CRI-O and flannel and you want to use Kata Containers, edit the /etc/crio/crio.conf file to add:
+        #    [crio.runtime]
+        #    manage_network_ns_lifecycle = true
+        #
+        # We don't use Kata Containers, so that particular change is not made to /etc/crio/crio.conf
+        # at this time.
 
-    # flannel + CRI-O + Kata Containers needs a crio.conf change (https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes):
-    #    If you are using CRI-O and flannel and you want to use Kata Containers, edit the /etc/crio/crio.conf file to add:
-    #    [crio.runtime]
-    #    manage_network_ns_lifecycle = true
-    #
-    # We don't use Kata Containers, so that particular change is not made to /etc/crio/crio.conf
-    # at this time.
+        # /opt/cni/bin is where runtimes like CRI-O expect CNI plugins. But cloud-native-basic installs into
+        # /usr/libexec/cni. Instructions at https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes#id2
+        # are inconsistent at this time (https://github.com/clearlinux/clear-linux-documentation/issues/388).
+        #
+        # We solve this by creating the directory and symlinking all existing CNI plugins into it.
+        mkdir -p /opt/cni/bin
+        for i in /usr/libexec/cni/*;do
+            ln -s $i /opt/cni/bin/
+        done
 
-    # /opt/cni/bin is where runtimes like CRI-O expect CNI plugins. But cloud-native-basic installs into
-    # /usr/libexec/cni. Instructions at https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes#id2
-    # are inconsistent at this time (https://github.com/clearlinux/clear-linux-documentation/issues/388).
-    #
-    # We solve this by creating the directory and symlinking all existing CNI plugins into it.
-    mkdir -p /opt/cni/bin
-    for i in /usr/libexec/cni/*;do
-        ln -s $i /opt/cni/bin/
-    done
-
-    # Reconfiguration done, start daemons. Starting kubelet must wait until kubeadm has created
-    # the necessary config files.
-    systemctl daemon-reload
-    systemctl restart $cri_daemon || (
-        systemctl status $cri_daemon || true
-        journalctl -xe || true
-        false
-    )
-    systemctl enable $cri_daemon kubelet
+        # Reconfiguration done, start daemons. Starting kubelet must wait until kubeadm has created
+        # the necessary config files.
+        systemctl daemon-reload
+        systemctl restart $cri_daemon || (
+            systemctl status $cri_daemon || true
+            journalctl -xe || true
+            false
+        )
+        systemctl enable $cri_daemon kubelet
+    fi
 }
 
-install_kubernetes
+install_bundles

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -9,7 +9,6 @@ set -x
 set -o errexit # TODO: replace with explicit error checking and messages
 set -o pipefail
 
-: ${TEST_INIT_REGION:=true}
 : ${TEST_CREATE_REGISTRY:=false}
 
 function error_handler(){
@@ -174,19 +173,6 @@ fi
 ${TEST_CONFIGURE_POST_ALL}
 
 }
-
-
-function init_region(){
-trap 'error_handler ${LINENO}' ERR
-sudo ndctl disable-region region0
-sudo ndctl init-labels nmem0
-sudo ndctl enable-region region0
-
-}
-
-if $TEST_INIT_REGION; then
-    init_region
-fi
 
 if [[ "$HOSTNAME" == *"master"* ]]; then
 	setup_kubernetes_master

--- a/test/start-stop.make
+++ b/test/start-stop.make
@@ -33,3 +33,6 @@ restart:
 		echo "Cluster $(CLUSTER) is not running, it cannot be restarted."; \
 		exit 1; \
 	fi
+
+start_test_vm: _work/bin/govm
+	PATH="$(PWD)/_work/bin:$$PATH" NODES=$(NODE) INIT_CLUSTER=false test/start-kubernetes.sh

--- a/test/test.make
+++ b/test/test.make
@@ -149,6 +149,17 @@ RUN_TESTS = TEST_WORK=$(abspath _work) \
 run_tests: _work/pmem-ca/.ca-stamp _work/evil-ca/.ca-stamp check-go-version-$(GO_BINARY)
 	$(RUN_TESTS)
 
+run_dm_tests: TEST_BINARY_NAME=pmem-dm-tests
+run_dm_tests: NODE=pmem-csi-$(CLUSTER)-worker1
+run_dm_tests: _work/bin/govm start_test_vm
+	$(TEST_CMD) ./pkg/pmem-device-manager -v -c -o $(PWD)/_work/$(shell echo  $(TEST_BINARY_NAME))
+	NODE_IP=$(shell `pwd`/_work/bin/govm list -f '{{select (filterRegexp . "Name" "^'$(NODE)'") "IP"}}'); \
+	SSH=$$(grep -l $$NODE_IP _work/$(CLUSTER)/ssh.*); \
+	SSH_USER=$$(grep ^exec $$SSH | rev | cut -f2 -d' ' | rev | cut -f1 -d'@'); \
+	SSH_ARGS=$$(grep ^exec $$SSH | cut -f3- -d' ' | rev | cut -f3- -d' ' | rev); \
+	scp $$SSH_ARGS `pwd`/_work/$(TEST_BINARY_NAME) $$SSH_USER@$$NODE_IP:. ; \
+	$$SSH sudo ./$(TEST_BINARY_NAME) -ginkgo.v
+
 _work/%/.ca-stamp: test/setup-ca.sh _work/.setupcfssl-stamp
 	rm -rf $(@D)
 	WORKDIR='$(@D)' PATH='$(PWD)/_work/bin/:$(PATH)' CA='$*' EXTRA_CNS="wrong-node-controller" $<

--- a/test/test.make
+++ b/test/test.make
@@ -145,7 +145,7 @@ test_e2e: start
 .PHONY: run_tests
 test: run_tests
 RUN_TESTS = TEST_WORK=$(abspath _work) \
-	$(TEST_CMD) $(shell $(GO) list $(TEST_ARGS) | sed -e 's;$(IMPORT_PATH);.;')
+	$(TEST_CMD) $(shell $(GO) list $(TEST_ARGS) | grep -v pmem-device-manager | sed -e 's;$(IMPORT_PATH);.;')
 run_tests: _work/pmem-ca/.ca-stamp _work/evil-ca/.ca-stamp check-go-version-$(GO_BINARY)
 	$(RUN_TESTS)
 

--- a/vendor-bom.csv
+++ b/vendor-bom.csv
@@ -55,6 +55,7 @@ golang.org/x/time;golang time;BSD 3-clause "New" or "Revised" License
 google.golang.org/appengine;Golang appengine;Apache License 2.0
 google.golang.org/genproto;Google go-genproto;Apache License 2.0
 google.golang.org/grpc;grpc grpc-go;Apache License 2.0
+gopkg.in/freddierice/go-losetup.v1; Go losetup; MIT License
 gopkg.in/fsnotify.v1;fsnotify;BSD 3-clause "New" or "Revised" License
 gopkg.in/inf.v0;go-inf;BSD 3-clause "New" or "Revised" License
 gopkg.in/square/go-jose.v2;go-jose;Apache License 2.0

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/.gitignore
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/LICENSE
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Freddie Rice
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/README.md
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/README.md
@@ -1,0 +1,24 @@
+# go-losetup
+A losetup implementation for go-lang
+
+## how to get it
+```
+go get gopkg.in/freddierice/go-losetup.v1
+```
+
+## example usage
+```go
+// attach a raw file to a loop device
+dev, err := losetup.Attach("rawfile.img", 0, false)
+if err != nil {
+	// error checking
+}
+
+fmt.Printf("attached rawfile.img to %v\n", dev.Path())
+
+err := dev.Detach()
+if err != nil {
+	// error checking
+}
+```
+

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/constants.go
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/constants.go
@@ -1,0 +1,45 @@
+package losetup
+
+const (
+	// general constants
+	NameSize = 64
+	KeySize  = 32
+	Major    = 7
+
+	// paths
+	LoopControlPath = "/dev/loop-control"
+
+	// loop flags
+	FlagsReadOnly  = 1
+	FlagsAutoClear = 4
+	FlagsPartScan  = 8
+	FlagsDirectIO  = 16
+
+	// loop filter types
+	CryptNone      = 0
+	CryptXor       = 1
+	CryptDes       = 2
+	CryptFish2     = 3
+	CryptBlow      = 4
+	CryptCast128   = 5
+	CryptIdea      = 6
+	CryptDummy     = 9
+	CryptSkipjack  = 10
+	CryptCryptoApi = 18
+	MaxCrypt       = 20
+
+	// ioctl commands
+	SetFd       = 0x4C00
+	ClrFd       = 0x4C01
+	SetStatus   = 0x4C02
+	GetStatus   = 0x4C03
+	SetStatus64 = 0x4C04
+	GetStatus64 = 0x4C05
+	ChangeFd    = 0x4C06
+	SetCapacity = 0x4C07
+	SetDirectIO = 0x4C08
+
+	CtlAdd     = 0x4C80
+	CtlRemove  = 0x4C81
+	CtlGetFree = 0x4C82
+)

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/device.go
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/device.go
@@ -1,0 +1,26 @@
+package losetup
+
+import (
+	"fmt"
+	"os"
+)
+
+// Device represents a loop device /dev/loop#
+type Device struct {
+	// device number (i.e. 7 if /dev/loop7)
+	number uint64
+
+	// flags with which to open the device with
+	flags int
+}
+
+// open returns a file handle to /dev/loop# and returns an error if it cannot
+// be opened.
+func (device Device) open() (*os.File, error) {
+	return os.OpenFile(device.Path(), device.flags, 0660)
+}
+
+// Path returns the path to the loopback device
+func (device Device) Path() string {
+	return fmt.Sprintf(DeviceFormatString, device.number)
+}

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/format.go
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/format.go
@@ -1,0 +1,16 @@
+package losetup
+
+import "fmt"
+
+// DeviceFormatString holds the format of loopback devices
+const DeviceFormatString = "/dev/loop%d"
+
+// String implements the Stringer interface for Device
+func (device Device) String() string {
+	return device.Path()
+}
+
+// String implements the Stringer interface for Info
+func (info Info) String() string {
+	return fmt.Sprintf("")
+}

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/info.go
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/info.go
@@ -1,0 +1,71 @@
+package losetup
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Info is a datastructure that holds relevant information about a file backed
+// loopback device.
+type Info struct {
+	Device         uint64
+	INode          uint64
+	RDevice        uint64
+	Offset         uint64
+	SizeLimit      uint64
+	Number         uint32
+	EncryptType    uint32
+	EncryptKeySize uint32
+	Flags          uint32
+	FileName       [NameSize]byte
+	CryptName      [NameSize]byte
+	EncryptKey     [KeySize]byte
+	Init           [2]uint64
+}
+
+// GetInfo returns information about a loop device
+func (device Device) GetInfo() (Info, error) {
+	f, err := device.open()
+	if err != nil {
+		return Info{}, fmt.Errorf("could not open %v: %v", device, err)
+	}
+	defer f.Close()
+
+	return getInfo(f.Fd())
+}
+
+func getInfo(fd uintptr) (Info, error) {
+	retInfo := Info{}
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, GetStatus64, uintptr(unsafe.Pointer(&retInfo)))
+	if errno == unix.ENXIO {
+		return Info{}, fmt.Errorf("device not backed by a file")
+	} else if errno != 0 {
+		return Info{}, fmt.Errorf("could not get info about %v (err: %d): %v", errno, errno)
+	}
+
+	return retInfo, nil
+}
+
+// SetInfo sets options in the loop device.
+func (device Device) SetInfo(info Info) error {
+	f, err := device.open()
+	if err != nil {
+		return fmt.Errorf("could not open %v: %v", device, err)
+	}
+	defer f.Close()
+
+	return setInfo(f.Fd(), info)
+}
+
+func setInfo(fd uintptr, info Info) error {
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, fd, SetStatus64, uintptr(unsafe.Pointer(&info)))
+	if errno == unix.ENXIO {
+		return fmt.Errorf("device not backed by a file")
+	} else if errno != 0 {
+		return fmt.Errorf("could not get info about %v (err: %d): %v", errno, errno)
+	}
+
+	return nil
+}

--- a/vendor/gopkg.in/freddierice/go-losetup.v1/losetup.go
+++ b/vendor/gopkg.in/freddierice/go-losetup.v1/losetup.go
@@ -1,0 +1,117 @@
+package losetup
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Add will add a loopback device if it does not exist already.
+func (device Device) Add() error {
+	ctrl, err := os.OpenFile(LoopControlPath, os.O_RDWR, 0660)
+	if err != nil {
+		return fmt.Errorf("could not open %v: %v", LoopControlPath, err)
+	}
+	defer ctrl.Close()
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, ctrl.Fd(), CtlAdd, uintptr(device.number))
+	if errno == unix.EEXIST {
+		return fmt.Errorf("device already exits")
+	}
+	if errno != 0 {
+		return fmt.Errorf("could not add device (err: %d): %v", errno, errno)
+	}
+	return nil
+}
+
+// Remove will remove a loopback device if it is not busy.
+func (device Device) Remove() error {
+	ctrl, err := os.OpenFile(LoopControlPath, os.O_RDWR, 0660)
+	if err != nil {
+		return fmt.Errorf("could not open %v: %v", LoopControlPath, err)
+	}
+	defer ctrl.Close()
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, ctrl.Fd(), CtlRemove, uintptr(device.number))
+	if errno == unix.EBUSY {
+		return fmt.Errorf("could not remove, device in use")
+	}
+	if errno != 0 {
+		return fmt.Errorf("could not remove (err: %d): %v", errno, errno)
+	}
+	return nil
+}
+
+// GetFree searches for the first free loopback device. If it cannot find one,
+// it will attempt to create one. If anything fails, GetFree will return an
+// error.
+func GetFree() (Device, error) {
+	ctrl, err := os.OpenFile(LoopControlPath, os.O_RDWR, 0660)
+	if err != nil {
+		return Device{}, fmt.Errorf("could not open %v: %v", LoopControlPath, err)
+	}
+	defer ctrl.Close()
+	dev, _, errno := unix.Syscall(unix.SYS_IOCTL, ctrl.Fd(), CtlGetFree, 0)
+	if dev < 0 {
+		return Device{}, fmt.Errorf("could not get free device (err: %d): %v", errno, errno)
+	}
+	return Device{number: uint64(dev), flags: os.O_RDWR}, nil
+}
+
+// Attach attaches backingFile to the loopback device starting at offset. If ro
+// is true, then the file is attached read only.
+func Attach(backingFile string, offset uint64, ro bool) (Device, error) {
+	var dev Device
+
+	flags := os.O_RDWR
+	if ro {
+		flags = os.O_RDONLY
+	}
+
+	back, err := os.OpenFile(backingFile, flags, 0660)
+	if err != nil {
+		return dev, fmt.Errorf("could not open backing file: %v", err)
+	}
+	defer back.Close()
+
+	dev, err = GetFree()
+	if err != nil {
+		return dev, err
+	}
+	dev.flags = flags
+
+	loopFile, err := dev.open()
+	if err != nil {
+		return dev, fmt.Errorf("could not open loop device: %v", err)
+	}
+	defer loopFile.Close()
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, loopFile.Fd(), SetFd, back.Fd())
+	if errno == 0 {
+		info := Info{}
+		copy(info.FileName[:], []byte(backingFile))
+		info.Offset = offset
+		if err := setInfo(loopFile.Fd(), info); err != nil {
+			unix.Syscall(unix.SYS_IOCTL, loopFile.Fd(), ClrFd, 0)
+			return dev, fmt.Errorf("could not set info")
+		}
+	}
+
+	return dev, nil
+}
+
+// Detach removes the file backing the device.
+func (device Device) Detach() error {
+
+	loopFile, err := os.OpenFile(device.Path(), os.O_RDONLY, 0660)
+	if err != nil {
+		return fmt.Errorf("could not open loop device")
+	}
+	defer loopFile.Close()
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, loopFile.Fd(), ClrFd, 0)
+	if errno != 0 {
+		return fmt.Errorf("error clearing loopfile: %v", errno)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -266,6 +266,8 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
+# gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124
+gopkg.in/freddierice/go-losetup.v1
 # gopkg.in/fsnotify.v1 v1.4.7
 gopkg.in/fsnotify.v1
 # gopkg.in/inf.v0 v0.9.1


### PR DESCRIPTION
This PR address a couple of issues:

- Defined new error codes that are returned by DeviceManager interface methods. Made changes to implementations to use these error codes and revised the error messages using error formatting features provided by go-1.13 `fmt` package.

- Discussion on issue #413, raised a requirement that PMEM-CSI should handle the DeleteVolume() call for volumes that the underlined device already deleted manually by the admin.  So for such a volume we just ignore and return no error in DeviceManager.DeleteVolume(). This also makes DeleteVolume() idempotent.

- Issue #402 : CSI.DeleteVolume should return FailedPreCondition error in case of the volume is in use. Test case added for the same.

- Unit tests for device manager

- This PR also contains a commit that removes the unused code in DeviceManager.