### PR TITLE
Fedora support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,23 +137,23 @@ pipeline {
             }
         }
 
-        stage('testing 1.15 LVM') {
+        stage('testing 1.16 LVM') {
             options {
                 timeout(time: 90, unit: "MINUTES")
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "testing", "clear", "${env.CLEAR_LINUX_VERSION_1_15}", "")
+                TestInVM("lvm", "testing", "fedora", "", "1.16")
             }
         }
 
-        stage('testing 1.15 direct') {
+        stage('testing 1.16 direct') {
             options {
                 timeout(time: 180, unit: "MINUTES")
                 retry(2)
             }
             steps {
-                TestInVM("direct", "testing", "clear", "${env.CLEAR_LINUX_VERSION_1_15}", "")
+                TestInVM("direct", "testing", "fedora", "", "1.16")
             }
         }
 
@@ -205,6 +205,16 @@ pipeline {
           In production we can only run E2E testing, no sanity testing.
           Therefore it is faster.
         */
+
+        stage('production 1.15, Clear Linux') {
+            options {
+                timeout(time: 90, unit: "MINUTES")
+                retry(2)
+            }
+            steps {
+                TestInVM("lvm", "production", "clear", "${env.CLEAR_LINUX_VERSION_1_15}", "")
+            }
+        }
 
         stage('production 1.15 LVM') {
             when { not { changeRequest() } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "testing", "${env.CLEAR_LINUX_VERSION_1_15}")
+                TestInVM("lvm", "testing", "clear", "${env.CLEAR_LINUX_VERSION_1_15}", "")
             }
         }
 
@@ -153,7 +153,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("direct", "testing", "${env.CLEAR_LINUX_VERSION_1_15}")
+                TestInVM("direct", "testing", "clear", "${env.CLEAR_LINUX_VERSION_1_15}", "")
             }
         }
 
@@ -164,7 +164,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "testing", "${env.CLEAR_LINUX_VERSION_1_14}")
+                TestInVM("lvm", "testing", "fedora", "", "1.14")
             }
         }
 
@@ -175,7 +175,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("direct", "testing", "${env.CLEAR_LINUX_VERSION_1_14}")
+                TestInVM("direct", "testing", "fedora", "", "1.14")
             }
         }
 
@@ -186,7 +186,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "testing", "${env.CLEAR_LINUX_VERSION_1_13}")
+                TestInVM("lvm", "testing", "fedora", "", "1.13")
             }
         }
 
@@ -197,7 +197,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("direct", "testing", "${env.CLEAR_LINUX_VERSION_1_13}")
+                TestInVM("direct", "testing", "fedora", "", "1.13")
             }
         }
 
@@ -213,7 +213,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "production", "${env.CLEAR_LINUX_VERSION_1_15}")
+                TestInVM("lvm", "production", "fedora", "", "1.15")
             }
         }
 
@@ -224,7 +224,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("direct", "production", "${env.CLEAR_LINUX_VERSION_1_15}")
+                TestInVM("direct", "production", "fedora", "", "1.15")
             }
         }
 
@@ -235,7 +235,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "production", "${env.CLEAR_LINUX_VERSION_1_14}")
+                TestInVM("lvm", "production", "fedora", "", "1.14")
             }
         }
 
@@ -246,7 +246,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("direct", "production", "${env.CLEAR_LINUX_VERSION_1_14}")
+                TestInVM("direct", "production", "fedora", "", "1.14")
             }
         }
 
@@ -257,7 +257,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "production", "${env.CLEAR_LINUX_VERSION_1_13}")
+                TestInVM("lvm", "production", "fedora", "", "1.13")
             }
         }
 
@@ -268,7 +268,7 @@ pipeline {
                 retry(2)
             }
             steps {
-                TestInVM("direct", "production", "${env.CLEAR_LINUX_VERSION_1_13}")
+                TestInVM("direct", "production", "fedora", "", "1.13")
             }
         }
 
@@ -356,7 +356,7 @@ String DockerBuildArgs() {
     "
 }
 
-void TestInVM(deviceMode, deploymentMode, clearVersion) {
+void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersion) {
     try {
         /*
         We have to run "make start" in the current directory
@@ -380,7 +380,9 @@ void TestInVM(deviceMode, deploymentMode, clearVersion) {
                   -e TEST_DEPLOYMENTMODE=${deploymentMode} \
                   -e TEST_CREATE_REGISTRY=true \
                   -e TEST_CHECK_SIGNED_FILES=false \
-                  -e TEST_CLEAR_LINUX_VERSION=${clearVersion} \
+                  -e TEST_DISTRO=${distro} \
+                  -e TEST_DISTRO_VERSION=${distroVersion} \
+                  -e TEST_KUBERNETES_VERSION=${kubernetesVersion} \
                   ${DockerBuildArgs()} \
                   -v `pwd`:`pwd` \
                   -w `pwd` \

--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,8 @@ clean:
 # All of the commands operate on a cluster stored in _work/$(CLUSTER),
 # which defaults to _work/clear-govm. This can be changed with
 # make variables, for example:
-#   CLUSTER=clear-govm-crio TEST_CRI=crio make start
-export CLUSTER ?= clear-govm
+#   CLUSTER=pmem-govm-crio TEST_CRI=crio make start
+export CLUSTER ?= pmem-govm
 include test/start-stop.make
 include test/test.make
 

--- a/README.md
+++ b/README.md
@@ -831,14 +831,14 @@ to ensure that the cluster runs those rebuilt images.
 
 ### Running commands on test cluster nodes over ssh
 
-`make start` generates ssh wrapper scripts `_work/clear-govm/ssh.N` for each
+`make start` generates ssh wrapper scripts `_work/pmem-govm/ssh.N` for each
 test cluster node which are handy for running a single command or to
 start an interactive shell. Examples:
 
-`_work/clear-govm/ssh.0 kubectl get pods` runs a kubectl command on
+`_work/pmem-govm/ssh.0 kubectl get pods` runs a kubectl command on
 the master node.
 
-`_work/clear-govm/ssh.1` starts a shell on the first worker node.
+`_work/pmem-govm/ssh.1` starts a shell on the first worker node.
 
 ### Configuration options
 
@@ -849,7 +849,7 @@ environment variables of `make start` on a case-by-case basis or
 permanently by creating a file like `test/test-config.d/my-config.sh`.
 
 Multiple different clusters can be brought up in parallel by changing
-the default `clear-govm` cluster name via the `CLUSTER` env variable.
+the default `pmem-govm` cluster name via the `CLUSTER` env variable.
 
 For example, this invocation sets up a cluster using the non-default
 direct device mode:
@@ -872,7 +872,7 @@ of the test run. For example, to run just the E2E provisioning test
 (create PVC, write data in one pod, read it in another) in verbose mode:
 
 ``` sh
-$ KUBECONFIG=$(pwd)/_work/clear-govm/kube.config REPO_ROOT=$(pwd) ginkgo -v -focus=pmem-csi.*should.provision.storage.with.defaults ./test/e2e/
+$ KUBECONFIG=$(pwd)/_work/pmem-govm/kube.config REPO_ROOT=$(pwd) ginkgo -v -focus=pmem-csi.*should.provision.storage.with.defaults ./test/e2e/
 Nov 26 11:21:28.805: INFO: The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.
 Running Suite: PMEM E2E suite
 =============================
@@ -880,7 +880,7 @@ Random Seed: 1543227683 - Will randomize all specs
 Will run 1 of 61 specs
 
 Nov 26 11:21:28.812: INFO: checking config
-Nov 26 11:21:28.812: INFO: >>> kubeConfig: /nvme/gopath/src/github.com/intel/pmem-csi/_work/clear-govm/kube.config
+Nov 26 11:21:28.812: INFO: >>> kubeConfig: /nvme/gopath/src/github.com/intel/pmem-csi/_work/pmem-govm/kube.config
 Nov 26 11:21:28.817: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
 ...
 Ran 1 of 61 Specs in 58.465 seconds

--- a/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct-testing.yaml
@@ -223,7 +223,7 @@ spec:
           type: DirectoryOrCreate
         name: coverage-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node-testing
@@ -269,7 +269,7 @@ spec:
           type: DirectoryOrCreate
         name: mountpoint-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.13/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-direct.yaml
@@ -193,7 +193,7 @@ spec:
             path: pmem-csi-registry.key
           secretName: pmem-csi-registry-secrets
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm-testing.yaml
@@ -223,7 +223,7 @@ spec:
           type: DirectoryOrCreate
         name: coverage-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node-testing
@@ -269,7 +269,7 @@ spec:
           type: DirectoryOrCreate
         name: mountpoint-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.13/pmem-csi-lvm.yaml
@@ -193,7 +193,7 @@ spec:
             path: pmem-csi-registry.key
           secretName: pmem-csi-registry-secrets
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -244,7 +244,7 @@ spec:
           type: DirectoryOrCreate
         name: coverage-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node-testing
@@ -290,7 +290,7 @@ spec:
           type: DirectoryOrCreate
         name: mountpoint-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.14/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct.yaml
@@ -214,7 +214,7 @@ spec:
             path: pmem-csi-registry.key
           secretName: pmem-csi-registry-secrets
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -244,7 +244,7 @@ spec:
           type: DirectoryOrCreate
         name: coverage-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node-testing
@@ -290,7 +290,7 @@ spec:
           type: DirectoryOrCreate
         name: mountpoint-dir
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -214,7 +214,7 @@ spec:
             path: pmem-csi-registry.key
           secretName: pmem-csi-registry-secrets
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node

--- a/deploy/kubernetes-1.16
+++ b/deploy/kubernetes-1.16
@@ -1,0 +1,1 @@
+kubernetes-1.14

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -85,7 +85,7 @@ spec:
             path: pmem-csi-registry.key
 ---
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: pmem-csi-node
 spec:

--- a/deploy/kustomize/kubernetes-1.13-direct-coverage/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13-direct-coverage/kustomization.yaml
@@ -10,7 +10,7 @@ patchesJson6902:
   path: ../testing/controller-coverage-patch.yaml
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/node-coverage-patch.yaml

--- a/deploy/kustomize/kubernetes-1.13-direct-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13-direct-testing/kustomization.yaml
@@ -19,7 +19,7 @@ patchesJson6902:
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/args-two-containers-patch.yaml

--- a/deploy/kustomize/kubernetes-1.13-direct/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13-direct/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 patchesJson6902:
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../patches/direct-patch.yaml

--- a/deploy/kustomize/kubernetes-1.13-lvm-coverage/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13-lvm-coverage/kustomization.yaml
@@ -11,13 +11,13 @@ patchesJson6902:
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/node-coverage-patch.yaml
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/lvm-coverage-patch.yaml

--- a/deploy/kustomize/kubernetes-1.13-lvm-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13-lvm-testing/kustomization.yaml
@@ -19,14 +19,14 @@ patchesJson6902:
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/args-two-containers-patch.yaml
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/args-two-initcontainers-patch.yaml

--- a/deploy/kustomize/kubernetes-1.13-lvm/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.13-lvm/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 patchesJson6902:
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../patches/lvm-patch.yaml

--- a/deploy/kustomize/kubernetes-1.14-direct-coverage/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.14-direct-coverage/kustomization.yaml
@@ -11,7 +11,7 @@ patchesJson6902:
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/node-coverage-patch.yaml

--- a/deploy/kustomize/kubernetes-1.14-direct-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.14-direct-testing/kustomization.yaml
@@ -19,7 +19,7 @@ patchesJson6902:
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/args-two-containers-patch.yaml

--- a/deploy/kustomize/kubernetes-1.14-direct/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.14-direct/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 patchesJson6902:
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../patches/direct-patch.yaml

--- a/deploy/kustomize/kubernetes-1.14-lvm-coverage/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.14-lvm-coverage/kustomization.yaml
@@ -11,13 +11,13 @@ patchesJson6902:
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/node-coverage-patch.yaml
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/lvm-coverage-patch.yaml

--- a/deploy/kustomize/kubernetes-1.14-lvm-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.14-lvm-testing/kustomization.yaml
@@ -19,14 +19,14 @@ patchesJson6902:
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/args-two-containers-patch.yaml
 
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../testing/args-two-initcontainers-patch.yaml

--- a/deploy/kustomize/kubernetes-1.14-lvm/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.14-lvm/kustomization.yaml
@@ -6,7 +6,7 @@ bases:
 patchesJson6902:
 - target:
     group: apps
-    version: v1beta2
+    version: v1
     kind: DaemonSet
     name: pmem-csi-node
   path: ../patches/lvm-patch.yaml

--- a/deploy/kustomize/testing/socat.yaml
+++ b/deploy/kustomize/testing/socat.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - port: 10001 # port inside the pod where controller-socat-path.yaml forwards the csi.sock
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pmem-csi-node-testing

--- a/test/setup-deployment.sh
+++ b/test/setup-deployment.sh
@@ -6,7 +6,7 @@ set -o pipefail
 TEST_DIRECTORY=${TEST_DIRECTORY:-$(dirname $(readlink -f $0))}
 source ${TEST_CONFIG:-${TEST_DIRECTORY}/test-config.sh}
 
-CLUSTER=${CLUSTER:-clear-govm}
+CLUSTER=${CLUSTER:-pmem-govm}
 REPO_DIRECTORY="${REPO_DIRECTORY:-$(dirname $(dirname $(readlink -f $0)))}"
 WORK_DIRECTORY="${WORK_DIRECTORY:-${REPO_DIRECTORY}/_work/${CLUSTER}}"
 KUBECTL="${KUBECTL:-${WORK_DIRECTORY}/ssh-${CLUSTER} kubectl}"

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Implements the first-boot configuration of the different virtual machines
+# for Fedora running in GoVM.
+#
+# This script runs *inside* the cluster. All setting env variables
+# used by it must be passed in explicitly via ssh and it must run as root.
+
+set -x
+set -o errexit # TODO: replace with explicit error checking and error messages.
+set -o pipefail
+
+HOSTNAME=${HOSTNAME:-$1}
+IPADDR=${IPADDR:-127.0.0.1}
+
+function error_handler(){
+    local line="${1}"
+    echo >&2 "ERROR: the command '${BASH_COMMAND}' at $0:${line} failed"
+}
+trap 'error_handler ${LINENO}' ERR
+
+# Always use Docker.
+cat <<'EOF' > /etc/yum.repos.d/docker-ce.repo
+[docker-ce-stable]
+name=Docker CE Stable - $basearch
+baseurl=https://download.docker.com/linux/centos/7/$basearch/stable
+enabled=1
+gpgcheck=1
+gpgkey=https://download.docker.com/linux/centos/gpg
+EOF
+packages+=" docker-ce"
+
+# For PMEM.
+packages+=" ndctl"
+
+# Some additional utilities.
+packages+=" device-mapper-persistent-data lvm2"
+
+# Install according to https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/
+modprobe br_netfilter
+echo 1 >/proc/sys/net/bridge/bridge-nf-call-iptables
+setenforce 0
+sed -i --follow-symlinks 's/SELINUX=enforcing/SELINUX=disabled/g' /etc/sysconfig/selinux
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+packages+=" kubelet kubeadm kubectl --disableexcludes=kubernetes"
+
+yum install -y $packages
+
+# Upstream kubelet looks in /opt/cni/bin, actual files are in
+# /usr/libexec/cni from
+# containernetworking-plugins-0.8.1-1.fc30.x86_64.
+mkdir -p /opt/cni
+ln -s /usr/libexec/cni /opt/cni/bin
+
+# Testing may involve a Docker registry running on the build host (see
+# TEST_LOCAL_REGISTRY and TEST_PMEM_REGISTRY). We need to trust that
+# registry, otherwise Docker will fail to pull images from it.
+mkdir -p /etc/docker
+cat >/etc/docker/daemon.json <<EOF
+{ "insecure-registries": [ $(echo $INSECURE_REGISTRIES | sed 's|^|"|g;s| |", "|g;s|$|"|') ] }
+EOF
+
+# Proxy settings for Docker.
+mkdir -p /etc/systemd/system/docker.service.d/
+cat >/etc/systemd/system/docker.service.d/proxy.conf <<EOF
+[Service]
+Environment="HTTP_PROXY=$HTTP_PROXY" "HTTPS_PROXY=$HTTPS_PROXY" "NO_PROXY=$NO_PROXY"
+EOF
+
+# kubelet must start after the container runtime that it depends on.
+mkdir -p /etc/systemd/system/kubelet.service.d
+cat >/etc/systemd/system/kubelet.service.d/10-cri.conf <<EOF
+[Unit]
+After=docker.service
+EOF
+
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+systemctl daemon-reload
+systemctl enable --now docker kubelet

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -82,6 +82,13 @@ $kubeadm_config_kubelet
 $kubeadm_config_cluster
 EOF
 
+# We install old Kubernetes releases on current distros and must
+# disable the kernel preflight check for that to work, because those
+# old releases do not necessarily have a recent kernel in their
+# whitelist (for example, 1.13.9 fails on Linux
+# 5.0.9-301.fc30.x86_64).
+kubeadm_args="$kubeadm_args --ignore-preflight-errors=SystemVerification"
+
 kubeadm_args_init="$kubeadm_args_init --config=$kubeadm_config_file"
 sudo kubeadm init $kubeadm_args $kubeadm_args_init
 mkdir -p $HOME/.kube

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -52,11 +52,11 @@ nodeRegistration:
 	exit 1
 	;;
 esac
+
 # Needed for flannel (https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes).
 kubeadm_config_cluster="$kubeadm_config_cluster
 networking:
   podSubnet: \"10.244.0.0/16\""
-
 
 if [ ! -z ${TEST_FEATURE_GATES} ]; then
     kubeadm_config_kubelet="$kubeadm_config_kubelet
@@ -105,7 +105,9 @@ kubectl get pods --all-namespaces
 ${TEST_CONFIGURE_POST_MASTER}
 
 # From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/bc79dd1505b0c8681ece4de4c0d86c5cd2643275/Documentation/kube-flannel.yml
+# However, the commit currently listed there for 1.16 is broken. Current master fixes some issues
+# and works.
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/2140ac876ef134e0ed5af15c65e414cf26827915/Documentation/kube-flannel.yml
 
 # Install addon storage CRDs, needed if certain feature gates are enabled.
 # Only applicable to Kubernetes 1.13 and older. 1.14 will have them as builtin APIs.

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -348,8 +348,8 @@ EOF
 
         vm_name=$(govm list -f '{{select (filterRegexp . "IP" "'${ip}'") "Name"}}') || die "could not find VM name for $ip"
         log_name=${WORKING_DIRECTORY}/${vm_name}.log
-        ( ssh $SSH_ARGS ${CLOUD_USER}@${ip} "$ENV_VARS sudo $join_token" &&
-          ssh $SSH_ARGS ${CLOUD_USER}@${master_ip} "kubectl label --overwrite node $vm_name storage=pmem" ) </dev/null &> >(log_lines "$vm_name" "$log_name") &
+        ( ssh $SSH_ARGS ${CLOUD_USER}@${ip} "set -x; $ENV_VARS sudo ${join_token/kubeadm/kubeadm --ignore-preflight-errors=SystemVerification}" &&
+          ssh $SSH_ARGS ${CLOUD_USER}@${master_ip} "set -x; kubectl label --overwrite node $vm_name storage=pmem" ) </dev/null &> >(log_lines "$vm_name" "$log_name") &
         pids+=" $!"
     done
     waitall $pids || die "at least one worker failed to join the cluster"

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -133,9 +133,11 @@ EOF
 
         # We need a qcow image, otherwise copy-on-write does not work
         # (https://github.com/govm-project/govm/blob/08f276f574f9ad6cad29f7c8fde070a4eb542b06/startvm#L25-L29)
-        # and the different machines conflict with each other.
+        # and the different machines conflict with each other. We cannot call qemu-img directly (might not be
+        # installed), but we can use docker and the https://hub.docker.com/r/govm/govm image because we depend
+        # on both already.
         if ! file ${CLOUD_IMAGE} | grep -q "QEMU QCOW"; then
-            qemu-img convert -O qcow2 ${CLOUD_IMAGE} ${CLOUD_IMAGE}.tmp && mv ${CLOUD_IMAGE}.tmp ${CLOUD_IMAGE} || die "conversion to qcow2 format failed"
+            docker run --rm --volume `pwd`:/resources --entrypoint /usr/bin/qemu-img govm/govm -- convert -O qcow2 /resources/${CLOUD_IMAGE} /resources/${CLOUD_IMAGE}.tmp && mv ${CLOUD_IMAGE}.tmp ${CLOUD_IMAGE} || die "conversion to qcow2 format failed"
         fi
     fi
 

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -24,7 +24,7 @@ FLAVOR="${FLAVOR:-medium}"
 SSH_KEY="${SSH_KEY:-${RESOURCES_DIRECTORY}/id_rsa}"
 SSH_PUBLIC_KEY="${SSH_KEY}.pub"
 KVM_CPU_OPTS="${KVM_CPU_OPTS:-\
- -m 2G,slots=${TEST_MEM_SLOTS:-2},maxmem=34G -smp 4\
+ -m 4G,slots=${TEST_MEM_SLOTS:-2},maxmem=36G -smp 4\
  -machine pc,accel=kvm,nvdimm=on}"
 EXTRA_QEMU_OPTS="${EXTRA_QWEMU_OPTS:-\
  -object memory-backend-file,id=mem1,share=${TEST_PMEM_SHARE:-on},\

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -99,6 +99,9 @@ fi
 # (https://github.com/clearlinux/distribution/issues/85).
 : ${TEST_CHECK_SIGNED_FILES:=true}
 
+# The operating system to install inside the nodes.
+: ${TEST_OS:=clear}
+
 # If set to a number, that version of Clear Linux is installed
 # instead of the latest one.
-: ${TEST_CLEAR_LINUX_VERSION:=}
+: ${TEST_DISTRO_VERSION:=}

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -105,3 +105,9 @@ fi
 # If set to a number, that version of Clear Linux is installed
 # instead of the latest one.
 : ${TEST_DISTRO_VERSION:=}
+
+# If set to a <major>.<minor> number, that version of Kubernetes
+# is installed instead of the latest one. Ignored when
+# using Clear Linux as OS because with Clear Linux we have
+# to use the Kubernetes version that ships with it.
+: ${TEST_KUBERNETES_VERSION:=1.16}


### PR DESCRIPTION
This enables booting Fedora in the virtual cluster and installing arbitrary Kubernetes versions on it. The CI gets switched over to Fedora to get rid of the hack with testing on old, obsolete Clear Linux versions.
