### PR TITLE
Go version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@
 ! pkg/**
 ! test/test-config.d/**
 ! test/test-config.sh
-! hack/copy-modules-license.sh
+! hack/**
 ! vendor/**
 ! go.mod
 ! go.sum

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,15 +49,18 @@ Build PMEM-CSI
 
 See the [Makefile](Makefile) for additional make targets and possible make variables.
 
+The source code gets developed and tested using the version of Go that
+is set with `GO_VERSION` in the [Dockerfile](Dockerfile). Some other
+version may or may not work. In particular, `test_fmt` and
+`test_vendor` are known to be sensitive to the version of Go.
+
 Code quality
 ============
 
 Coding style
 ------------
 
-The normal Go style guide applies. It is enforced by `make test`, which calls `gofmt`. `gofmt` should be
-from Go >= v1.11.4, older versions (like v1.10) format the code slightly differently.
-Running `go test` requires go 1.12 or newer.
+The normal Go style guide applies. It is enforced by `make test`, which calls `gofmt`.
 
 
 Input validation

--- a/hack/verify-go-version.sh
+++ b/hack/verify-go-version.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GO="$1"
+
+if [ ! "$GO" ]; then
+    echo >&2 "usage: $0 <path to go binary>"
+    exit 1
+fi
+
+die () {
+    echo "ERROR: $*"
+    exit 1
+}
+
+version=$("$GO" version) || die "determining version of $GO failed"
+# shellcheck disable=SC2001
+majorminor=$(echo "$version" | sed -e 's/.*go\([0-9]*\)\.\([0-9]*\).*/\1.\2/')
+# shellcheck disable=SC2001
+expected=$(grep "^ARG GO_VERSION" Dockerfile | sed -e 's/.*GO_VERSION *= *"*\([0-9]*\)\.\([0-9]*\).*/\1.\2/')
+
+if [ "$majorminor" != "$expected" ]; then
+    cat >&2 <<EOF
+
+======================================================
+                  WARNING
+
+  This projects is tested with Go v$expected.
+  Your current Go version is v$majorminor.
+  This may or may not be close enough.
+
+  In particular test_fmt and test_vendor
+  are known to be sensitive to the version of
+  Go.
+======================================================
+
+EOF
+fi

--- a/test/test.make
+++ b/test/test.make
@@ -198,7 +198,7 @@ _work/coverage.out: _work/gocovmerge-$(GOCOVMERGE_VERSION)
 	$< _work/coverage/* >$@
 
 _work/coverage.html: _work/coverage.out
-	$(G0) tool cover -html $< -o $@
+	$(GO) tool cover -html $< -o $@
 
 _work/coverage.txt: _work/coverage.out
 	$(GO) tool cover -func $< -o $@

--- a/test/test.make
+++ b/test/test.make
@@ -2,7 +2,7 @@ TEST_CMD=$(GO) test
 TEST_ARGS=$(IMPORT_PATH)/pkg/...
 
 .PHONY: vet
-test: vet
+test: vet check-go-version-$(GO_BINARY)
 	$(GO) vet $(IMPORT_PATH)/pkg/...
 
 # Check resp. fix formatting.
@@ -59,7 +59,7 @@ test_vendor:
 .PHONY: test_runtime_deps
 test: test_runtime_deps
 
-test_runtime_deps:
+test_runtime_deps: check-go-version-$(GO_BINARY)
 	@ if ! diff -c \
 		runtime-deps.csv \
 		<( $(RUNTIME_DEPS) ); then \
@@ -146,7 +146,7 @@ test_e2e: start
 test: run_tests
 RUN_TESTS = TEST_WORK=$(abspath _work) \
 	$(TEST_CMD) $(shell $(GO) list $(TEST_ARGS) | sed -e 's;$(IMPORT_PATH);.;')
-run_tests: _work/pmem-ca/.ca-stamp _work/evil-ca/.ca-stamp
+run_tests: _work/pmem-ca/.ca-stamp _work/evil-ca/.ca-stamp check-go-version-$(GO_BINARY)
 	$(RUN_TESTS)
 
 _work/%/.ca-stamp: test/setup-ca.sh _work/.setupcfssl-stamp
@@ -200,7 +200,7 @@ _work/coverage.out: _work/gocovmerge-$(GOCOVMERGE_VERSION)
 _work/coverage.html: _work/coverage.out
 	$(GO) tool cover -html $< -o $@
 
-_work/coverage.txt: _work/coverage.out
+_work/coverage.txt: _work/coverage.out check-go-version-$(GO_BINARY)
 	$(GO) tool cover -func $< -o $@
 
 .PHONY: coverage


### PR DESCRIPTION
Fixes a typo (G0 instad of GO) and adds a warning that tells developers when they are using a different Go version.
