### PR TITLE
TRY: blockvolume without local kubectl support, combining #365 and #380

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Kubernetes cluster has been verified on:
 
 | Branch            | Kubernetes branch/version      | Required alpha feature gates   |
 |-------------------|--------------------------------|------------------------------- |
-| devel             | Kubernetes 1.13                | CSINodeInfo, CSIDriverRegistry |
+| devel             | Kubernetes 1.13                | CSINodeInfo, CSIDriverRegistry, CSIBlockVolume |
 | devel             | Kubernetes 1.14                |                                |
 | devel             | Kubernetes 1.15                |                                |
 
@@ -743,6 +743,10 @@ parameters:
          command:
          - /go/bin/pmem-ns-init
 ```
+
+#### Note about raw block volumes
+
+Applications can use volumes provisioned by PMEM-CSI as [raw block devices](https://kubernetes.io/blog/2019/03/07/raw-block-volume-support-to-beta/). For provisioning a PMEM volume as raw block device, one has to create a `PersistentVolumeClaim` with `volumeMode: Block`. See example [PVC](deploy/common/pmem-pvc-block-volume.yaml) and [application](deploy/common/pmem-app-block-volume.yaml) for usage reference.
 
 <!-- FILL TEMPLATE:
 

--- a/deploy/common/pmem-app-block-volume.yaml
+++ b/deploy/common/pmem-app-block-volume.yaml
@@ -1,0 +1,18 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-csi-app
+spec:
+  containers:
+    - name: my-frontend
+      image: busybox
+      command: [ "sleep", "100000" ]
+      volumeDevices:
+      - devicePath: "/dev/xpmem"
+        name: my-csi-volume
+  nodeSelector:
+    storage: pmem
+  volumes:
+  - name: my-csi-volume
+    persistentVolumeClaim:
+      claimName: pmem-csi-pvc-block-volume

--- a/deploy/common/pmem-pvc-block-volume.yaml
+++ b/deploy/common/pmem-pvc-block-volume.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pmem-csi-pvc-block-volume
+spec:
+  volumeMode: Block
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+  storageClassName: pmem-csi-sc-ext4 # defined in deploy/kubernetes-1.13/pmem-storageclass-ext4.yaml

--- a/deploy/kubernetes-1.13/pmem-app-block-volume.yaml
+++ b/deploy/kubernetes-1.13/pmem-app-block-volume.yaml
@@ -1,0 +1,1 @@
+../common/pmem-app-block-volume.yaml

--- a/deploy/kubernetes-1.13/pmem-pvc-block-volume.yaml
+++ b/deploy/kubernetes-1.13/pmem-pvc-block-volume.yaml
@@ -1,0 +1,1 @@
+../common/pmem-pvc-block-volume.yaml

--- a/deploy/kubernetes-1.14/pmem-app-block-volume.yaml
+++ b/deploy/kubernetes-1.14/pmem-app-block-volume.yaml
@@ -1,0 +1,1 @@
+../common/pmem-app-block-volume.yaml

--- a/deploy/kubernetes-1.14/pmem-pvc-block-volume.yaml
+++ b/deploy/kubernetes-1.14/pmem-pvc-block-volume.yaml
@@ -1,0 +1,1 @@
+../common/pmem-pvc-block-volume.yaml

--- a/pkg/pmem-csi-driver/controllerserver-master.go
+++ b/pkg/pmem-csi-driver/controllerserver-master.go
@@ -152,12 +152,6 @@ func (cs *masterController) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, "Name missing in request")
 	}
 
-	for _, cap := range req.VolumeCapabilities {
-		if cap.GetBlock() != nil {
-			return nil, status.Error(codes.Unimplemented, "VolumeCapability access_type:block unimplemented")
-		}
-	}
-
 	asked := req.GetCapacityRange().GetRequiredBytes()
 
 	outTopology := []*csi.Topology{}
@@ -342,12 +336,6 @@ func (cs *masterController) ValidateVolumeCapabilities(ctx context.Context, req 
 			return &csi.ValidateVolumeCapabilitiesResponse{
 				Confirmed: nil,
 				Message:   "Driver does not support '" + cap.AccessMode.Mode.String() + "' mode",
-			}, nil
-		}
-		if cap.GetBlock() != nil {
-			return &csi.ValidateVolumeCapabilitiesResponse{
-				Confirmed: nil,
-				Message:   "Driver does not support access type: block",
 			}, nil
 		}
 	}

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -79,7 +79,8 @@ var _ = Describe("PMEM Volumes", func() {
 				// We use 16Mi size volumes because this is the minimum size supported
 				// by xfs filesystem's allocation group
 				// Ref: http://man7.org/linux/man-pages/man8/mkfs.xfs.8.html
-				claimSize: "16Mi",
+				claimSize: "110Mi",
+				// VolumeIO test suite requires at least 102 MB volume.
 			}
 		},
 	}
@@ -91,7 +92,7 @@ var _ = Describe("PMEM Volumes", func() {
 		testsuites.InitProvisioningTestSuite,
 		// testsuites.InitSnapshottableTestSuite,
 		// testsuites.InitSubPathTestSuite,
-		// testsuites.InitVolumeIOTestSuite,
+		testsuites.InitVolumeIOTestSuite,
 		testsuites.InitVolumeModeTestSuite,
 		testsuites.InitVolumesTestSuite,
 	}

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -92,7 +92,7 @@ var _ = Describe("PMEM Volumes", func() {
 		// testsuites.InitSnapshottableTestSuite,
 		// testsuites.InitSubPathTestSuite,
 		// testsuites.InitVolumeIOTestSuite,
-		// testsuites.InitVolumeModeTestSuite,
+		testsuites.InitVolumeModeTestSuite,
 		testsuites.InitVolumesTestSuite,
 	}
 

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -70,6 +70,7 @@ var _ = Describe("PMEM Volumes", func() {
 						testsuites.CapPersistence: true,
 						testsuites.CapFsGroup:     true,
 						testsuites.CapExec:        true,
+						testsuites.CapBlock:       true,
 					},
 				},
 				scManifest: map[string]string{

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -91,7 +91,7 @@ fi
 
 # Kubernetes feature gates to enable/disable
 # featurename=true,feature=false
-: ${TEST_FEATURE_GATES:=CSINodeInfo=true,CSIDriverRegistry=true}
+: ${TEST_FEATURE_GATES:=CSINodeInfo=true,CSIDriverRegistry=true,CSIBlockVolume=true}
 
 # DeviceMode to be used during testing.
 # Allowed values: lvm, direct

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/ephemeral.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/ephemeral.go
@@ -119,7 +119,7 @@ func (p *ephemeralTestSuite) defineTests(driver TestDriver, pattern testpatterns
 
 		l.testCase.ReadOnly = true
 		l.testCase.RunningPodCheck = func(pod *v1.Pod) interface{} {
-			storageutils.VerifyExecInPodSucceed(pod, "mount | grep /mnt/test | grep ro,")
+			storageutils.VerifyExecInPodSucceed(f, pod, "mount | grep /mnt/test | grep ro,")
 			return nil
 		}
 		l.testCase.TestEphemeral()
@@ -131,7 +131,7 @@ func (p *ephemeralTestSuite) defineTests(driver TestDriver, pattern testpatterns
 
 		l.testCase.ReadOnly = false
 		l.testCase.RunningPodCheck = func(pod *v1.Pod) interface{} {
-			storageutils.VerifyExecInPodSucceed(pod, "mount | grep /mnt/test | grep rw,")
+			storageutils.VerifyExecInPodSucceed(f, pod, "mount | grep /mnt/test | grep rw,")
 			return nil
 		}
 		l.testCase.TestEphemeral()
@@ -160,8 +160,8 @@ func (p *ephemeralTestSuite) defineTests(driver TestDriver, pattern testpatterns
 			// visible in the other.
 			if !readOnly && !shared {
 				ginkgo.By("writing data in one pod and checking for it in the second")
-				storageutils.VerifyExecInPodSucceed(pod, "touch /mnt/test-0/hello-world")
-				storageutils.VerifyExecInPodSucceed(pod2, "[ ! -f /mnt/test-0/hello-world ]")
+				storageutils.VerifyExecInPodSucceed(f, pod, "touch /mnt/test-0/hello-world")
+				storageutils.VerifyExecInPodSucceed(f, pod2, "[ ! -f /mnt/test-0/hello-world ]")
 			}
 
 			defer StopPod(f.ClientSet, pod2)

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/multivolume.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/multivolume.go
@@ -345,18 +345,18 @@ func testAccessMultipleVolumes(f *framework.Framework, cs clientset.Interface, n
 		index := i + 1
 		path := fmt.Sprintf("/mnt/volume%d", index)
 		ginkgo.By(fmt.Sprintf("Checking if the volume%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
-		utils.CheckVolumeModeOfPath(pod, *pvc.Spec.VolumeMode, path)
+		utils.CheckVolumeModeOfPath(f, pod, *pvc.Spec.VolumeMode, path)
 
 		if readSeedBase > 0 {
 			ginkgo.By(fmt.Sprintf("Checking if read from the volume%d works properly", index))
-			utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, readSeedBase+int64(i))
+			utils.CheckReadFromPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, readSeedBase+int64(i))
 		}
 
 		ginkgo.By(fmt.Sprintf("Checking if write to the volume%d works properly", index))
-		utils.CheckWriteToPath(pod, *pvc.Spec.VolumeMode, path, byteLen, writeSeedBase+int64(i))
+		utils.CheckWriteToPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, writeSeedBase+int64(i))
 
 		ginkgo.By(fmt.Sprintf("Checking if read from the volume%d works properly", index))
-		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, writeSeedBase+int64(i))
+		utils.CheckReadFromPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, writeSeedBase+int64(i))
 	}
 
 	pod, err = cs.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
@@ -432,22 +432,22 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 	for i, pod := range pods {
 		index := i + 1
 		ginkgo.By(fmt.Sprintf("Checking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
-		utils.CheckVolumeModeOfPath(pod, *pvc.Spec.VolumeMode, path)
+		utils.CheckVolumeModeOfPath(f, pod, *pvc.Spec.VolumeMode, path)
 
 		if i != 0 {
 			ginkgo.By(fmt.Sprintf("From pod%d, checking if reading the data that pod%d write works properly", index, index-1))
 			// For 1st pod, no one has written data yet, so pass the read check
-			utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
+			utils.CheckReadFromPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 		}
 
 		// Update the seed and check if write/read works properly
 		seed = time.Now().UTC().UnixNano()
 
 		ginkgo.By(fmt.Sprintf("Checking if write to the volume in pod%d works properly", index))
-		utils.CheckWriteToPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
+		utils.CheckWriteToPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 
 		ginkgo.By(fmt.Sprintf("Checking if read from the volume in pod%d works properly", index))
-		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
+		utils.CheckReadFromPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 	}
 
 	// Delete the last pod and remove from slice of pods
@@ -463,7 +463,7 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 		index := i + 1
 		// index of pod and index of pvc match, because pods are created above way
 		ginkgo.By(fmt.Sprintf("Rechecking if the volume in pod%d exists as expected volume mode (%s)", index, *pvc.Spec.VolumeMode))
-		utils.CheckVolumeModeOfPath(pod, *pvc.Spec.VolumeMode, "/mnt/volume1")
+		utils.CheckVolumeModeOfPath(f, pod, *pvc.Spec.VolumeMode, "/mnt/volume1")
 
 		if i == 0 {
 			// This time there should be data that last pod wrote, for 1st pod
@@ -471,15 +471,15 @@ func TestConcurrentAccessToSingleVolume(f *framework.Framework, cs clientset.Int
 		} else {
 			ginkgo.By(fmt.Sprintf("From pod%d, rechecking if reading the data that pod%d write works properly", index, index-1))
 		}
-		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
+		utils.CheckReadFromPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 
 		// Update the seed and check if write/read works properly
 		seed = time.Now().UTC().UnixNano()
 
 		ginkgo.By(fmt.Sprintf("Rechecking if write to the volume in pod%d works properly", index))
-		utils.CheckWriteToPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
+		utils.CheckWriteToPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 
 		ginkgo.By(fmt.Sprintf("Rechecking if read from the volume in pod%d works properly", index))
-		utils.CheckReadFromPath(pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
+		utils.CheckReadFromPath(f, pod, *pvc.Spec.VolumeMode, path, byteLen, seed)
 	}
 }

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volume_io.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volume_io.go
@@ -249,7 +249,7 @@ func writeToFile(f *framework.Framework, pod *v1.Pod, fpath, ddInput string, fsi
 // Verify that the test file is the expected size and contains the expected content.
 func verifyFile(f *framework.Framework, pod *v1.Pod, fpath string, expectSize int64, ddInput string) error {
 	ginkgo.By("verifying file size")
-	rtnstr, err := utils.PodExec(pod, fmt.Sprintf("stat -c %%s %s", fpath))
+	rtnstr, err := utils.PodExec(f, pod, fmt.Sprintf("stat -c %%s %s", fpath))
 	if err != nil || rtnstr == "" {
 		return fmt.Errorf("unable to get file size via `stat %s`: %v", fpath, err)
 	}
@@ -281,7 +281,7 @@ func verifyFile(f *framework.Framework, pod *v1.Pod, fpath string, expectSize in
 }
 
 // Delete `fpath` to save some disk space on host. Delete errors are logged but ignored.
-func deleteFile(pod *v1.Pod, fpath string) {
+func deleteFile(f *framework.Framework, pod *v1.Pod, fpath string) {
 	ginkgo.By(fmt.Sprintf("deleting test file %s...", fpath))
 	_, err := utils.PodExec(f, pod, fmt.Sprintf("rm -f %s", fpath))
 	if err != nil {
@@ -314,7 +314,7 @@ func testVolumeIO(f *framework.Framework, cs clientset.Interface, config volume.
 		return fmt.Errorf("failed to create client pod %q: %v", clientPod.Name, err)
 	}
 	defer func() {
-		deleteFile(clientPod, ddInput)
+		deleteFile(f, clientPod, ddInput)
 		ginkgo.By(fmt.Sprintf("deleting client pod %q...", clientPod.Name))
 		e := e2epod.DeletePodWithWait(cs, clientPod)
 		if e != nil {

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volume_io.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volume_io.go
@@ -237,17 +237,17 @@ func makePodSpec(config volume.TestConfig, initCmd string, volsrc v1.VolumeSourc
 }
 
 // Write `fsize` bytes to `fpath` in the pod, using dd and the `ddInput` file.
-func writeToFile(pod *v1.Pod, fpath, ddInput string, fsize int64) error {
+func writeToFile(f *framework.Framework, pod *v1.Pod, fpath, ddInput string, fsize int64) error {
 	ginkgo.By(fmt.Sprintf("writing %d bytes to test file %s", fsize, fpath))
 	loopCnt := fsize / testpatterns.MinFileSize
 	writeCmd := fmt.Sprintf("i=0; while [ $i -lt %d ]; do dd if=%s bs=%d >>%s 2>/dev/null; let i+=1; done", loopCnt, ddInput, testpatterns.MinFileSize, fpath)
-	_, err := utils.PodExec(pod, writeCmd)
+	_, err := utils.PodExec(f, pod, writeCmd)
 
 	return err
 }
 
 // Verify that the test file is the expected size and contains the expected content.
-func verifyFile(pod *v1.Pod, fpath string, expectSize int64, ddInput string) error {
+func verifyFile(f *framework.Framework, pod *v1.Pod, fpath string, expectSize int64, ddInput string) error {
 	ginkgo.By("verifying file size")
 	rtnstr, err := utils.PodExec(pod, fmt.Sprintf("stat -c %%s %s", fpath))
 	if err != nil || rtnstr == "" {
@@ -262,7 +262,7 @@ func verifyFile(pod *v1.Pod, fpath string, expectSize int64, ddInput string) err
 	}
 
 	ginkgo.By("verifying file hash")
-	rtnstr, err = utils.PodExec(pod, fmt.Sprintf("md5sum %s | cut -d' ' -f1", fpath))
+	rtnstr, err = utils.PodExec(f, pod, fmt.Sprintf("md5sum %s | cut -d' ' -f1", fpath))
 	if err != nil {
 		return fmt.Errorf("unable to test file hash via `md5sum %s`: %v", fpath, err)
 	}
@@ -283,7 +283,7 @@ func verifyFile(pod *v1.Pod, fpath string, expectSize int64, ddInput string) err
 // Delete `fpath` to save some disk space on host. Delete errors are logged but ignored.
 func deleteFile(pod *v1.Pod, fpath string) {
 	ginkgo.By(fmt.Sprintf("deleting test file %s...", fpath))
-	_, err := utils.PodExec(pod, fmt.Sprintf("rm -f %s", fpath))
+	_, err := utils.PodExec(f, pod, fmt.Sprintf("rm -f %s", fpath))
 	if err != nil {
 		// keep going, the test dir will be deleted when the volume is unmounted
 		e2elog.Logf("unable to delete test file %s: %v\nerror ignored, continuing test", fpath, err)
@@ -341,12 +341,12 @@ func testVolumeIO(f *framework.Framework, cs clientset.Interface, config volume.
 		}
 		fpath := filepath.Join(mountPath, fmt.Sprintf("%s-%d", file, fsize))
 		defer func() {
-			deleteFile(clientPod, fpath)
+			deleteFile(f, clientPod, fpath)
 		}()
-		if err = writeToFile(clientPod, fpath, ddInput, fsize); err != nil {
+		if err = writeToFile(f, clientPod, fpath, ddInput, fsize); err != nil {
 			return err
 		}
-		if err = verifyFile(clientPod, fpath, fsize, ddInput); err != nil {
+		if err = verifyFile(f, clientPod, fpath, fsize, ddInput); err != nil {
 			return err
 		}
 	}

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volumes.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/volumes.go
@@ -174,9 +174,9 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		// local), plugin skips setting fsGroup if volume is already mounted
 		// and we don't have reliable way to detect volumes are unmounted or
 		// not before starting the second pod.
-		volume.InjectContent(f.ClientSet, config, fsGroup, pattern.FsType, tests)
+		volume.InjectContent(f, f.ClientSet, config, fsGroup, pattern.FsType, tests)
 		if driver.GetDriverInfo().Capabilities[CapPersistence] {
-			volume.TestVolumeClient(f.ClientSet, config, fsGroup, pattern.FsType, tests)
+			volume.TestVolumeClient(f, f.ClientSet, config, fsGroup, pattern.FsType, tests)
 		} else {
 			ginkgo.By("Skipping persistence check for non-persistent volume")
 		}

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/utils/utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/utils/utils.go
@@ -210,13 +210,13 @@ func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Fra
 	seed := time.Now().UTC().UnixNano()
 
 	ginkgo.By("Writing to the volume.")
-	CheckWriteToPath(clientPod, v1.PersistentVolumeFilesystem, path, byteLen, seed)
+	CheckWriteToPath(f, clientPod, v1.PersistentVolumeFilesystem, path, byteLen, seed)
 
 	ginkgo.By("Restarting kubelet")
 	KubeletCommand(KRestart, c, clientPod)
 
 	ginkgo.By("Testing that written file is accessible.")
-	CheckReadFromPath(clientPod, v1.PersistentVolumeFilesystem, path, byteLen, seed)
+	CheckReadFromPath(f, clientPod, v1.PersistentVolumeFilesystem, path, byteLen, seed)
 
 	e2elog.Logf("Volume mount detected on pod %s and written file %s is readable post-restart.", clientPod.Name, path)
 }
@@ -228,13 +228,13 @@ func TestKubeletRestartsAndRestoresMap(c clientset.Interface, f *framework.Frame
 	seed := time.Now().UTC().UnixNano()
 
 	ginkgo.By("Writing to the volume.")
-	CheckWriteToPath(clientPod, v1.PersistentVolumeBlock, path, byteLen, seed)
+	CheckWriteToPath(f, clientPod, v1.PersistentVolumeBlock, path, byteLen, seed)
 
 	ginkgo.By("Restarting kubelet")
 	KubeletCommand(KRestart, c, clientPod)
 
 	ginkgo.By("Testing that written pv is accessible.")
-	CheckReadFromPath(clientPod, v1.PersistentVolumeBlock, path, byteLen, seed)
+	CheckReadFromPath(f, clientPod, v1.PersistentVolumeBlock, path, byteLen, seed)
 
 	e2elog.Logf("Volume map detected on pod %s and written data %s is readable post-restart.", clientPod.Name, path)
 }
@@ -610,7 +610,7 @@ func genBinDataFromSeed(len int, seed int64) []byte {
 }
 
 // CheckReadFromPath validate that file can be properly read.
-func CheckReadFromPath(pod *v1.Pod, volMode v1.PersistentVolumeMode, path string, len int, seed int64) {
+func CheckReadFromPath(f *framework.Framework, pod *v1.Pod, volMode v1.PersistentVolumeMode, path string, len int, seed int64) {
 	var pathForVolMode string
 	if volMode == v1.PersistentVolumeBlock {
 		pathForVolMode = path
@@ -620,12 +620,12 @@ func CheckReadFromPath(pod *v1.Pod, volMode v1.PersistentVolumeMode, path string
 
 	sum := sha256.Sum256(genBinDataFromSeed(len, seed))
 
-	VerifyExecInPodSucceed(pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum", pathForVolMode, len))
-	VerifyExecInPodSucceed(pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", pathForVolMode, len, sum))
+	VerifyExecInPodSucceed(f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum", pathForVolMode, len))
+	VerifyExecInPodSucceed(f, pod, fmt.Sprintf("dd if=%s bs=%d count=1 | sha256sum | grep -Fq %x", pathForVolMode, len, sum))
 }
 
 // CheckWriteToPath that file can be properly written.
-func CheckWriteToPath(pod *v1.Pod, volMode v1.PersistentVolumeMode, path string, len int, seed int64) {
+func CheckWriteToPath(f *framework.Framework, pod *v1.Pod, volMode v1.PersistentVolumeMode, path string, len int, seed int64) {
 	var pathForVolMode string
 	if volMode == v1.PersistentVolumeBlock {
 		pathForVolMode = path
@@ -635,8 +635,8 @@ func CheckWriteToPath(pod *v1.Pod, volMode v1.PersistentVolumeMode, path string,
 
 	encoded := base64.StdEncoding.EncodeToString(genBinDataFromSeed(len, seed))
 
-	VerifyExecInPodSucceed(pod, fmt.Sprintf("echo %s | base64 -d | sha256sum", encoded))
-	VerifyExecInPodSucceed(pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, pathForVolMode, len))
+	VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | sha256sum", encoded))
+	VerifyExecInPodSucceed(f, pod, fmt.Sprintf("echo %s | base64 -d | dd of=%s bs=%d count=1", encoded, pathForVolMode, len))
 }
 
 // ListPodVolumePluginDirectory returns all volumes in /var/lib/kubelet/pods/<pod UID>/volumes/* and


### PR DESCRIPTION
This combines effect of #365 and #380 (plus small extra commit to polish it to get to build). so that we can see possibly running CI tests about block volumes.
In my local test I see one failure
```
Dynamic PV (block volmode)] volumeMode [It] should fail in binding dynamic provisioned PV to PVC
```
where error is expected but we get nil instead.
Let's see does CI hit the same.