### PR TITLE
set classname in junit file to group tests

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -54,7 +54,7 @@ func csiTunePattern(patterns []testpatterns.TestPattern) []testpatterns.TestPatt
 	return tunedPatterns
 }
 
-var _ = Describe("PMEM Volumes", func() {
+var _ = Describe("E2E", func() {
 	// List of testDrivers to be executed in below loop
 	var csiTestDrivers = []func() testsuites.TestDriver{
 		// pmem-csi


### PR DESCRIPTION
What matters for Jenkins seems to be the classname. By turning
that into <testrun>.<first word of test> we get a nicer grouping.