### PR TITLE
update Clear Linux and CRI support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 ! **/*.make
+! Dockerfile
 ! LICENSE
 ! Makefile
 ! cmd/**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,8 +126,8 @@ pipeline {
                     sh "env; echo Building BUILD_IMAGE=${env.BUILD_IMAGE} for BUILD_TARGET=${env.BUILD_TARGET}, CHANGE_ID=${env.CHANGE_ID}, CACHEBUST=${env.CACHEBUST}."
                     sh "docker build --cache-from ${env.BUILD_IMAGE} --label cachebust=${env.CACHEBUST} --target build --build-arg CACHEBUST=${env.CACHEBUST} -t ${env.BUILD_IMAGE} ."
                     // Create a running container (https://stackoverflow.com/a/38308399).
-                    sh "docker create --name=builder -it ${env.BUILD_IMAGE}"
-                    sh "docker start builder"
+                    sh "docker create --name=builder ${env.BUILD_IMAGE} sleep infinity"
+                    sh "docker start builder && \
                         timeout=0; \
                         while [ \$(docker inspect --format '{{.State.Status}}' builder) != running ]; do \
                             docker ps; \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,17 @@ pipeline {
                     // Create a running container (https://stackoverflow.com/a/38308399).
                     sh "docker create --name=builder -it ${env.BUILD_IMAGE}"
                     sh "docker start builder"
+                        timeout=0; \
+                        while [ \$(docker inspect --format '{{.State.Status}}' builder) != running ]; do \
+                            docker ps; \
+                            if [ \$timeout -ge 60 ]; then \
+                               docker inspect builder; \
+                               echo 'ERROR: builder container still not running'; \
+                               exit 1; \
+                            fi; \
+                            sleep 10; \
+                            timeout=\$((timeout + 10)); \
+                       done"
 
                     // Install additional tools:
                     // - ssh client for govm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,8 @@ pipeline {
           the control plane is unsupported.
         */
 
+        CLEAR_LINUX_VERSION_1_16 = "31760" // latest version right now
+
         CLEAR_LINUX_VERSION_1_15 = "31070"
         /* 29890 broke networking
         (https://github.com/clearlinux/distribution/issues/904). In
@@ -243,13 +245,13 @@ pipeline {
           Therefore it is faster.
         */
 
-        stage('production 1.15, Clear Linux') {
+        stage('production 1.16, Clear Linux') {
             options {
                 timeout(time: 90, unit: "MINUTES")
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "production", "clear", "${env.CLEAR_LINUX_VERSION_1_15}", "")
+                TestInVM("lvm", "production", "clear", "${env.CLEAR_LINUX_VERSION_1_16}", "")
             }
         }
 

--- a/test/setup-clear-govm.sh
+++ b/test/setup-clear-govm.sh
@@ -171,6 +171,16 @@ EOF
             ln -s $i /opt/cni/bin/
         done
 
+        # Switch to systemd cgroup driver (https://kubernetes.io/docs/setup/production-environment/container-runtimes/#cgroup-drivers):
+        # "Changing the settings such that your container runtime and kubelet use systemd as the cgroup driver stabilized the system."
+        # It's already the default in cri-o in recent Clear Linux. Docker and containerd might need further work.
+        #
+        # Not sure which file is used on Clear Linux, simply set both.
+        for config in /etc/default/kubelet /etc/sysconfig/kubelet; do
+            mkdir -p $(dirname $config)
+            echo 'KUBELET_EXTRA_ARGS=--cgroup-driver=systemd' >$config
+        done
+
         # Reconfiguration done, start daemons. Starting kubelet must wait until kubeadm has created
         # the necessary config files.
         systemctl daemon-reload

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -36,17 +36,17 @@ kind: KubeProxyConfiguration"
 kubeadm_config_file="/tmp/kubeadm-config.yaml"
 
 case $TEST_CRI in
-	docker)
-		cri_daemon=docker
-		# [ERROR SystemVerification]: unsupported docker version: 18.06.1
-		kubeadm_args="$kubeadm_args --ignore-preflight-errors=SystemVerification"
+    docker)
+	# [ERROR SystemVerification]: unsupported docker version: 18.06.1
+	kubeadm_args="$kubeadm_args --ignore-preflight-errors=SystemVerification"
 	;;
-	crio)
-		cri_daemon=cri-o
-		# Needed for CRI-O (https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes).
-		kubeadm_config_init="$kubeadm_config_init
+    crio)
+	# Needed for CRI-O (https://clearlinux.org/documentation/clear-linux/tutorials/kubernetes).
+	kubeadm_config_init="$kubeadm_config_init
 nodeRegistration:
   criSocket: /run/crio/crio.sock"
+	;;
+    containerd)
 	;;
     *)
 	echo "ERROR: unsupported TEST_CRI=$TEST_CRI"

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -132,7 +132,13 @@ cat ${kubeadm_config_file}
 kubeadm_args="$kubeadm_args --ignore-preflight-errors=SystemVerification"
 
 kubeadm_args_init="$kubeadm_args_init --config=$kubeadm_config_file"
-sudo kubeadm init $kubeadm_args $kubeadm_args_init
+sudo kubeadm init $kubeadm_args $kubeadm_args_init || (
+    set +e
+    # Dump some information that might explain the failure.
+    sudo systemctl status docker crio containerd kubelet
+    sudo journalctl -xe -u docker -u crio -u containerd -u kubelet
+    exit 1
+)
 mkdir -p $HOME/.kube
 sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -156,7 +156,7 @@ ${TEST_CONFIGURE_POST_MASTER}
 # From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network
 # However, the commit currently listed there for 1.16 is broken. Current master fixes some issues
 # and works.
-kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/2140ac876ef134e0ed5af15c65e414cf26827915/Documentation/kube-flannel.yml
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/960b3243b9a7faccdfe7b3c09097105e68030ea7/Documentation/kube-flannel.yml
 
 # Install addon storage CRDs, needed if certain feature gates are enabled.
 # Only applicable to Kubernetes 1.13 and older. 1.14 will have them as builtin APIs.

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -9,16 +9,9 @@ set -x
 set -o errexit # TODO: replace with explicit error checking and messages
 set -o pipefail
 
-: ${TEST_CREATE_REGISTRY:=false}
-
 function error_handler(){
         local line="${1}"
         echo >&2 "ERROR: command '${BASH_COMMAND}' in function ${FUNCNAME[1]} at $0:${line} failed"
-}
-
-function create_local_registry(){
-trap 'error_handler ${LINENO}' ERR
-sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
 }
 
 function setup_kubernetes_master(){
@@ -182,7 +175,4 @@ ${TEST_CONFIGURE_POST_ALL}
 
 if [[ "$HOSTNAME" == *"master"* ]]; then
 	setup_kubernetes_master
-    if $TEST_CREATE_REGISTRY; then
-	    create_local_registry
-    fi
 fi

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -35,35 +35,18 @@ fi
 # on. Here we default to the IP address of the docker0 interface.
 : ${TEST_LOCAL_REGISTRY:=$(ip addr show dev docker0 2>/dev/null | (grep " inet " || echo localhost) | sed -e 's/.* inet //' -e 's;/.*;;'):5000}
 
-# Set up a Docker registry on the master node.
-: ${TEST_CREATE_REGISTRY:=false}
-
 # The registry used for PMEM-CSI image(s). Must be reachable from
-# inside the cluster. The default is the registry on the master
-# node if that is enabled, otherwise a registry on the build
-# host.
-: ${TEST_PMEM_REGISTRY:=$(if ${TEST_CREATE_REGISTRY}; then echo pmem-csi-${CLUSTER}-master:5000; else echo ${TEST_LOCAL_REGISTRY}; fi)}
+# inside the cluster.
+: ${TEST_PMEM_REGISTRY:=${TEST_LOCAL_REGISTRY}}
 
 # The same registry reachable from the build host.
-# This is needed for "make push-images". Pushing
-# to the registry on the master node (TEST_CREATE_REGISTRY=true)
-# is only supported when making additional changes on the
-# build host (like enabling insecure access to that registry)
-# and therefore the default is always a local registry.
+# This is needed for "make push-images".
 : ${TEST_BUILD_PMEM_REGISTRY:=localhost:5000}
 
 # Additional insecure registries (for example, my-registry:5000),
 # separated by spaces. The default local registry above is always
 # marked as insecure and does not need to be listed.
 : ${TEST_INSECURE_REGISTRIES:=}
-
-# When using TEST_CREATE_REGISTRY, some images can be copied into
-# that registry to boot-strap the cluster.
-#
-# To use this, do:
-# - make build-images
-# - TEST_CREATE_REGISTRY=true make start
-: ${TEST_BOOTSTRAP_IMAGES:=${TEST_BUILD_PMEM_REGISTRY}/pmem-csi-driver:canary ${TEST_BUILD_PMEM_REGISTRY}/pmem-csi-driver-test:canary}
 
 # Additional Clear Linux bundles.
 : ${TEST_CLEAR_LINUX_BUNDLES:=storage-utils}

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -15,7 +15,7 @@ if [ -d test/test-config.d ]; then
 fi
 
 # The container runtime that is meant to be used inside Clear Linux.
-# Possible values are "docker" and "crio".
+# Possible values are "docker", "containerd", and "crio".
 #
 # Docker is the default for two reasons:
 # - survives killing the VMs while cri-o doesn't (https://github.com/kubernetes-sigs/cri-o/issues/1742#issuecomment-442384980)

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -14,13 +14,20 @@ if [ -d test/test-config.d ]; then
     done
 fi
 
-# The container runtime that is meant to be used inside Clear Linux.
-# Possible values are "docker", "containerd", and "crio".
+# The operating system to install inside the nodes.
+: ${TEST_DISTRO:=clear}
+
+# Choose the version of the operating system that gets installed. Valid
+# values depend on the OS.
+: ${TEST_DISTRO_VERSION:=}
+
+# The container runtime that is meant to be used.
+# Possible values are "docker", "containerd", and "crio". Non-default
+# values are untested and may or may not work.
 #
-# Docker is the default for two reasons:
-# - survives killing the VMs while cri-o doesn't (https://github.com/kubernetes-sigs/cri-o/issues/1742#issuecomment-442384980)
-# - Docker mounts /sys read/write while cri-o read-only. pmem-csi needs it in writable state.
-: ${TEST_CRI:=docker}
+# cri-o is the default on Clear Linux because that is supported better
+# and Docker elsewhere because we can install it easily.
+: ${TEST_CRI:=$(case ${TEST_DISTRO} in clear) echo crio;; *) echo docker;; esac)}
 
 # A local registry running on the build host, aka localhost:5000.
 # In order to reach it from inside the virtual cluster, we need
@@ -110,13 +117,6 @@ fi
 # on the version of OpenSSL on the build host
 # (https://github.com/clearlinux/distribution/issues/85).
 : ${TEST_CHECK_SIGNED_FILES:=true}
-
-# The operating system to install inside the nodes.
-: ${TEST_OS:=clear}
-
-# If set to a number, that version of Clear Linux is installed
-# instead of the latest one.
-: ${TEST_DISTRO_VERSION:=}
 
 # If set to a <major>.<minor> number, that version of Kubernetes
 # is installed instead of the latest one. Ignored when


### PR DESCRIPTION
We should better test with a recent Clear Linux. On that release we can also enable "containerd" as runtime.
