### PR TITLE
remove entry point for PMEM-CSI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,3 @@ RUN echo "global { use_lvmetad = 0 }" >> /etc/lvm/lvm.conf && \
     echo "activation { udev_sync = 0 udev_rules = 0 }" >> /etc/lvm/lvm.conf
 
 ENV LD_LIBRARY_PATH=/usr/lib
-ENTRYPOINT ["/usr/local/bin/pmem-csi-driver"]

--- a/deploy/kubernetes-1.14/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/direct/pmem-csi.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.14/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/lvm/pmem-csi.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -289,10 +291,9 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-ns-init
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -305,10 +306,9 @@ spec:
         volumeMounts:
         - mountPath: /sys
           name: sys-dir
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-vgm
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -325,12 +327,11 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-ns-init
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-ns-init-*.out
-        command:
-        - /usr/local/bin/pmem-ns-init
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -345,12 +346,11 @@ spec:
           name: sys-dir
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      - args:
+      - command:
+        - /usr/local/bin/pmem-vgm
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-vgm-*.out
-        command:
-        - /usr/local/bin/pmem-vgm
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.14/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -325,12 +327,11 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-ns-init
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-ns-init-*.out
-        command:
-        - /usr/local/bin/pmem-ns-init
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -345,12 +346,11 @@ spec:
           name: sys-dir
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      - args:
+      - command:
+        - /usr/local/bin/pmem-vgm
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-vgm-*.out
-        command:
-        - /usr/local/bin/pmem-vgm
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -289,10 +291,9 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-ns-init
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -305,10 +306,9 @@ spec:
         volumeMounts:
         - mountPath: /sys
           name: sys-dir
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-vgm
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kubernetes-1.16/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/pmem-csi.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -289,10 +291,9 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-ns-init
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -305,10 +306,9 @@ spec:
         volumeMounts:
         - mountPath: /sys
           name: sys-dir
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-vgm
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -325,12 +327,11 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-ns-init
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-ns-init-*.out
-        command:
-        - /usr/local/bin/pmem-ns-init
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -345,12 +346,11 @@ spec:
           name: sys-dir
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      - args:
+      - command:
+        - /usr/local/bin/pmem-vgm
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-vgm-*.out
-        command:
-        - /usr/local/bin/pmem-vgm
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.16/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=ndctl
         - -v=3
         - -drivername=pmem-csi.intel.com

--- a/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
@@ -171,7 +171,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -258,7 +259,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -325,12 +327,11 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-ns-init
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-ns-init-*.out
-        command:
-        - /usr/local/bin/pmem-ns-init
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -345,12 +346,11 @@ spec:
           name: sys-dir
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      - args:
+      - command:
+        - /usr/local/bin/pmem-vgm
         - -v=3
         - -v=5
         - -coverprofile=/var/lib/pmem-csi-coverage/pmem-vgm-*.out
-        command:
-        - /usr/local/bin/pmem-vgm
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
@@ -160,7 +160,8 @@ spec:
         app: pmem-csi-controller
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -v=3
         - -drivername=pmem-csi.intel.com
         - -mode=controller
@@ -228,7 +229,8 @@ spec:
         app: pmem-csi-node
     spec:
       containers:
-      - args:
+      - command:
+        - /usr/local/bin/pmem-csi-driver
         - -deviceManager=lvm
         - -v=3
         - -drivername=pmem-csi.intel.com
@@ -289,10 +291,9 @@ spec:
           name: registration-dir
       hostNetwork: true
       initContainers:
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-ns-init
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-ns-init-termination-log
@@ -305,10 +306,9 @@ spec:
         volumeMounts:
         - mountPath: /sys
           name: sys-dir
-      - args:
-        - -v=3
-        command:
+      - command:
         - /usr/local/bin/pmem-vgm
+        - -v=3
         env:
         - name: TERMINATION_LOG_PATH
           value: /tmp/pmem-vgm-termination-log

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -37,7 +37,9 @@ spec:
       - name: pmem-driver
         image: intel/pmem-csi-driver:canary
         imagePullPolicy: Always
-        args:  [ "-v=3",
+        command: [
+                 "/usr/local/bin/pmem-csi-driver",
+                 "-v=3",
                  "-drivername=pmem-csi.intel.com",
                  "-mode=controller",
                  "-endpoint=unix:///csi/csi-controller.sock",
@@ -104,7 +106,9 @@ spec:
       - name: pmem-driver
         imagePullPolicy: Always
         image: intel/pmem-csi-driver:canary
-        args: [ "-v=3",
+        command: [
+                  "/usr/local/bin/pmem-csi-driver",
+                  "-v=3",
                   "-drivername=pmem-csi.intel.com",
                   "-mode=node",
                   "-endpoint=$(CSI_ENDPOINT)",

--- a/deploy/kustomize/patches/direct-patch.yaml
+++ b/deploy/kustomize/patches/direct-patch.yaml
@@ -1,6 +1,6 @@
-# Select LVM mode. The PMEM-CSI driver must be in container #0.
+# Select direct mode. The PMEM-CSI driver must be in container #0.
 - op: add
-  path: /spec/template/spec/containers/0/args/0
+  path: /spec/template/spec/containers/0/command/1
   value: "-deviceManager=ndctl"
 
 # Direct mode needs /dev and /sys.

--- a/deploy/kustomize/patches/lvm-patch.yaml
+++ b/deploy/kustomize/patches/lvm-patch.yaml
@@ -1,6 +1,6 @@
 # Select LVM mode. The PMEM-CSI driver must be in container #0.
 - op: add
-  path: /spec/template/spec/containers/0/args/0
+  path: /spec/template/spec/containers/0/command/1
   value: "-deviceManager=lvm"
 
 # LVM mode needs init containers.
@@ -10,8 +10,7 @@
   - name: pmem-ns-init
     imagePullPolicy: Always
     image: intel/pmem-csi-driver:canary
-    command: ["/usr/local/bin/pmem-ns-init"]
-    args: [ "-v=3" ]
+    command: ["/usr/local/bin/pmem-ns-init", "-v=3"]
     env:
       - name: TERMINATION_LOG_PATH
         value: /tmp/pmem-ns-init-termination-log
@@ -24,8 +23,7 @@
   - name: pmem-vgm
     imagePullPolicy: Always
     image: intel/pmem-csi-driver:canary
-    command: ["/usr/local/bin/pmem-vgm"]
-    args: [ "-v=3" ]
+    command: ["/usr/local/bin/pmem-vgm", "-v=3"]
     env:
       - name: TERMINATION_LOG_PATH
         value: /tmp/pmem-vgm-termination-log

--- a/deploy/kustomize/testing/args-two-containers-patch.yaml
+++ b/deploy/kustomize/testing/args-two-containers-patch.yaml
@@ -2,11 +2,11 @@
 # and set -testEndpoint to pmem-csi-driver container (expected to
 # come first).
 - op: add
-  path: /spec/template/spec/containers/0/args/-
+  path: /spec/template/spec/containers/0/command/-
   value: "-v=5"
 
 - op: add
-  path: /spec/template/spec/containers/0/args/-
+  path: /spec/template/spec/containers/0/command/-
   value: "-testEndpoint"
 
 - op: add

--- a/deploy/kustomize/testing/args-two-initcontainers-patch.yaml
+++ b/deploy/kustomize/testing/args-two-initcontainers-patch.yaml
@@ -1,8 +1,8 @@
 # Raise log verbosity level to 5 in initContainers
 - op: add
-  path: /spec/template/spec/initContainers/0/args/-
+  path: /spec/template/spec/initContainers/0/command/-
   value: "-v=5"
 
 - op: add
-  path: /spec/template/spec/initContainers/1/args/-
+  path: /spec/template/spec/initContainers/1/command/-
   value: "-v=5"

--- a/deploy/kustomize/testing/controller-coverage-patch.yaml
+++ b/deploy/kustomize/testing/controller-coverage-patch.yaml
@@ -1,6 +1,6 @@
 # Container #0 is expected to be pmem-driver.
 - op: add
-  path: /spec/template/spec/containers/0/args/-
+  path: /spec/template/spec/containers/0/command/-
   value: -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/deploy/kustomize/testing/lvm-coverage-patch.yaml
+++ b/deploy/kustomize/testing/lvm-coverage-patch.yaml
@@ -1,6 +1,6 @@
 # Order of init containers from lvm-patch.yaml.
 - op: add
-  path: /spec/template/spec/initContainers/0/args/-
+  path: /spec/template/spec/initContainers/0/command/-
   value: -coverprofile=/var/lib/pmem-csi-coverage/pmem-ns-init-*.out
 - op: add
   path: /spec/template/spec/initContainers/0/volumeMounts/-
@@ -8,7 +8,7 @@
     mountPath: /var/lib/pmem-csi-coverage
     name: coverage-dir
 - op: add
-  path: /spec/template/spec/initContainers/1/args/-
+  path: /spec/template/spec/initContainers/1/command/-
   value: -coverprofile=/var/lib/pmem-csi-coverage/pmem-vgm-*.out
 - op: add
   path: /spec/template/spec/initContainers/1/volumeMounts

--- a/deploy/kustomize/testing/node-coverage-patch.yaml
+++ b/deploy/kustomize/testing/node-coverage-patch.yaml
@@ -1,6 +1,6 @@
 # Container #0 is expected to be pmem-driver.
 - op: add
-  path: /spec/template/spec/containers/0/args/-
+  path: /spec/template/spec/containers/0/command/-
   value: -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/test/setup-deployment.sh
+++ b/test/setup-deployment.sh
@@ -67,10 +67,10 @@ patchesJson6902:
 EOF
             ${SSH} "cat >'$tmpdir/my-deployment/lvm-parameters-patch.yaml'" <<EOF
 - op: add
-  path: /spec/template/spec/initContainers/0/args/-
+  path: /spec/template/spec/initContainers/0/command/-
   value: "--useforfsdax=50"
 - op: add
-  path: /spec/template/spec/initContainers/0/args/-
+  path: /spec/template/spec/initContainers/0/command/-
   value: "--useforsector=10"
 EOF
         fi


### PR DESCRIPTION
It's very annoying that the pmem-csi-driver is marked as entry point
for the pmem-csi-driver image when using it as the container for
running tools that aren't installed on a host, like ndctl or LVM. For
example:

     $ docker run --privileged  --rm intel/pmem-csi-driver:v0.5.0 -- ndctl list -Nu
     failed to initialize driver: Invalid driver mode: unified

It's better to not specify an entry point and instead select the
command in the deployment. This is then also consistent for all three
commands that we run from the image.

Fixes: #377