### PR TITLE
images: fix content of /usr/local

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,5 @@
 ! pkg/**
 ! test/test-config.d/**
 ! test/test-config.sh
+! hack/copy-modules-license.sh
 ! vendor/**

--- a/hack/copy-modules-license.sh
+++ b/hack/copy-modules-license.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright 2019 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copy the licenses of ".Deps" modules for a package to a target directory
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# -lt 2 ] || [ "$1" = "?" ] || [ "$1" = "--help" ]; then
+	echo "Usage: $0 <license target dir> <package> ..." >&2
+	exit 1
+fi
+
+licensedir=$1
+shift
+
+if [ ! -d "$licensedir" ] || [ ! -w "$licensedir" ]; then
+	echo "Error: cannot use $licensedir as the license target directory"
+	exit 1
+fi
+
+LICENSE_FILES=$(find vendor |grep -e LICENSE -e NOTICE|cut -d / -f 2-)
+PACKAGE_DEPS=$(go list -f '{{ join .Deps "\n" }}' "$@" |grep "\.")
+
+pushd vendor > /dev/null
+
+for lic in $LICENSE_FILES; do
+	# Copy the license if its repository path is found in package .Deps
+	if [ $(echo $PACKAGE_DEPS | grep -c `dirname $lic`) -gt 0 ]; then
+		cp -t "$licensedir" --parent $lic
+	fi
+done
+
+popd > /dev/null


### PR DESCRIPTION
Because both PMEM binaries and the Go toolchain were installed into
/go and the runtime image contained all of /go/bin, we ended up also
copying the Go toolchain.

License files for everything that goes into our /usr/local are
important. 3-clause BSD requires that the copright notice is
reproduced in "other materials provided with the distribution", which
we comply with by copying the license file and its copyright remark
into the image.

hack/copy-modules-license was originally developed for
https://github.com/intel/intel-device-plugins-for-kubernetes/pull/232
and adapted to PMEM-CSI here (multiple packages, no dependency on "go
mod", etc.)