### PR TITLE
CI: performance monitoring + improvements

### DIFF
--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -70,6 +70,21 @@ apiServer:
     feature-gates: ${TEST_FEATURE_GATES}"
 fi
 
+if [ -e /dev/vdc ]; then
+    # We have an extra volume specifically for etcd (see TEST_ETCD_VOLUME_SIZE).
+    sudo mkdir -p /mnt/etcd-volume
+    sudo mkfs.ext4 /dev/vdc
+    sudo mount /dev/vdc /mnt/etcd-volume
+    # etcd wants an empty directory, giving it the volume fails due to "lost+found".
+    sudo mkdir /mnt/etcd-volume/etcd
+    sudo chmod a+rwx /mnt/etcd-volume/etcd
+    kubeadm_config_cluster="$kubeadm_config_cluster
+etcd:
+  local:
+    dataDir: /mnt/etcd-volume/etcd
+"
+fi
+
 # TODO: it is possible to set up each node in parallel, see
 # https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#automating-kubeadm
 

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -82,8 +82,15 @@ function die() {
 }
 
 function download() {
+    # Sometimes we just have a temporary connection issue or bad mirror, try repeatedly.
     echo >&2 "Downloading ${IMAGE_URL}/${CLOUD_IMAGE} image"
-    curl --fail --location --output "${CLOUD_IMAGE}" "${IMAGE_URL}/${CLOUD_IMAGE}" || die "failed to download ${IMAGE_URL}/${CLOUD_IMAGE}"
+    local cnt=0
+    while ! curl --fail --location --output "${CLOUD_IMAGE}" "${IMAGE_URL}/${CLOUD_IMAGE}"; do
+        if [ $cnt -ge 5 ]; then
+            die "Download failed repeatedly, giving up."
+        fi
+        cnt=$(($cnt + 1))
+    done
 }
 
 function download_image() (

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -31,6 +31,16 @@ EXTRA_QEMU_OPTS="${EXTRA_QWEMU_OPTS:-\
 mem-path=/data/nvdimm0,size=${TEST_PMEM_MEM_SIZE}M \
  -device nvdimm,id=nvdimm1,memdev=mem1,label-size=${TEST_PMEM_LABEL_SIZE} \
  -machine pc,nvdimm}"
+EXTRA_MASTER_ETCD_VOLUME=
+
+
+# We might already be running as root, for example inside the
+# CI's build container.
+if [ $(id -u) -eq 0 ]; then
+    SUDO=env
+else
+    SUDO=sudo
+fi
 
 # Set distro-specific defaults.
 case ${TEST_DISTRO} in
@@ -151,6 +161,25 @@ EOF
     echo "$CLOUD_IMAGE"
 ) 200>$LOCKFILE
 
+
+# Create a tmpfs volume for etcd. It will become /dev/vdc inside
+# the master VMs where it will be used by setup-kubernetes.sh.
+# The file must be in the "data" directory used for master,
+# because that directory is available inside the Docker
+# container where QEMU runs.
+function setup_etcd_volume() (
+    if [ "${TEST_ETCD_VOLUME_SIZE}" -gt 0 ]; then
+        etcd_volume_path="${WORKING_DIRECTORY}/data/pmem-csi-${CLUSTER}-master/etcd-volume"
+        # Unmount old volume, in case that the size changed and to get rid of old data.
+        $SUDO umount --lazy "${etcd_volume_path}" >/dev/null 2>&1|| true
+        mkdir -p "${etcd_volume_path}"
+        $SUDO mount -osize="${TEST_ETCD_VOLUME_SIZE}" -t tmpfs none "${etcd_volume_path}" || die "failed to mount tmpfs with size ${TEST_ETCD_VOLUME_SIZE} on ${etcd_volume_path}"
+        etcd_volume_disk="${etcd_volume_path}/disk"
+        $SUDO truncate --size="${TEST_ETCD_VOLUME_SIZE}" "${etcd_volume_disk}" || die "failed to enlarge disk file ${etcd_volume_disk} to size ${TEST_ETCD_VOLUME_SIZE}"
+        echo "${etcd_volume_path}"
+    fi
+)
+
 function print_govm_yaml() (
     cat  <<EOF
 ---
@@ -172,7 +201,7 @@ EOF
         ${KVM_CPU_OPTS}
       - |
         EXTRA_QEMU_OPTS=
-        ${EXTRA_QEMU_OPTS}
+        ${EXTRA_QEMU_OPTS} $(if [[ "$node" =~ -master$ ]] && [ "$EXTRA_MASTER_ETCD_VOLUME" ]; then echo "-drive file=/data/$(basename "$EXTRA_MASTER_ETCD_VOLUME")/disk,if=virtio,format=raw"; fi )
 EOF
     done
 )
@@ -194,7 +223,16 @@ function create_vms() (
         cat <<EOF
 #!/bin/bash -e
 $(for i in $machines; do echo govm remove $i; done)
-rm -rf ${WORKING_DIRECTORY}
+if [ '${EXTRA_MASTER_ETCD_VOLUME}' ] && mount | grep -q '${EXTRA_MASTER_ETCD_VOLUME}'; then
+    # Somehow the volume was still busy in the CI (mount propagation too slow?).
+    # --lazy was meant to force removal of the mount point from the
+    # filesystem, but ...
+    $SUDO umount --lazy '${EXTRA_MASTER_ETCD_VOLUME}'
+    # ... "rm -rf" still failed with "etcd-volume busy". We simply ignore that.
+    rm -rf ${WORKING_DIRECTORY} || true
+else
+    rm -rf ${WORKING_DIRECTORY}
+fi
 EOF
     ) > $STOP_VMS_SCRIPT && chmod +x $STOP_VMS_SCRIPT || die "failed to create $STOP_VMS_SCRIPT"
 
@@ -393,6 +431,9 @@ function cleanup() (
         for vm in $(govm list -f '{{select (filterRegexp . "Name" "^'${DEPLOYMENT_ID}'-(master|worker[[:digit:]]+)$") "Name"}}'); do
             govm remove "$vm"
         done
+        if [ "${EXTRA_MASTER_ETCD_VOLUME}" ] && mount | grep -q "${EXTRA_MASTER_ETCD_VOLUME}"; then
+            $SUDO umount --lazy "${EXTRA_MASTER_ETCD_VOLUME}"
+        fi
         rm -rf $WORKING_DIRECTORY
     fi
 )
@@ -401,6 +442,7 @@ check_status # exits if nothing to do
 trap cleanup EXIT
 
 if init_workdir &&
+   EXTRA_MASTER_ETCD_VOLUME=$(setup_etcd_volume) &&
    CLOUD_IMAGE=$(download_image) &&
    create_vms &&
    init_kubernetes_cluster; then

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -20,16 +20,16 @@ NODES=( $DEPLOYMENT_ID-master
         $DEPLOYMENT_ID-worker2
         $DEPLOYMENT_ID-worker3)
 CLOUD="${CLOUD:-true}"
-FLAVOR="${FLAVOR:-medium}"
+FLAVOR="${FLAVOR:-medium}" # actual memory size and CPUs selected below
 SSH_KEY="${SSH_KEY:-${RESOURCES_DIRECTORY}/id_rsa}"
 SSH_PUBLIC_KEY="${SSH_KEY}.pub"
 KVM_CPU_OPTS="${KVM_CPU_OPTS:-\
- -m 4G,slots=${TEST_MEM_SLOTS:-2},maxmem=36G -smp 4\
+ -m ${TEST_NORMAL_MEM_SIZE}M,slots=${TEST_MEM_SLOTS},maxmem=$((${TEST_NORMAL_MEM_SIZE} + ${TEST_PMEM_MEM_SIZE}))M -smp ${TEST_NUM_CPUS} \
  -machine pc,accel=kvm,nvdimm=on}"
 EXTRA_QEMU_OPTS="${EXTRA_QWEMU_OPTS:-\
- -object memory-backend-file,id=mem1,share=${TEST_PMEM_SHARE:-on},\
-mem-path=/data/nvdimm0,size=${TEST_PMEM_MEM_SIZE:-32768}M \
- -device nvdimm,id=nvdimm1,memdev=mem1,label-size=${TEST_PMEM_LABEL_SIZE:-2097152} \
+ -object memory-backend-file,id=mem1,share=${TEST_PMEM_SHARE},\
+mem-path=/data/nvdimm0,size=${TEST_PMEM_MEM_SIZE}M \
+ -device nvdimm,id=nvdimm1,memdev=mem1,label-size=${TEST_PMEM_LABEL_SIZE} \
  -machine pc,nvdimm}"
 
 # Set distro-specific defaults.

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -78,7 +78,7 @@ fi
 : ${TEST_PMEM_LABEL_SIZE:=2097152}
 
 # Number of CPUS in QEMU VM. Must be at least 2 for Kubernetes.
-: ${TEST_NUM_CPUS:=4}
+: ${TEST_NUM_CPUS:=2}
 
 # The etcd instance running on the master node can be configured to
 # store its data in a tmpfs volume that gets created on the build

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -80,6 +80,15 @@ fi
 # Number of CPUS in QEMU VM. Must be at least 2 for Kubernetes.
 : ${TEST_NUM_CPUS:=4}
 
+# The etcd instance running on the master node can be configured to
+# store its data in a tmpfs volume that gets created on the build
+# host. This is useful when the _work directory is on a slow disk
+# because that can lead to slow performance and failures
+# (https://github.com/kubernetes/kubernetes/issues/70082).
+#
+# This is the size of that volume in bytes, zero disables this feature.
+: ${TEST_ETCD_VOLUME_SIZE:=0}
+
 # Kubernetes feature gates to enable/disable
 # featurename=true,feature=false
 : ${TEST_FEATURE_GATES:=CSINodeInfo=true,CSIDriverRegistry=true}

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -77,6 +77,9 @@ fi
 : ${TEST_PMEM_SHARE:=on}
 : ${TEST_PMEM_LABEL_SIZE:=2097152}
 
+# Number of CPUS in QEMU VM. Must be at least 2 for Kubernetes.
+: ${TEST_NUM_CPUS:=4}
+
 # Kubernetes feature gates to enable/disable
 # featurename=true,feature=false
 : ${TEST_FEATURE_GATES:=CSINodeInfo=true,CSIDriverRegistry=true}


### PR DESCRIPTION
We see timeouts between VMs and network issues. The etcd container log provided the smoking gun: etcd IO was taking too long. Putting it's data into a ramdisk solved that.

Together with a retry-loop for Fedora downloads the CI is now stable and faster than before thanks to the tuning of the number of CPUs: https://cloudnative-k8sci.southcentralus.cloudapp.azure.com/job/pmem-csi/view/change-requests/job/PR-426/



