### PR TITLE
test: enable ephemeral test pattern for dax testing only if supported

### DIFF
--- a/test/e2e/ephemeral/ephemeral.go
+++ b/test/e2e/ephemeral/ephemeral.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 Intel Corporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ephemeral
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var Supported = func() bool {
+	k8sVersion := os.Getenv("TEST_KUBERNETES_VERSION")
+
+	if k8sVersion == "" {
+		// No K8S version set, default enable ephemeral tests
+		framework.Logf("No Kubernetes version set! Providing (via TEST_KUBERNETES_VERSION environment) the right Kubernetes version might affect the test suites to be run.")
+		return true
+	}
+	var major, minor int
+	if _, err := fmt.Sscanf(k8sVersion, "%d.%d", &major, &minor); err != nil {
+		framework.Logf("Failed to parse 'TEST_KUBERNETES_VERSION=%s': %s. Enabling ephemeral volume tests.", k8sVersion, err.Error())
+		// Allow ephemeral tests
+		return true
+	}
+	if (major <= 0) || (major == 1 && minor <= 14) {
+		// Kubernetes version <= 1.14 does not support ephemeral volumes.
+		framework.Logf("Provided Kubernetes version '%s' does not support ephemeral volumes. Tests involving ephemeral volumes are disabled.", k8sVersion)
+		return false
+	}
+
+	return true
+}()

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
 
+	"github.com/intel/pmem-csi/test/e2e/ephemeral"
 	"github.com/intel/pmem-csi/test/e2e/storage/dax"
 
 	v1 "k8s.io/api/core/v1"
@@ -90,28 +90,7 @@ var _ = Describe("E2E", func() {
 		dax.InitDaxTestSuite,
 	}
 
-	enableEphemeralTests := func(k8sVersion string) bool {
-		if k8sVersion == "" {
-			// No K8S version set, default enable ephemeral tests
-			framework.Logf("No Kubernetes version set! Providing(via TEST_KUBERNETES_VERSION environment) the right Kubernetes version might affect the test suites to be run.")
-			return true
-		}
-		var major, minor int
-		if _, err := fmt.Sscanf(k8sVersion, "%d.%d", &major, &minor); err != nil {
-			framework.Logf("Failed to parse 'TEST_KUBERNETES_VERSION=%s': %s", k8sVersion, err.Error())
-			// Allow ephemeral tests
-			return true
-		}
-		if (major <= 0) || (major == 1 && minor <= 14) {
-			// Kubernetes version <= 1.14 does not support ephemeral devices
-			framework.Logf("Provided Kubernetes version '%s' does not support ephemeral volume provisioning. So disabling ephemeral testsuite", k8sVersion)
-			return false
-		}
-
-		return true
-	}(os.Getenv("TEST_KUBERNETES_VERSION"))
-
-	if enableEphemeralTests {
+	if ephemeral.Supported {
 		csiTestSuites = append(csiTestSuites, testsuites.InitEphemeralTestSuite)
 	}
 

--- a/test/e2e/storage/dax/dax.go
+++ b/test/e2e/storage/dax/dax.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 
+	"github.com/intel/pmem-csi/test/e2e/ephemeral"
 	pmempod "github.com/intel/pmem-csi/test/e2e/pod"
 
 	. "github.com/onsi/ginkgo"
@@ -42,7 +43,7 @@ var _ testsuites.TestSuite = &daxTestSuite{}
 
 // InitDaxTestSuite returns daxTestSuite that implements TestSuite interface
 func InitDaxTestSuite() testsuites.TestSuite {
-	return &daxTestSuite{
+	suite := &daxTestSuite{
 		tsInfo: testsuites.TestSuiteInfo{
 			Name: "dax",
 			TestPatterns: []testpatterns.TestPattern{
@@ -50,14 +51,18 @@ func InitDaxTestSuite() testsuites.TestSuite {
 				testpatterns.Ext4DynamicPV,
 				testpatterns.XfsDynamicPV,
 
-				testpatterns.DefaultFsEphemeralVolume,
-				testpatterns.Ext4EphemeralVolume,
-				testpatterns.XfsEphemeralVolume,
-
 				testpatterns.BlockVolModeDynamicPV,
 			},
 		},
 	}
+	if ephemeral.Supported {
+		suite.tsInfo.TestPatterns = append(suite.tsInfo.TestPatterns,
+			testpatterns.DefaultFsEphemeralVolume,
+			testpatterns.Ext4EphemeralVolume,
+			testpatterns.XfsEphemeralVolume,
+		)
+	}
+	return suite
 }
 
 func (p *daxTestSuite) GetTestSuiteInfo() testsuites.TestSuiteInfo {


### PR DESCRIPTION
The tests were failing on Kubernetes 1.14 because ephemeral volumes
aren't supported there.