### PR TITLE
WIP: #447 + add repeated node tests (vendor) + tolerate repeated node ops

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -252,15 +252,15 @@
   version = "v0.6.1"
 
 [[projects]]
-  digest = "1:652c938b1510b21f775fcea8cadd523a9f7706f117e08338e9efdba7edd6662f"
+  digest = "1:e2ec36588cab12eed6abce39593398f5d37e53746801d6ebf793a608e3345a69"
   name = "github.com/kubernetes-csi/csi-test"
   packages = [
     "pkg/sanity",
     "utils",
   ]
   pruneopts = "UT"
-  revision = "82b05190c167c52bb6d5aaf2e1d7c833fa539783"
-  version = "v2.2.0"
+  revision = "6931aedb3df0224d9d2e463316315cdcffaf6192"
+  version = "v2.3.0"
 
 [[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
@@ -1268,6 +1268,8 @@
     "github.com/kubernetes-csi/csi-test/pkg/sanity",
     "github.com/kubernetes-csi/csi-test/utils",
     "github.com/onsi/ginkgo",
+    "github.com/onsi/ginkgo/config",
+    "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",
     "github.com/pkg/errors",
     "golang.org/x/net/context",
@@ -1299,6 +1301,7 @@
     "k8s.io/kubernetes/pkg/volume/util/hostutil",
     "k8s.io/kubernetes/test/e2e/framework",
     "k8s.io/kubernetes/test/e2e/framework/config",
+    "k8s.io/kubernetes/test/e2e/framework/ginkgowrapper",
     "k8s.io/kubernetes/test/e2e/framework/pod",
     "k8s.io/kubernetes/test/e2e/framework/podlogs",
     "k8s.io/kubernetes/test/e2e/framework/ssh",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,7 @@
 
 [[constraint]]
   name = "github.com/kubernetes-csi/csi-test"
-  version = "2.1.0"
+  version = "2.3.0"
 
 # We have to select the right version by name because of the "kubernetes-" prefix, dep doesn't
 # recognize these as normal releases. Upstream is considering to change the tagging,

--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -241,7 +241,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	volumeMutex.LockKey(req.GetVolumeId())
 	defer volumeMutex.UnlockKey(req.GetVolumeId())
 
-	// showing for debug:
 	klog.V(4).Infof("NodeStageVolume: VolumeID:%v Staging target path:%v Requested fsType:%v",
 		req.GetVolumeId(), stagingtargetPath, requestedFsType)
 
@@ -257,6 +256,27 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		klog.Errorf("NodeStageVolume: determineFilesystemType failed: %v", err)
 		return nil, err
 	}
+	if existingFsType != "" && existingFsType != requestedFsType {
+		klog.Errorf("NodeStageVolume: File system with different type %v exists on %s",
+			existingFsType, device.Path)
+		return nil, status.Error(codes.AlreadyExists, "File system with different type exists")
+	}
+	// Check is something already mounted to stagingtargetPath
+	mounter := mount.New("")
+	mountedDev, _, err := mount.GetDeviceNameFromMount(mounter, stagingtargetPath)
+	if err != nil {
+		klog.Errorf("NodeStageVolume: Error getting device name for mount")
+		return nil, err
+	}
+	if mountedDev == device.Path {
+		klog.V(4).Infof("NodeStageVolume: Device %s already mounted to path %s", mountedDev, stagingtargetPath)
+		// Check are the capabilities compatible.
+		if existingFsType == requestedFsType {
+			// If fstype compatible, return OK.
+			klog.V(4).Infof("NodeStageVolume: Device:%s fsType:%s matches", mountedDev, requestedFsType)
+			return &csi.NodeStageVolumeResponse{}, nil
+		}
+	}
 
 	// what to do if existing file system is detected and is different from request;
 	// forced re-format would lead to loss of previous data, so we refuse.
@@ -265,37 +285,29 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		// Is existing filesystem type same as requested?
 		if existingFsType == requestedFsType {
 			klog.V(4).Infof("Skip mkfs as %v file system already exists on %v", existingFsType, device.Path)
-		} else {
-			klog.Errorf("NodeStageVolume: File system with different type %v exist on %v",
-				existingFsType, device.Path)
-			return nil, status.Error(codes.InvalidArgument, "File system with different type exists")
 		}
 	} else {
 		// no existing file system, make fs
-		// Empty FsType means "unspecified" and we pick default, currently hard-codes to ext4
 		cmd := ""
 		args := []string{}
-		// hard-code block size to 4k to avoid smaller values and trouble to dax mount option
-		if requestedFsType == "ext4" || requestedFsType == "" {
+		// requestedFsType can't be empty here as it is set to ext4 above in case of empty
+		if requestedFsType == "ext4" {
 			cmd = "mkfs.ext4"
+			// hard-code block size to 4k to avoid smaller values and trouble to dax mount option
 			args = []string{"-b 4096", "-F", device.Path}
 		} else if requestedFsType == "xfs" {
 			cmd = "mkfs.xfs"
 			args = []string{"-b", "size=4096", "-f", device.Path}
 		} else {
 			klog.Errorf("NodeStageVolume: Unsupported fstype: %v", requestedFsType)
-			return nil, status.Error(codes.InvalidArgument, "xfs, ext4 are supported as file system types")
+			return nil, status.Error(codes.Unimplemented, "xfs, ext4 are supported as file system types")
 		}
 		output, err := pmemexec.RunCommand(cmd, args...)
 		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, "mkfs failed: "+output)
+			return nil, status.Error(codes.Unknown, "mkfs failed: "+output)
 		}
 	}
 
-	// If file system is already mounted, can happen if out-of-sync "stage" is asked again without unstage
-	// then the mount here will fail. I guess it's ok to not check explicitly for existing mount,
-	// as end result after mount attempt will be same: no new mount and existing mount remains.
-	// TODO: cleaner is to explicitly check (although CSI spec may tell that out-of-order call is illegal (check it))
 	klog.V(5).Infof("NodeStageVolume: mount %s %s", device.Path, stagingtargetPath)
 
 	/* THIS is how it could go with using "mount" package
@@ -326,7 +338,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	args = append(args, device.Path, stagingtargetPath)
 	klog.V(4).Infof("NodeStageVolume: mount args: [%v]", args)
 	if _, err := pmemexec.RunCommand("mount", args...); err != nil {
-		return nil, status.Error(codes.InvalidArgument, "mount filesystem failed"+err.Error())
+		return nil, status.Error(codes.Unknown, "mount filesystem failed"+err.Error())
 	}
 
 	return &csi.NodeStageVolumeResponse{}, nil

--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -60,6 +60,7 @@ var _ = Describe("sanity", func() {
 	workerSocatAddresses := []string{}
 	config := sanity.Config{
 		TestVolumeSize: 1 * 1024 * 1024,
+		IdempotentCount: 4,
 		// The actual directories will be created as unique
 		// temp directories inside these directories.
 		// We intentionally do not use the real /var/lib/kubelet/pods as

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go
@@ -66,6 +66,208 @@ func isPluginCapabilitySupported(c csi.IdentityClient,
 	return false
 }
 
+func runControllerTest(sc *SanityContext, c  csi.NodeClient, s  csi.ControllerClient, cl *Cleanup, controllerPublishSupported bool, nodeStageSupported         bool, nodeVolumeStatsSupported   bool, count int) {
+
+	name := UniqueString("sanity-node-full")
+
+	By("getting node information")
+	ni, err := c.NodeGetInfo(
+		context.Background(),
+		&csi.NodeGetInfoRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ni).NotTo(BeNil())
+	Expect(ni.GetNodeId()).NotTo(BeEmpty())
+
+	var accReqs *csi.TopologyRequirement
+	if ni.AccessibleTopology != nil {
+		// Topology requirements are honored if provided by the driver
+		accReqs = &csi.TopologyRequirement{
+			Requisite: []*csi.Topology{ni.AccessibleTopology},
+		}
+	}
+
+	// Create Volume First
+	By("creating a single node writer volume")
+	vol, err := s.CreateVolume(
+		context.Background(),
+		&csi.CreateVolumeRequest{
+			Name: name,
+			VolumeCapabilities: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+			Secrets:                   sc.Secrets.CreateVolumeSecret,
+			Parameters:                sc.Config.TestVolumeParameters,
+			AccessibilityRequirements: accReqs,
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(vol).NotTo(BeNil())
+	Expect(vol.GetVolume()).NotTo(BeNil())
+	Expect(vol.GetVolume().GetVolumeId()).NotTo(BeEmpty())
+	cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetVolumeId()})
+
+	var conpubvol *csi.ControllerPublishVolumeResponse
+	if controllerPublishSupported {
+		By("controller publishing volume")
+
+		conpubvol, err = s.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{
+				VolumeId: vol.GetVolume().GetVolumeId(),
+				NodeId:   ni.GetNodeId(),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeContext: vol.GetVolume().GetVolumeContext(),
+				Readonly:      false,
+				Secrets:       sc.Secrets.ControllerPublishVolumeSecret,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetVolumeId(), NodeID: ni.GetNodeId()})
+		Expect(conpubvol).NotTo(BeNil())
+	}
+	// NodeStageVolume
+	if nodeStageSupported {
+		By("node staging volume")
+		for i := 0; i < count; i++ {
+			nodestagevol, err := c.NodeStageVolume(
+				context.Background(),
+				&csi.NodeStageVolumeRequest{
+					VolumeId: vol.GetVolume().GetVolumeId(),
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+					StagingTargetPath: sc.StagingPath,
+					VolumeContext:     vol.GetVolume().GetVolumeContext(),
+					PublishContext:    conpubvol.GetPublishContext(),
+					Secrets:           sc.Secrets.NodeStageVolumeSecret,
+				},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodestagevol).NotTo(BeNil())
+		}
+	}
+	// NodePublishVolume
+	By("publishing the volume on a node")
+	var stagingPath string
+	if nodeStageSupported {
+		stagingPath = sc.StagingPath
+	}
+	for i := 0; i < count; i++ {
+		nodepubvol, err := c.NodePublishVolume(
+			context.Background(),
+			&csi.NodePublishVolumeRequest{
+				VolumeId:          vol.GetVolume().GetVolumeId(),
+				TargetPath:        sc.TargetPath + "/target",
+				StagingTargetPath: stagingPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeContext:  vol.GetVolume().GetVolumeContext(),
+				PublishContext: conpubvol.GetPublishContext(),
+				Secrets:        sc.Secrets.NodePublishVolumeSecret,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodepubvol).NotTo(BeNil())
+	}
+	// NodeGetVolumeStats
+	if nodeVolumeStatsSupported {
+		By("Get node volume stats")
+		statsResp, err := c.NodeGetVolumeStats(
+			context.Background(),
+			&csi.NodeGetVolumeStatsRequest{
+				VolumeId:   vol.GetVolume().GetVolumeId(),
+				VolumePath: sc.TargetPath + "/target",
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(statsResp.GetUsage()).ToNot(BeNil())
+	}
+
+	for i := 0; i < count; i++ {
+		// NodeUnpublishVolume
+		By("cleaning up calling nodeunpublish")
+		nodeunpubvol, err := c.NodeUnpublishVolume(
+			context.Background(),
+			&csi.NodeUnpublishVolumeRequest{
+				VolumeId:   vol.GetVolume().GetVolumeId(),
+				TargetPath: sc.TargetPath + "/target",
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeunpubvol).NotTo(BeNil())
+	}
+
+	if nodeStageSupported {
+		for i := 0; i < count; i++ {
+			By("cleaning up calling nodeunstage")
+			nodeunstagevol, err := c.NodeUnstageVolume(
+				context.Background(),
+				&csi.NodeUnstageVolumeRequest{
+					VolumeId:          vol.GetVolume().GetVolumeId(),
+					StagingTargetPath: sc.StagingPath,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeunstagevol).NotTo(BeNil())
+		}
+	}
+
+	if controllerPublishSupported {
+		for i := 0; i < count; i++ {
+			By("cleaning up calling controllerunpublishing")
+
+			controllerunpubvol, err := s.ControllerUnpublishVolume(
+				context.Background(),
+				&csi.ControllerUnpublishVolumeRequest{
+					VolumeId: vol.GetVolume().GetVolumeId(),
+					NodeId:   ni.GetNodeId(),
+					Secrets:  sc.Secrets.ControllerUnpublishVolumeSecret,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(controllerunpubvol).NotTo(BeNil())
+		}
+	}
+
+	By("cleaning up deleting the volume")
+
+	for i := 0; i < count; i++ {
+		_, err = s.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				VolumeId: vol.GetVolume().GetVolumeId(),
+				Secrets:  sc.Secrets.DeleteVolumeSecret,
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+
 var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 	var (
 		cl *Cleanup
@@ -645,191 +847,21 @@ var _ = DescribeSanity("Node Service", func(sc *SanityContext) {
 			Skip("Controller Service not provided: CreateVolume not supported")
 		}
 
-		name := UniqueString("sanity-node-full")
-
-		By("getting node information")
-		ni, err := c.NodeGetInfo(
-			context.Background(),
-			&csi.NodeGetInfoRequest{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ni).NotTo(BeNil())
-		Expect(ni.GetNodeId()).NotTo(BeEmpty())
-
-		var accReqs *csi.TopologyRequirement
-		if ni.AccessibleTopology != nil {
-			// Topology requirements are honored if provided by the driver
-			accReqs = &csi.TopologyRequirement{
-				Requisite: []*csi.Topology{ni.AccessibleTopology},
-			}
+		By("runControllerTest")
+		runControllerTest(sc, c, s, cl, controllerPublishSupported, nodeStageSupported, nodeVolumeStatsSupported, 1)
+	})
+	It("should be idempotent", func() {
+		if !providesControllerService {
+			Skip("Controller Service not provided: CreateVolume not supported")
 		}
-
-		// Create Volume First
-		By("creating a single node writer volume")
-		vol, err := s.CreateVolume(
-			context.Background(),
-			&csi.CreateVolumeRequest{
-				Name: name,
-				VolumeCapabilities: []*csi.VolumeCapability{
-					{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-				},
-				Secrets:                   sc.Secrets.CreateVolumeSecret,
-				Parameters:                sc.Config.TestVolumeParameters,
-				AccessibilityRequirements: accReqs,
-			},
-		)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(vol).NotTo(BeNil())
-		Expect(vol.GetVolume()).NotTo(BeNil())
-		Expect(vol.GetVolume().GetVolumeId()).NotTo(BeEmpty())
-		cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetVolumeId()})
-
-		var conpubvol *csi.ControllerPublishVolumeResponse
-		if controllerPublishSupported {
-			By("controller publishing volume")
-
-			conpubvol, err = s.ControllerPublishVolume(
-				context.Background(),
-				&csi.ControllerPublishVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					NodeId:   ni.GetNodeId(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					VolumeContext: vol.GetVolume().GetVolumeContext(),
-					Readonly:      false,
-					Secrets:       sc.Secrets.ControllerPublishVolumeSecret,
-				},
-			)
-			Expect(err).NotTo(HaveOccurred())
-			cl.RegisterVolume(name, VolumeInfo{VolumeID: vol.GetVolume().GetVolumeId(), NodeID: ni.GetNodeId()})
-			Expect(conpubvol).NotTo(BeNil())
+		if sc.Config.IdempotentCount < 0 {
+			Skip("Config.IdempotentCount is negative, skip tests")
 		}
-		// NodeStageVolume
-		if nodeStageSupported {
-			By("node staging volume")
-			nodestagevol, err := c.NodeStageVolume(
-				context.Background(),
-				&csi.NodeStageVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					VolumeCapability: &csi.VolumeCapability{
-						AccessType: &csi.VolumeCapability_Mount{
-							Mount: &csi.VolumeCapability_MountVolume{},
-						},
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-						},
-					},
-					StagingTargetPath: sc.StagingPath,
-					VolumeContext:     vol.GetVolume().GetVolumeContext(),
-					PublishContext:    conpubvol.GetPublishContext(),
-					Secrets:           sc.Secrets.NodeStageVolumeSecret,
-				},
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nodestagevol).NotTo(BeNil())
+		count := sc.Config.IdempotentCount
+		if count == 0 {
+			count = 10
 		}
-		// NodePublishVolume
-		By("publishing the volume on a node")
-		var stagingPath string
-		if nodeStageSupported {
-			stagingPath = sc.StagingPath
-		}
-		nodepubvol, err := c.NodePublishVolume(
-			context.Background(),
-			&csi.NodePublishVolumeRequest{
-				VolumeId:          vol.GetVolume().GetVolumeId(),
-				TargetPath:        sc.TargetPath + "/target",
-				StagingTargetPath: stagingPath,
-				VolumeCapability: &csi.VolumeCapability{
-					AccessType: &csi.VolumeCapability_Mount{
-						Mount: &csi.VolumeCapability_MountVolume{},
-					},
-					AccessMode: &csi.VolumeCapability_AccessMode{
-						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-					},
-				},
-				VolumeContext:  vol.GetVolume().GetVolumeContext(),
-				PublishContext: conpubvol.GetPublishContext(),
-				Secrets:        sc.Secrets.NodePublishVolumeSecret,
-			},
-		)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(nodepubvol).NotTo(BeNil())
-
-		// NodeGetVolumeStats
-		if nodeVolumeStatsSupported {
-			By("Get node volume stats")
-			statsResp, err := c.NodeGetVolumeStats(
-				context.Background(),
-				&csi.NodeGetVolumeStatsRequest{
-					VolumeId:   vol.GetVolume().GetVolumeId(),
-					VolumePath: sc.TargetPath + "/target",
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(statsResp.GetUsage()).ToNot(BeNil())
-		}
-
-		// NodeUnpublishVolume
-		By("cleaning up calling nodeunpublish")
-		nodeunpubvol, err := c.NodeUnpublishVolume(
-			context.Background(),
-			&csi.NodeUnpublishVolumeRequest{
-				VolumeId:   vol.GetVolume().GetVolumeId(),
-				TargetPath: sc.TargetPath + "/target",
-			})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(nodeunpubvol).NotTo(BeNil())
-
-		if nodeStageSupported {
-			By("cleaning up calling nodeunstage")
-			nodeunstagevol, err := c.NodeUnstageVolume(
-				context.Background(),
-				&csi.NodeUnstageVolumeRequest{
-					VolumeId:          vol.GetVolume().GetVolumeId(),
-					StagingTargetPath: sc.StagingPath,
-				},
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nodeunstagevol).NotTo(BeNil())
-		}
-
-		if controllerPublishSupported {
-			By("cleaning up calling controllerunpublishing")
-
-			controllerunpubvol, err := s.ControllerUnpublishVolume(
-				context.Background(),
-				&csi.ControllerUnpublishVolumeRequest{
-					VolumeId: vol.GetVolume().GetVolumeId(),
-					NodeId:   ni.GetNodeId(),
-					Secrets:  sc.Secrets.ControllerUnpublishVolumeSecret,
-				},
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(controllerunpubvol).NotTo(BeNil())
-		}
-
-		By("cleaning up deleting the volume")
-
-		_, err = s.DeleteVolume(
-			context.Background(),
-			&csi.DeleteVolumeRequest{
-				VolumeId: vol.GetVolume().GetVolumeId(),
-				Secrets:  sc.Secrets.DeleteVolumeSecret,
-			},
-		)
-		Expect(err).NotTo(HaveOccurred())
+		By("runControllerTest with Idempotent count")
+		runControllerTest(sc, c, s, cl, controllerPublishSupported, nodeStageSupported, nodeVolumeStatsSupported, count)
 	})
 })

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
@@ -127,6 +127,16 @@ type Config struct {
 	// it will be set to a DefaultIDGenerator instance when
 	// passing the config to Test or GinkgoTest.
 	IDGen IDGenerator
+
+	// Repeat count for Volume operations to test idempotency requirements.
+	// csi-test/pkg/sanity/node.go:runControllerTest() optionally runs
+	// added variant set of tests which repeats those Volume operations
+	// that are required to be idempotent, based on this count value.
+	// -1 : Skip idempotency test
+	//  0 : Use default value, 10 repetitions
+	//  n : repeat n times
+	// Note that missing explicit value leads to default repetition count.
+	IdempotentCount int
 }
 
 // SanityContext holds the variables that each test can depend on. It


### PR DESCRIPTION
This is continuation of #393 but rebased onto csi test 2.3.0 as in #447
Resolves #386 : improves NodeStageVolume to handle repeated requests
Resolves #411 : improves NodePublishVolume to handle repeated requests
Resolves #403 : Adds Volume existence check in NodeUnpublishVolume