### PR TITLE
test: Remove leftover traces of Kubernetes 1.13

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -73,8 +73,8 @@ var _ = Describe("PMEM Volumes", func() {
 					},
 				},
 				scManifest: map[string]string{
-					"ext4": "deploy/kubernetes-1.13/pmem-storageclass-ext4.yaml",
-					"xfs":  "deploy/kubernetes-1.13/pmem-storageclass-xfs.yaml",
+					"ext4": "deploy/common/pmem-storageclass-ext4.yaml",
+					"xfs":  "deploy/common/pmem-storageclass-xfs.yaml",
 				},
 				// We use 16Mi size volumes because this is the minimum size supported
 				// by xfs filesystem's allocation group


### PR DESCRIPTION
In commit 2e9fde49, we dropped support for v1.13, but tests are still pointing to
storage class files in deploy/kubernetes-1.13. This change fixes this by
pointing to deploy/common.