### PR TITLE
build: restore automatic building of images during 'docker push'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build-image build-test-image: build%-image:
 PUSH_IMAGE_DEP = build%-image
 # "docker push" has been seen to fail temporarily with "error creating overlay mount to /var/lib/docker/overlay2/xxx/merged: device or resource busy".
 # Here we simply try three times before giving up.
-push-image push-test-image: push%-image: # $(PUSH_IMAGE_DEP)
+push-image push-test-image: push%-image: $(PUSH_IMAGE_DEP)
 	@ i=0; while true; do \
 		if (set -x; docker push $(IMAGE_TAG)); then \
 			exit 0; \


### PR DESCRIPTION
https://github.com/intel/pmem-csi/pull/430 unintentionally disabled
the make dependencies. That was used during debugging and shouldn't
have been included in the PR.