### PR TITLE
test/test.make: add test/ to gofmt checking path set

### DIFF
--- a/test/e2e/storage/latebinding.go
+++ b/test/e2e/storage/latebinding.go
@@ -29,8 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 )
 
 // TestDynamicLateBindingProvisioning is a variant of k8s.io/kubernetes/test/e2e/storage/testsuites/provisioning.go

--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -43,9 +43,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	clientexec "k8s.io/client-go/util/exec"
 	"k8s.io/kubernetes/test/e2e/framework"
-	testutils "k8s.io/kubernetes/test/utils"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	testutils "k8s.io/kubernetes/test/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test/test.make
+++ b/test/test.make
@@ -9,7 +9,7 @@ test: vet
 .PHONY: test_fmt fmt
 test: test_fmt
 test_fmt:
-	@ files=$$(find pkg cmd -name '*.go'); \
+	@ files=$$(find pkg cmd test -name '*.go'); \
 	if [ $$(gofmt -d $$files | wc -l) -ne 0 ]; then \
 		echo "formatting errors:"; \
 		gofmt -d $$files; \


### PR DESCRIPTION
test/ was left out of gofmt checking and some formatting
errors have been slipped in there.