### PR TITLE
CI: speed up execution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -457,6 +457,7 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                   -e TEST_DEVICEMODE=${deviceMode} \
                   -e TEST_DEPLOYMENTMODE=${deploymentMode} \
                   -e TEST_CHECK_SIGNED_FILES=false \
+                  -e TEST_CHECK_KVM=false \
                   -e TEST_DISTRO=${distro} \
                   -e TEST_DISTRO_VERSION=${distroVersion} \
                   -e TEST_KUBERNETES_VERSION=${kubernetesVersion} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -510,7 +510,9 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                                loggers=\"\$loggers \$!\"; \
                            done && \
                            testrun=\$(echo '${distro}-${distroVersion}-${kubernetesVersion}-${deviceMode}-${deploymentMode}' | sed -e s/--*/-/g | tr . _ ) && \
-                           make test_e2e TEST_E2E_REPORT_DIR=${WORKSPACE}/build/reports.tmp/\$testrun' \
+                           make test_e2e TEST_E2E_REPORT_DIR=${WORKSPACE}/build/reports.tmp/\$testrun \
+                                         TEST_E2E_SKIP=\$(if [ \"${env.CHANGE_ID}\" ] && [ \"${env.CHANGE_ID}\" != null ]; then echo \\\\[Slow\\\\]; fi) \
+                           ' \
            "
     } finally {
         // Each test run produces junit_*.xml files with testsuite name="PMEM E2E suite".

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,13 +290,25 @@ pipeline {
           Therefore it is faster.
         */
 
-        stage('production 1.16, Clear Linux') {
+        stage('production 1.14 LVM') {
+            when { not { changeRequest() } }
             options {
-                timeout(time: 90, unit: "MINUTES")
+                timeout(time: 45, unit: "MINUTES")
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "production", "clear", "${env.CLEAR_LINUX_VERSION_1_16}", "")
+                TestInVM("lvm", "production", "fedora", "", "1.14")
+            }
+        }
+
+        stage('production 1.14 direct') {
+            when { not { changeRequest() } }
+            options {
+                timeout(time: 45, unit: "MINUTES")
+                retry(2)
+            }
+            steps {
+                TestInVM("direct", "production", "fedora", "", "1.14")
             }
         }
 
@@ -322,25 +334,13 @@ pipeline {
             }
         }
 
-        stage('production 1.14 LVM') {
-            when { not { changeRequest() } }
+        stage('production 1.16, Clear Linux') {
             options {
-                timeout(time: 45, unit: "MINUTES")
+                timeout(time: 90, unit: "MINUTES")
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "production", "fedora", "", "1.14")
-            }
-        }
-
-        stage('production 1.14 direct') {
-            when { not { changeRequest() } }
-            options {
-                timeout(time: 45, unit: "MINUTES")
-                retry(2)
-            }
-            steps {
-                TestInVM("direct", "production", "fedora", "", "1.14")
+                TestInVM("lvm", "production", "clear", "${env.CLEAR_LINUX_VERSION_1_16}", "")
             }
         }
 
@@ -470,7 +470,6 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
            loggers=\"\$loggers \$!\" && \
            ${RunInBuilder()} \
                   -e CLUSTER=${env.CLUSTER} \
-                  -e GOVM_YAML=${WORKSPACE}/_work/${env.CLUSTER}/deployment.yaml \
                   -e TEST_LOCAL_REGISTRY=\$(ip addr show dev docker0 | grep ' inet ' | sed -e 's/.* inet //' -e 's;/.*;;'):5000 \
                   -e TEST_DEVICEMODE=${deviceMode} \
                   -e TEST_DEPLOYMENTMODE=${deploymentMode} \
@@ -485,7 +484,13 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                            loggers=; \
                            atexit () { set -x; kill \$loggers; kill \$( ps --no-header -o %p ); }; \
                            trap atexit EXIT; \
+                           echo CLUSTER=\$CLUSTER TEST_LOCAL_REGISTRY=\$TEST_LOCAL_REGISTRY TEST_DISTRO=\$TEST_DISTRO TEST_DISTRO_VERSION=\$TEST_DISTRO_VERSION TEST_KUBERNETES_VERSION=\$TEST_KUBERNETES_VERSION >_work/new-cluster-config && \
+                           if [ -e _work/\$CLUSTER/cluster-config ] && ! diff _work/\$CLUSTER/cluster-config _work/new-cluster-config; then \
+                               echo QEMU cluster configuration has changed, need to stop old cluster. && \
+                               make stop; \
+                           fi && \
                            make start && \
+                           mv _work/new-cluster-config _work/\$CLUSTER/cluster-config && \
                            _work/${env.CLUSTER}/ssh.0 kubectl get pods --all-namespaces -o wide && \
                            for pod in ${env.LOGGING_PODS}; do \
                                _work/${env.CLUSTER}/ssh.0 kubectl logs -f -n kube-system \$pod-pmem-csi-${env.CLUSTER}-master | sed -e \"s/^/\$pod: /\" & \
@@ -520,8 +525,5 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                     sed -e "s/PMEM E2E suite/$testrun/" -e 's/testcase name="\\([^ ]*\\) *\\(.*\\)" classname="\\([^"]*\\)"/testcase classname="\\3.\\1" name="\\2"/' $i >build/reports/$testrun.xml
                fi
            done'''
-
-        // Always shut down the cluster to free up resources.
-        sh "${RunInBuilder()} -e CLUSTER=${env.CLUSTER} ${env.BUILD_CONTAINER} make stop"
     }
 }

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -79,9 +79,9 @@ scheduler:
 fi
 
 if [ -e /dev/vdc ]; then
-    # We have an extra volume specifically for etcd (see TEST_ETCD_VOLUME_SIZE).
+    # We have an extra volume specifically for etcd (see TEST_ETCD_VOLUME).
     sudo mkdir -p /mnt/etcd-volume
-    sudo mkfs.ext4 /dev/vdc
+    sudo mkfs.ext4 -F /dev/vdc
     sudo mount /dev/vdc /mnt/etcd-volume
     # etcd wants an empty directory, giving it the volume fails due to "lost+found".
     sudo mkdir /mnt/etcd-volume/etcd

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -453,7 +453,7 @@ function check_status() { # intentionally a composite command, so "exit" will ex
         fi
     fi
 
-    if [ ! -e /dev/kvm ]; then
+    if ${TEST_CHECK_KVM} && [ ! -e /dev/kvm ]; then
         echo "ERROR: /dev/kvm does not exist. KVM has to be enabled before starting the virtual cluster."
         exit 1
     fi

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -101,6 +101,16 @@ fi
 # (https://github.com/clearlinux/distribution/issues/85).
 : ${TEST_CHECK_SIGNED_FILES:=true}
 
+# "make start" tests that /dev/kvm exists before invoking govm because
+# when it is missing, the failure of QEMU inside the containers is
+# hard to diagnose.
+#
+# However, in some rather special circumstances it may be necessary to
+# disable this check. For example, the CI runs "make start" in a
+# non-privileged container without /dev/kvm whereas QEMU will run in
+# privileged containers where /dev/kvm is available.
+: ${TEST_CHECK_KVM:=true}
+
 # If set to a <major>.<minor> number, that version of Kubernetes
 # is installed instead of the latest one. Ignored when
 # using Clear Linux as OS because with Clear Linux we have

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -71,13 +71,15 @@ fi
 : ${TEST_NUM_CPUS:=2}
 
 # The etcd instance running on the master node can be configured to
-# store its data in a tmpfs volume that gets created on the build
-# host. This is useful when the _work directory is on a slow disk
+# store its data on a separate disk. This is the path to an existing
+# file of the desired size which will then be passed into the master
+# node via "-drive file=...". For that to work the file has
+# to be inside the "data" directory of the master node.
+#
+# This is useful when the _work directory is on a slow disk
 # because that can lead to slow performance and failures
 # (https://github.com/kubernetes/kubernetes/issues/70082).
-#
-# This is the size of that volume in bytes, zero disables this feature.
-: ${TEST_ETCD_VOLUME_SIZE:=0}
+: ${TEST_ETCD_VOLUME:=}
 
 # Kubernetes feature gates to enable/disable
 # featurename=true,feature=false

--- a/test/test.make
+++ b/test/test.make
@@ -121,12 +121,13 @@ run_tests: $(RUN_TEST_DEPS)
 	$(RUN_TESTS)
 
 # E2E tests which are known to be unsuitable (space separated list of regular expressions).
-TEST_E2E_SKIP = no-such-test
+TEST_E2E_SKIP =
+TEST_E2E_SKIP_ALL = no-such-test $(TEST_E2E_SKIP)
 
 # The test's check whether a driver supports multiple nodes is incomplete and does
 # not work for the topology-based single-node access in PMEM-CSI:
 # https://github.com/kubernetes/kubernetes/blob/25ffbe633810609743944edd42d164cd7990071c/test/e2e/storage/testsuites/provisioning.go#L175-L181
-TEST_E2E_SKIP += should.access.volume.from.different.nodes
+TEST_E2E_SKIP_ALL += should.access.volume.from.different.nodes
 
 # E2E tests which are to be executed (space separated list of regular expressions, default is all that aren't skipped).
 TEST_E2E_FOCUS =
@@ -156,7 +157,7 @@ RUN_E2E = KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
 	GO='$(GO)' \
 	TEST_PKGS='$(shell for i in $(TEST_PKGS); do if ls $$i/*_test.go 2>/dev/null >&2; then echo $$i; fi; done)' \
 	$(GO) test -count=1 -timeout 0 -v ./test/e2e \
-                -ginkgo.skip='$(subst $(space),|,$(TEST_E2E_SKIP))' \
+                -ginkgo.skip='$(subst $(space),|,$(TEST_E2E_SKIP_ALL))' \
                 -ginkgo.focus='$(subst $(space),|,$(TEST_E2E_FOCUS))' \
                 -report-dir=$(TEST_E2E_REPORT_DIR)
 test_e2e: start $(RUN_TEST_DEPS)

--- a/test/test.make
+++ b/test/test.make
@@ -150,7 +150,7 @@ RUN_E2E = KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
 	  echo TEST_DEPLOYMENTMODE=$$TEST_DEPLOYMENTMODE; \
 	  echo TEST_DEVICEMODE=$$TEST_DEVICEMODE; \
 	  echo TEST_KUBERNETES_VERSION=$$TEST_KUBERNETES_VERSION; \
-	  echo PMEM_CSI_IMAGE=$$TEST_LOCAL_REGISTRY/pmem-csi-driver$$(if $$TEST_DEPLOYMENTMODE = testing; then echo -test; fi):$(IMAGE_VERSION); \
+	  echo PMEM_CSI_IMAGE=$$TEST_LOCAL_REGISTRY/pmem-csi-driver$$(if [ $$TEST_DEPLOYMENTMODE = testing ]; then echo -test; fi):$(IMAGE_VERSION); \
 	) \
 	TEST_CMD='$(TEST_CMD)' \
 	GO='$(GO)' \


### PR DESCRIPTION
The last remaining reason for requiring sudo and --privileged was that
the scripts themselve set up a tmpfs for etcd. By moving that step out
into the build host we can remove the need for sudo inside the
container.

The etcd volume gets used repeatedly, therefore "mkfs.ext4" must be
forced to ignore an already existing filesystem.

We can switch back and forth between LVM and direct mode on a cluster merely by applying a different deployment. If we run two tests back-to-back which use the same cluster configuration (for example, Fedora with Kubernetes 1.16), then we reuse the existing cluster, which saves around 5 minutes for the second test.

We have some tests marked as '[Slow]': https://cloudnative-k8sci.southcentralus.cloudapp.azure.com/job/pmem-csi/view/change-requests/job/PR-487/32/testReport/clear-31760-lvm-production/E2E/

For example, the `xfs` variant (somehow, haven't checked) is marked as slow. It seems okay to skip those tests in pre-merge testing. This cuts down the time down by several minutes (1:13h https://cloudnative-k8sci.southcentralus.cloudapp.azure.com/job/pmem-csi/view/change-requests/job/PR-487/32/testReport/ vs. 0:59h https://cloudnative-k8sci.southcentralus.cloudapp.azure.com/job/pmem-csi/view/change-requests/job/PR-487/33/testReport/).

Finally, some issues found while testing get fixed.