### PR TITLE
Use Fedora-31 cloud image for testers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
                     if command -v apt-get >/dev/null 2>&1; then \
                         sudo apt-get install procps; \
                     else \
-                        sudo yum -y install procps; \
+                        sudo dnf -y install procps; \
                     fi'
                 sh 'head -n 30 /proc/cpuinfo; echo ...; tail -n 30 /proc/cpuinfo'
                 sh "git remote set-url origin git@github.com:intel/pmem-csi.git"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 # tests using that address try to go through the proxy.
 HTTP_PROXY=$(shell echo "$${HTTP_PROXY:-$${http_proxy}}")
 HTTPS_PROXY=$(shell echo "$${HTTPS_PROXY:-$${https_proxy}}")
-NO_PROXY=$(shell echo "$${NO_PROXY:-$${no_proxy}},$$(ip addr | grep inet6 | grep /64 | sed -e 's;.*inet6 \(.*\)/64 .*;\1;' | tr '\n' ','; ip addr | grep -w inet | grep -e '/\(24\|16\|8\)' | sed -e 's;.*inet \(.*\)/\(24\|16\|8\) .*;\1;' | tr '\n' ',')",0.0.0.0,10.0.2.15)
+NO_PROXY=$(shell echo "$${NO_PROXY:-$${no_proxy}},$$(ip addr | grep inet6 | grep /64 | sed -e 's;.*inet6 \(.*\)/64 .*;\1;' | tr '\n' ','; ip addr | grep -w inet | grep -e '/\(24\|16\|8\)' | sed -e 's;.*inet \(.*\)/\(24\|16\|8\) .*;\1;' | tr '\n' ',')",0.0.0.0)
 export HTTP_PROXY HTTPS_PROXY NO_PROXY
 
 REGISTRY_NAME?=$(shell . test/test-config.sh && echo $${TEST_BUILD_PMEM_REGISTRY})

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -20,6 +20,8 @@ function error_handler(){
 }
 trap 'error_handler ${LINENO}' ERR
 
+# add own name to /etc/hosts to avoid external name lookup(s) that produce warning by kubeadm
+echo "127.0.0.1 `hostname`" >> /etc/hosts
 
 # For PMEM.
 packages+=" ndctl"

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -37,7 +37,7 @@ enabled=1
 gpgcheck=1
 gpgkey=https://download.docker.com/linux/centos/gpg
 EOF
-    packages+=" docker-ce-3:19.03.2-3.el7"
+    packages+=" docker-ce-3:19.03.5-3.el7"
 
     # Install according to https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/
     modprobe br_netfilter
@@ -59,10 +59,10 @@ EOF
     # List generated with:
     # for v in 1.13 1.14 1.15 1.16; do for i in kubelet kubeadm kubectl; do echo "$i-$(sudo yum --showduplicates list kubelet | grep " $v"  | sed -e 's/.* \([0-9]*\.[0-9]*\.[0-9]*[^ ]*\).*/\1/' | sort -u  | tail -n 1)"; done; done
     case ${TEST_KUBERNETES_VERSION} in
-        1.13) packages+=" kubelet-1.13.9-0 kubeadm-1.13.9-0 kubectl-1.13.9-0";;
-        1.14) packages+=" kubelet-1.14.7-0 kubeadm-1.14.7-0 kubectl-1.14.7-0";;
-        1.15) packages+=" kubelet-1.15.4-0 kubeadm-1.15.4-0 kubectl-1.15.4-0";;
-        1.16) packages+=" kubelet-1.16.0-0 kubeadm-1.16.0-0 kubectl-1.16.0-0";;
+        1.13) packages+=" kubelet-1.13.12-0 kubeadm-1.13.12-0 kubectl-1.13.12-0";;
+        1.14) packages+=" kubelet-1.14.10-0 kubeadm-1.14.10-0 kubectl-1.14.10-0";;
+        1.15) packages+=" kubelet-1.15.8-0 kubeadm-1.15.8-0 kubectl-1.15.8-0";;
+        1.16) packages+=" kubelet-1.16.5-0 kubeadm-1.16.5-0 kubectl-1.16.5-0";;
         *) echo >&2 "Kubernetes version ${TEST_KUBERNETES_VERSION} not supported, package list in $0 must be updated."; exit 1;;
     esac
     packages+=" --disableexcludes=kubernetes"

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -90,8 +90,13 @@ if $INIT_KUBERNETES; then
     # Upstream kubelet looks in /opt/cni/bin, actual files are in
     # /usr/libexec/cni from
     # containernetworking-plugins-0.8.1-1.fc30.x86_64.
-    mkdir -p /opt/cni
-    ln -s /usr/libexec/cni /opt/cni/bin
+    # There is reason why we don't create symlink /opt/cni/bin -> /usr/libexec/cni.
+    # Some CNI variants (weave) try to add binaries, which fails if bin/ is symlink
+    # We create /opt/cni/bin containing symlinks for every binary:
+    mkdir -p /opt/cni/bin
+    for i in /usr/libexec/cni/*; do
+        ln -vs $i /opt/cni/bin/
+    done
 
     # Testing may involve a Docker registry running on the build host (see
     # TEST_LOCAL_REGISTRY and TEST_PMEM_REGISTRY). We need to trust that

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -80,9 +80,9 @@ while ! dnf install -y $packages; do
     fi
     cnt=$(($cnt + 1))
     # If it works, proceed immediately. If it fails, sleep and try again without aborting on an error.
-    if ! dnf update --refresh; then
+    if ! dnf update -y --refresh; then
         sleep 20
-        dnf update --refresh || true
+        dnf update -y --refresh || true
     fi
 done
 

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -57,7 +57,7 @@ EOF
 
     # For the sake of reproducibility, use fixed versions.
     # List generated with:
-    # for v in 1.13 1.14 1.15 1.16; do for i in kubelet kubeadm kubectl; do echo "$i-$(sudo yum --showduplicates list kubelet | grep " $v"  | sed -e 's/.* \([0-9]*\.[0-9]*\.[0-9]*[^ ]*\).*/\1/' | sort -u  | tail -n 1)"; done; done
+    # for v in 1.13 1.14 1.15 1.16; do for i in kubelet kubeadm kubectl; do echo "$i-$(sudo dnf --showduplicates list kubelet | grep " $v"  | sed -e 's/.* \([0-9]*\.[0-9]*\.[0-9]*[^ ]*\).*/\1/' | sort -u  | tail -n 1)"; done; done
     case ${TEST_KUBERNETES_VERSION} in
         1.13) packages+=" kubelet-1.13.12-0 kubeadm-1.13.12-0 kubectl-1.13.12-0";;
         1.14) packages+=" kubelet-1.14.10-0 kubeadm-1.14.10-0 kubectl-1.14.10-0";;
@@ -73,9 +73,9 @@ fi
 # suggests to try again after a `dnf update --refresh`, so that's what we do here for
 # a maximum of 5 attempts.
 cnt=0
-while ! yum install -y $packages; do
+while ! dnf install -y $packages; do
     if [ $cnt -ge 5 ]; then
-        echo "yum install failed repeatedly, giving up"
+        echo "dnf install failed repeatedly, giving up"
         exit 1
     fi
     cnt=$(($cnt + 1))

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -65,9 +65,10 @@ case ${TEST_DISTRO} in
     fedora)
         CLOUD_USER=${CLOUD_USER:-fedora}
         EFI=${EFI:-false}
-        TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-30}
+        TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-31}
+        FEDORA_CLOUDIMG_REL=${FEDORA_CLOUDIMG_REL:-1.9}
         IMAGE_URL=${IMAGE_URL:-https://download.fedoraproject.org/pub/fedora/linux/releases/${TEST_DISTRO_VERSION}/Cloud/x86_64/images}
-        CLOUD_IMAGE=${CLOUD_IMAGE:-Fedora-Cloud-Base-${TEST_DISTRO_VERSION}-1.2.x86_64.raw.xz}
+        CLOUD_IMAGE=${CLOUD_IMAGE:-Fedora-Cloud-Base-${TEST_DISTRO_VERSION}-${FEDORA_CLOUDIMG_REL}.x86_64.raw.xz}
         ;;
 esac
 


### PR DESCRIPTION
Trial to use Fedora-31 cloud image.
In my local setup, after I made these changes, kubernetes setup does not complete on master but fails with timeout. There is kubelet running on master, but networking seems to have problem:
Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady
Let's see does we see same in CI.