### PR TITLE
Jenkinsfile: add timestamps option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 pipeline {
+    options {
+        timestamps()
+    }
     agent {
         label "pmem-csi"
     }


### PR DESCRIPTION
Jobs timings have differences that are not easy to understand, for example why "Create Build Env" sometimes takes 4 and some other time 17 minutes.
Seeing timestamps of CI is overall useful IMHO, so lets see does that clause activate those.