### PR TITLE
test: add individual machines to NO_PROXY

### DIFF
--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -219,6 +219,13 @@ function print_ips() (
     govm list -f '{{select (filterRegexp . "Name" "^'$(node_filter ${NODES[@]})'$") "IP"}}' | tac
 )
 
+function extend_no_proxy() (
+    for ip in $(print_ips); do
+        NO_PROXY+=",$ip"
+    done
+    echo "$NO_PROXY"
+)
+
 function create_vms() (
     setup_script="setup-${TEST_DISTRO}-govm.sh"
     STOP_VMS_SCRIPT="${WORKING_DIRECTORY}/stop.sh"
@@ -504,6 +511,7 @@ if init_workdir &&
    EXTRA_MASTER_ETCD_VOLUME=$(setup_etcd_volume) &&
    CLOUD_IMAGE=$(download_image) &&
    create_vms &&
+   NO_PROXY=$(extend_no_proxy) &&
    init_pmem_regions &&
    init_kubernetes_cluster; then
     FAILED=false


### PR DESCRIPTION
Extending NO_PROXY in create_vms only had an effect inside that
subshell. We explicitly need to make that change also in the outer
shell, otherwise kubeadm will fail to reach the API server because the
IP address is not on the exception list.