### PR TITLE
CI: run under normal user inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,7 @@ ARG GO_VERSION="1.13.4"
 #pull dependencies required for downloading and building libndctl
 ARG CACHEBUST
 RUN echo "Updating build image from ${CLEAR_LINUX_BASE} to ${SWUPD_UPDATE_ARG:-the latest release}."
-# openssh-client and sudo are needed for CI testing. They are small enough that it doesn't
-# affect developers that they get installed here, but it is a small saving in the CI
-# because then the installation can be cached.
-RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} c-basic openssh-client sudo && rm -rf /var/lib/swupd /var/tmp/swupd
-
+RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} c-basic && rm -rf /var/lib/swupd /var/tmp/swupd
 # Workaround for "pkg-config: error while loading shared libraries" when using older Docker
 # (see https://github.com/clearlinux/distribution/issues/831)
 RUN ldconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ ARG GO_VERSION="1.13.4"
 #pull dependencies required for downloading and building libndctl
 ARG CACHEBUST
 RUN echo "Updating build image from ${CLEAR_LINUX_BASE} to ${SWUPD_UPDATE_ARG:-the latest release}."
-RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} c-basic && rm -rf /var/lib/swupd /var/tmp/swupd
+# openssh-client and sudo are needed for CI testing. They are small enough that it doesn't
+# affect developers that they get installed here, but it is a small saving in the CI
+# because then the installation can be cached.
+RUN swupd update ${SWUPD_UPDATE_ARG} && swupd bundle-add ${NDCTL_BUILD_DEPS} c-basic openssh-client sudo && rm -rf /var/lib/swupd /var/tmp/swupd
+
 # Workaround for "pkg-config: error while loading shared libraries" when using older Docker
 # (see https://github.com/clearlinux/distribution/issues/831)
 RUN ldconfig

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
           valid values:
           etcd kube-apiserver kube-controller-manager kube-scheduler
         */
-        LOGGING_PODS = ""
+        LOGGING_PODS = " " // the space is intentional, otherwise ${env.LOGGING_PODS} expands to null below
 
         /*
           For each major Kubernetes release we need one version of Clear Linux

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,6 +127,11 @@ pipeline {
                     sh "docker create --name=builder -it ${env.BUILD_IMAGE}"
                     sh "docker start builder"
 
+                    // Install additional tools:
+                    // - ssh client for govm
+                    // - sudo for non-privileged user
+                    sh "docker exec builder swupd bundle-add openssh-client sudo"
+
                     // Allow non-root users to become root via sudo when they are part of the root group.
                     // ${DockerBuildArgs()} includes the necessary parameters for that.
                     sh "docker exec builder mkdir /etc/sudoers.d"

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -447,7 +447,7 @@ function init_workdir() (
     (
         flock -x -w $LOCKDELAY 200
         if [ ! -e  "$SSH_KEY" ]; then
-            ssh-keygen -N '' -f ${SSH_KEY} &>/dev/null || die "failed to create ${SSH_KEY}"
+            ssh-keygen -N '' -f ${SSH_KEY} >/dev/null || die "failed to create ${SSH_KEY}"
         fi
     ) 200>$LOCKFILE
 )


### PR DESCRIPTION
The recently added vendor check rewrites "vendor" inside Docker, which
later broken working with the repo because those files then became
owned by root.

We could run "sudo chown" after each "docker run" invocation, but it
is safer and faster to not run as root inside Docker in the first
place.