### PR TITLE
Volume leak test: use ssh Output instead of CombinedOutput

### DIFF
--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -1023,7 +1023,9 @@ func GetHostVolumes() map[string][]string {
 	for worker := 1; ; worker++ {
 		sshcmd := fmt.Sprintf("%s/_work/%s/ssh.%d", os.Getenv("REPO_ROOT"), os.Getenv("CLUSTER"), worker)
 		ssh := exec.Command(sshcmd, cmd)
-		out, err := ssh.CombinedOutput()
+		// Intentional Output instead of CombinedOutput to dismiss warnings from stderr.
+		// lvs may emit lvmetad-related WARNING msg which can't be silenced using -q option.
+		out, err := ssh.Output()
 		if err != nil && os.IsNotExist(err) {
 			break
 		}


### PR DESCRIPTION
Warnings from stderr, for example lvmetad-related warning,
can not be silenced with lvs -q option, and are printed
to stderr. We are not interested in parsing warnings,
so we can consider stdout only, as far as command
execution succeeded.

Resolves #468