### PR TITLE
CI speedup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -457,6 +457,7 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                   -e TEST_DEVICEMODE=${deviceMode} \
                   -e TEST_DEPLOYMENTMODE=${deploymentMode} \
                   -e TEST_CHECK_SIGNED_FILES=false \
+                  -e TEST_CHECK_KVM=false \
                   -e TEST_DISTRO=${distro} \
                   -e TEST_DISTRO_VERSION=${distroVersion} \
                   -e TEST_KUBERNETES_VERSION=${kubernetesVersion} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -513,7 +513,9 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                                loggers=\"\$loggers \$!\"; \
                            done && \
                            testrun=\$(echo '${distro}-${distroVersion}-${kubernetesVersion}-${deviceMode}-${deploymentMode}' | sed -e s/--*/-/g | tr . _ ) && \
-                           make test_e2e TEST_E2E_REPORT_DIR=${WORKSPACE}/build/reports.tmp/\$testrun' \
+                           make test_e2e TEST_E2E_REPORT_DIR=${WORKSPACE}/build/reports.tmp/\$testrun \
+                                         TEST_E2E_SKIP=\$(if [ \"${env.CHANGE_ID}\" ] && [ \"${env.CHANGE_ID}\" != null ]; then echo \\\\[Slow\\\\]; fi) \
+                           ' \
            "
     } finally {
         // Each test run produces junit_*.xml files with testsuite name="PMEM E2E suite".

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,10 @@ pipeline {
         // Set below via a script, must *not* be set here as it can't be overwritten.
         // BUILD_IMAGE = ""
 
+        // A running container based on BUILD_IMAGE, with volumes for everything that we
+        // need from the build host.
+        BUILD_CONTAINER = "builder"
+
         // Tag or branch name that is getting built, depending on the job.
         // Set below via a script, must *not* be set here as it can't be overwritten.
         // BUILD_TARGET = ""
@@ -139,15 +143,26 @@ pipeline {
                     }
                     sh "env; echo Building BUILD_IMAGE=${env.BUILD_IMAGE} for BUILD_TARGET=${env.BUILD_TARGET}, CHANGE_ID=${env.CHANGE_ID}, CACHEBUST=${env.CACHEBUST}."
                     sh "docker build --cache-from ${env.BUILD_IMAGE} --label cachebust=${env.CACHEBUST} --target build --build-arg CACHEBUST=${env.CACHEBUST} -t ${env.BUILD_IMAGE} ."
-                    // Create a running container (https://stackoverflow.com/a/38308399).
-                    sh "docker create --name=builder ${env.BUILD_IMAGE} sleep infinity"
-                    sh "docker start builder && \
+                    // Create a running container (https://stackoverflow.com/a/38308399). We keep it running
+                    // and just "docker exec" commands in it. withDockerRegistry creates the DOCKER_CONFIG directory
+                    // and deletes it when done, so we have to make a copy for later use inside the container.
+                    withDockerRegistry([ credentialsId: "e16bd38a-76cb-4900-a5cb-7f6aa3aeb22d", url: "https://${REGISTRY_NAME}" ]) {
+                        sh "mkdir -p _work"
+                        sh "cp -a $DOCKER_CONFIG _work/docker-config"
+                        sh "docker create --name=${env.BUILD_CONTAINER} \
+                                   --volume /var/run/docker.sock:/var/run/docker.sock \
+                                   --volume /usr/bin/docker:/usr/bin/docker \
+                                   --volume ${WORKSPACE}/..:${WORKSPACE}/.. \
+                                   ${env.BUILD_IMAGE} \
+                                   sleep infinity"
+                    }
+                    sh "docker start ${env.BUILD_CONTAINER} && \
                         timeout=0; \
-                        while [ \$(docker inspect --format '{{.State.Status}}' builder) != running ]; do \
+                        while [ \$(docker inspect --format '{{.State.Status}}' ${env.BUILD_CONTAINER}) != running ]; do \
                             docker ps; \
                             if [ \$timeout -ge 60 ]; then \
-                               docker inspect builder; \
-                               echo 'ERROR: builder container still not running'; \
+                               docker inspect ${env.BUILD_CONTAINER}; \
+                               echo 'ERROR: ${env.BUILD_CONTAINER} container still not running'; \
                                exit 1; \
                             fi; \
                             sleep 10; \
@@ -156,22 +171,20 @@ pipeline {
 
                     // Install additional tools:
                     // - ssh client for govm
-                    sh "docker exec builder swupd bundle-add openssh-client"
+                    sh "docker exec ${env.BUILD_CONTAINER} swupd bundle-add openssh-client"
+
+                    // Now commit those changes to ensure that the result of "swupd bundle add" gets cached.
+                    sh "docker commit ${env.BUILD_CONTAINER} ${env.BUILD_IMAGE}"
 
                     // Make /usr/local/bin writable for all users. Used to install kubectl.
-                    sh "docker exec builder sh -c 'mkdir -p /usr/local/bin && chmod a+wx /usr/local/bin'"
+                    sh "docker exec ${env.BUILD_CONTAINER} sh -c 'mkdir -p /usr/local/bin && chmod a+wx /usr/local/bin'"
 
                     // Some tools expect a user entry for the jenkins user (like govm?)
-                    sh "echo jenkins:x:`id -u`:0:Jenkins:`pwd`/..:/bin/bash | docker exec -i builder tee --append /etc/passwd >/dev/null"
-                    sh "echo 'jenkins:*:0:0:99999:0:::' | docker exec -i builder tee --append /etc/shadow >/dev/null"
-
-                    // Now commit those changes for use below and clean up.
-                    sh "docker commit builder ${env.BUILD_IMAGE}"
-                    sh "docker stop builder"
-                    sh "docker rm builder"
+                    sh "echo jenkins:x:`id -u`:0:Jenkins:${WORKSPACE}/..:/bin/bash | docker exec -i ${env.BUILD_CONTAINER} tee --append /etc/passwd >/dev/null"
+                    sh "echo 'jenkins:*:0:0:99999:0:::' | docker exec -i ${env.BUILD_CONTAINER} tee --append /etc/shadow >/dev/null"
 
                     // Verify that docker works in the updated image.
-                    sh "docker run --rm ${DockerBuildArgs()} ${env.BUILD_IMAGE} docker ps"
+                    sh "${RunInBuilder()} ${env.BUILD_CONTAINER} docker ps"
 
                     // Run a per-test registry on the build host.  This is where we
                     // will push images for use by the cluster during testing.
@@ -187,7 +200,7 @@ pipeline {
 
             steps {
                 script {
-                    status = sh ( script: "docker run --rm ${DockerBuildArgs()} ${env.BUILD_IMAGE} hack/create-new-release.sh", returnStatus: true )
+                    status = sh ( script: "${RunInBuilder()} ${env.BUILD_CONTAINER} hack/create-new-release.sh", returnStatus: true )
                     if ( status == 2 ) {
                         // https://stackoverflow.com/questions/42667600/abort-current-build-from-pipeline-in-jenkins
                         currentBuild.result = 'ABORTED'
@@ -206,7 +219,7 @@ pipeline {
             }
 
             steps {
-                sh "docker run --rm ${DockerBuildArgs()} ${env.BUILD_IMAGE} make test"
+                sh "${RunInBuilder()} ${env.BUILD_CONTAINER} make test"
             }
         }
 
@@ -219,11 +232,11 @@ pipeline {
             steps {
                 // This builds images for REGISTRY_NAME with the version automatically determined by
                 // the make rules.
-                sh "docker run --rm ${DockerBuildArgs()} ${env.BUILD_IMAGE} make build-images"
+                sh "${RunInBuilder()} ${env.BUILD_CONTAINER} make build-images"
 
                 // For testing we have to have those same images also in a registry. Tag and push for
                 // localhost, which is the default test registry.
-                sh "imageversion=\$(docker run --rm ${DockerBuildArgs()} ${env.BUILD_IMAGE} make print-image-version) && \
+                sh "imageversion=\$(${RunInBuilder()} ${env.BUILD_CONTAINER} make print-image-version) && \
                     for suffix in '' '-test'; do \
                         docker tag ${env.REGISTRY_NAME}/pmem-csi-driver\$suffix:\$imageversion localhost:5000/pmem-csi-driver\$suffix:\$imageversion && \
                         docker push localhost:5000/pmem-csi-driver\$suffix:\$imageversion; \
@@ -367,27 +380,27 @@ git push origin HEAD:master
             }
         }
 
+        // Pushing images uses the DOCKER_CONFIG set up inside the build container earlier.
         stage('Push images') {
             when {
                 not { changeRequest() }
                 not { environment name: 'JOB_BASE_NAME', value: 'pmem-csi-release' } // New release will be built and pushed normally.
             }
             steps {
-                withDockerRegistry([ credentialsId: "e16bd38a-76cb-4900-a5cb-7f6aa3aeb22d", url: "https://${REGISTRY_NAME}" ]) {
-                    // Push PMEM-CSI images without rebuilding them.
-                    // When building a tag, we expect the code to contain that version as image version.
-                    // When building a branch, we expect "canary" for the "devel" branch and (currently) don't publish
-                    // canary images for other branches.
-                    sh "imageversion=\$(docker run --rm ${DockerBuildArgs()} ${env.BUILD_IMAGE} make print-image-version) && \
-                        expectedversion=\$(echo '${env.BUILD_TARGET}' | sed -e 's/devel/canary/') && \
-                        if [ \"\$imageversion\" = \"\$expectedversion\" ] ; then \
-                            docker run --rm ${DockerBuildArgs()} -e DOCKER_CONFIG=$DOCKER_CONFIG -v $DOCKER_CONFIG:$DOCKER_CONFIG ${env.BUILD_IMAGE} make push-images PUSH_IMAGE_DEP=; \
-                        else \
-                            echo \"Skipping the pushing of PMEM-CSI driver images with version \$imageversion because this build is for ${env.BUILD_TARGET}.\"; \
-                        fi"
-                    // Also push the build image, for later reuse in PR jobs.
-                    sh "docker image push ${env.BUILD_IMAGE}"
-                }
+                // Push PMEM-CSI images without rebuilding them.
+                //
+                // When building a tag, we expect the code to contain that version as image version.
+                // When building a branch, we expect "canary" for the "devel" branch and (currently) don't publish
+                // canary images for other branches.
+                sh "imageversion=\$(${RunInBuilder()} ${env.BUILD_CONTAINER} make print-image-version) && \
+                    expectedversion=\$(echo '${env.BUILD_TARGET}' | sed -e 's/devel/canary/') && \
+                    if [ \"\$imageversion\" = \"\$expectedversion\" ] ; then \
+                        ${RunInBuilder()} ${env.BUILD_CONTAINER} make push-images PUSH_IMAGE_DEP=; \
+                    else \
+                        echo \"Skipping the pushing of PMEM-CSI driver images with version \$imageversion because this build is for ${env.BUILD_TARGET}.\"; \
+                    fi"
+                // Also push the build image, for later reuse in PR jobs.
+                sh "${RunInBuilder()} ${env.BUILD_CONTAINER} docker image push ${env.BUILD_IMAGE}"
             }
         }
     }
@@ -400,36 +413,33 @@ git push origin HEAD:master
 }
 
 /*
- "docker run" parameters which:
- - make the Docker instance on the host available inside a container (socket and command)
- - set common Makefile values (cachebust, cache populated from images if available)
+ A command line for running some command inside the build container with:
+ - common Makefile values (cachebust, cache populated from images if available) in environment
  - source in current directory
  - GOPATH alongside it
  - HOME above it
- - same user inside and outside the container
- - same uid/gid/groups as on the host
+ - same uid as on the host, gid same as for Docker socket
 
- "rshared" is needed for mount propagation when govm runs outside the build container.
+ Using the same uid/gid and auxiliary groups would be nicer, but "docker exec" does not
+ support --group-add.
 
  A function is used because a variable, even one which uses a closure with lazy evaluation,
  didn't actually result in a string with all variables replaced by the current values.
  Do not use lazy evaluation inside the function, that caused steps which use
  this function to get skipped silently?!
 */
-String DockerBuildArgs() {
+String RunInBuilder() {
     "\
+    docker exec \
     -e BUILD_IMAGE_ID=${env.CACHEBUST} \
     -e 'BUILD_ARGS=--cache-from ${env.BUILD_IMAGE} --cache-from ${env.PMEM_CSI_IMAGE}' \
+    -e DOCKER_CONFIG=${WORKSPACE}/_work/docker-config \
     -e REGISTRY_NAME=${env.REGISTRY_NAME} \
-    -e HOME=`pwd`/.. \
-    -e GOPATH=`pwd`/../gopath \
+    -e HOME=${WORKSPACE}/.. \
+    -e GOPATH=${WORKSPACE}/../gopath \
     -e USER=`id -nu` \
-    --user `id -u`:`id -g` \
-    --group-add `id -G | sed -e 's/ / --group-add /g'` \
-    --volume /var/run/docker.sock:/var/run/docker.sock \
-    --volume /usr/bin/docker:/usr/bin/docker \
-    --volume `pwd`/..:`pwd`/..:rshared \
-    --workdir `pwd` \
+    --user `id -u`:`stat --format %g /var/run/docker.sock` \
+    --workdir ${WORKSPACE} \
     "
 }
 
@@ -445,16 +455,25 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
         GOPATH. Once we can build outside of the GOPATH, we can
         simplify that to build inside one directory.
 
+        This spawns some long running processes. Those do not killed when the
+        main process returns when using "docker exec", so we should better clean
+        up ourselves. "make stop" was hanging and waiting for these processes to
+        exit even though there were from a different "docker exec" invocation.
+
         TODO: test in parallel (on different nodes? single node didn't work,
         https://github.com/intel/pmem-CSI/pull/309#issuecomment-504659383)
         */
         sh " \
+           loggers=; \
+           atexit () { set -x; kill \$loggers; killall sleep; }; \
+           trap atexit EXIT; \
            mkdir -p build/reports && \
            if ${env.LOGGING_JOURNALCTL}; then sudo journalctl -f; fi & \
-           ( set +x; while true; do sleep ${env.LOGGING_SAMPLING_DELAY}; top -b -n 1 -w 120 | head -n 20; df -h; done ) & \
-           docker run --rm \
+           ( set +x; while sleep ${env.LOGGING_SAMPLING_DELAY}; do top -b -n 1 -w 120 | head -n 20; df -h; done ) & \
+           loggers=\"\$loggers \$!\" && \
+           ${RunInBuilder()} \
                   -e CLUSTER=${env.CLUSTER} \
-                  -e GOVM_YAML=`pwd`/_work/${env.CLUSTER}/deployment.yaml \
+                  -e GOVM_YAML=${WORKSPACE}/_work/${env.CLUSTER}/deployment.yaml \
                   -e TEST_LOCAL_REGISTRY=\$(ip addr show dev docker0 | grep ' inet ' | sed -e 's/.* inet //' -e 's;/.*;;'):5000 \
                   -e TEST_DEVICEMODE=${deviceMode} \
                   -e TEST_DEPLOYMENTMODE=${deploymentMode} \
@@ -464,26 +483,32 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                   -e TEST_DISTRO_VERSION=${distroVersion} \
                   -e TEST_KUBERNETES_VERSION=${kubernetesVersion} \
                   -e TEST_ETCD_VOLUME=${env.TEST_ETCD_VOLUME} \
-                  ${DockerBuildArgs()} \
-                  ${env.BUILD_IMAGE} \
+                  ${env.BUILD_CONTAINER} \
                   bash -c 'set -x; \
-                           testrun=\$(echo '${distro}-${distroVersion}-${kubernetesVersion}-${deviceMode}-${deploymentMode}' | sed -e s/--*/-/g | tr . _ ) && \
+                           loggers=; \
+                           atexit () { set -x; kill \$loggers; kill \$( ps --no-header -o %p ); }; \
+                           trap atexit EXIT; \
                            make start && \
                            _work/${env.CLUSTER}/ssh.0 kubectl get pods --all-namespaces -o wide && \
                            for pod in ${env.LOGGING_PODS}; do \
                                _work/${env.CLUSTER}/ssh.0 kubectl logs -f -n kube-system \$pod-pmem-csi-${env.CLUSTER}-master | sed -e \"s/^/\$pod: /\" & \
+                               loggers=\"\$loggers \$!\"; \
                            done && \
                            _work/${env.CLUSTER}/ssh.0 tar -C / -cf - usr/bin/kubectl | tar -C /usr/local/bin --strip-components=2 -xf - && \
                            for ssh in \$(ls _work/${env.CLUSTER}/ssh.[0-9]); do \
                                hostname=\$(\$ssh hostname) && \
+                               if ${env.LOGGING_JOURNALCTL}; then \
+                                   ( set +x; while true; do \$ssh journalctl -f; done ) & \
+                                   loggers=\"\$loggers \$!\"; \
+                               fi; \
                                ( set +x; \
-                                 if ${env.LOGGING_JOURNALCTL}; then while true; do \$ssh journalctl -f; done; fi & \
-                                 while true; do \
-                                     sleep ${env.LOGGING_SAMPLING_DELAY}; \
+                                 while sleep ${env.LOGGING_SAMPLING_DELAY}; do \
                                      \$ssh top -b -n 1 -w 120 2>&1 | head -n 20; \
-                                 done ) | sed -e \"s/^/\$hostname: /\" & \
+                                 done | sed -e \"s/^/\$hostname: /\" ) & \
+                               loggers=\"\$loggers \$!\"; \
                            done && \
-                           make test_e2e TEST_E2E_REPORT_DIR=`pwd`/build/reports.tmp/\$testrun' \
+                           testrun=\$(echo '${distro}-${distroVersion}-${kubernetesVersion}-${deviceMode}-${deploymentMode}' | sed -e s/--*/-/g | tr . _ ) && \
+                           make test_e2e TEST_E2E_REPORT_DIR=${WORKSPACE}/build/reports.tmp/\$testrun' \
            "
     } finally {
         // Each test run produces junit_*.xml files with testsuite name="PMEM E2E suite".
@@ -500,6 +525,6 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
            done'''
 
         // Always shut down the cluster to free up resources.
-        sh "docker run --rm -e CLUSTER=${env.CLUSTER} ${DockerBuildArgs()} ${env.BUILD_IMAGE} make stop"
+        sh "${RunInBuilder()} -e CLUSTER=${env.CLUSTER} ${env.BUILD_CONTAINER} make stop"
     }
 }

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -79,9 +79,9 @@ scheduler:
 fi
 
 if [ -e /dev/vdc ]; then
-    # We have an extra volume specifically for etcd (see TEST_ETCD_VOLUME_SIZE).
+    # We have an extra volume specifically for etcd (see TEST_ETCD_VOLUME).
     sudo mkdir -p /mnt/etcd-volume
-    sudo mkfs.ext4 /dev/vdc
+    sudo mkfs.ext4 -F /dev/vdc
     sudo mount /dev/vdc /mnt/etcd-volume
     # etcd wants an empty directory, giving it the volume fails due to "lost+found".
     sudo mkdir /mnt/etcd-volume/etcd

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -453,7 +453,7 @@ function check_status() { # intentionally a composite command, so "exit" will ex
         fi
     fi
 
-    if [ ! -e /dev/kvm ]; then
+    if ${TEST_CHECK_KVM} && [ ! -e /dev/kvm ]; then
         echo "ERROR: /dev/kvm does not exist. KVM has to be enabled before starting the virtual cluster."
         exit 1
     fi

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -101,6 +101,16 @@ fi
 # (https://github.com/clearlinux/distribution/issues/85).
 : ${TEST_CHECK_SIGNED_FILES:=true}
 
+# "make start" tests that /dev/kvm exists before invoking govm because
+# when it is missing, the failure of QEMU inside the containers is
+# hard to diagnose.
+#
+# However, in some rather special circumstances it may be necessary to
+# disable this check. For example, the CI runs "make start" in a
+# non-privileged container without /dev/kvm whereas QEMU will run in
+# privileged containers where /dev/kvm is available.
+: ${TEST_CHECK_KVM:=true}
+
 # If set to a <major>.<minor> number, that version of Kubernetes
 # is installed instead of the latest one. Ignored when
 # using Clear Linux as OS because with Clear Linux we have

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -71,13 +71,15 @@ fi
 : ${TEST_NUM_CPUS:=2}
 
 # The etcd instance running on the master node can be configured to
-# store its data in a tmpfs volume that gets created on the build
-# host. This is useful when the _work directory is on a slow disk
+# store its data on a separate disk. This is the path to an existing
+# file of the desired size which will then be passed into the master
+# node via "-drive file=...". For that to work the file has
+# to be inside the "data" directory of the master node.
+#
+# This is useful when the _work directory is on a slow disk
 # because that can lead to slow performance and failures
 # (https://github.com/kubernetes/kubernetes/issues/70082).
-#
-# This is the size of that volume in bytes, zero disables this feature.
-: ${TEST_ETCD_VOLUME_SIZE:=0}
+: ${TEST_ETCD_VOLUME:=}
 
 # Kubernetes feature gates to enable/disable
 # featurename=true,feature=false

--- a/test/test.make
+++ b/test/test.make
@@ -121,12 +121,13 @@ run_tests: $(RUN_TEST_DEPS)
 	$(RUN_TESTS)
 
 # E2E tests which are known to be unsuitable (space separated list of regular expressions).
-TEST_E2E_SKIP = no-such-test
+TEST_E2E_SKIP =
+TEST_E2E_SKIP_ALL = $(TEST_E2E_SKIP)
 
 # The test's check whether a driver supports multiple nodes is incomplete and does
 # not work for the topology-based single-node access in PMEM-CSI:
 # https://github.com/kubernetes/kubernetes/blob/25ffbe633810609743944edd42d164cd7990071c/test/e2e/storage/testsuites/provisioning.go#L175-L181
-TEST_E2E_SKIP += should.access.volume.from.different.nodes
+TEST_E2E_SKIP_ALL += should.access.volume.from.different.nodes
 
 # E2E tests which are to be executed (space separated list of regular expressions, default is all that aren't skipped).
 TEST_E2E_FOCUS =
@@ -156,8 +157,8 @@ RUN_E2E = KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
 	GO='$(GO)' \
 	TEST_PKGS='$(shell for i in $(TEST_PKGS); do if ls $$i/*_test.go 2>/dev/null >&2; then echo $$i; fi; done)' \
 	$(GO) test -count=1 -timeout 0 -v ./test/e2e \
-                -ginkgo.skip='$(subst $(space),|,$(TEST_E2E_SKIP))' \
-                -ginkgo.focus='$(subst $(space),|,$(TEST_E2E_FOCUS))' \
+                -ginkgo.skip='$(subst $(space),|,$(strip $(TEST_E2E_SKIP_ALL)))' \
+                -ginkgo.focus='$(subst $(space),|,$(strip $(TEST_E2E_FOCUS)))' \
                 -report-dir=$(TEST_E2E_REPORT_DIR)
 test_e2e: start $(RUN_TEST_DEPS)
 	$(RUN_E2E)

--- a/test/test.make
+++ b/test/test.make
@@ -150,7 +150,7 @@ RUN_E2E = KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
 	  echo TEST_DEPLOYMENTMODE=$$TEST_DEPLOYMENTMODE; \
 	  echo TEST_DEVICEMODE=$$TEST_DEVICEMODE; \
 	  echo TEST_KUBERNETES_VERSION=$$TEST_KUBERNETES_VERSION; \
-	  echo PMEM_CSI_IMAGE=$$TEST_LOCAL_REGISTRY/pmem-csi-driver$$(if $$TEST_DEPLOYMENTMODE = testing; then echo -test; fi):$(IMAGE_VERSION); \
+	  echo PMEM_CSI_IMAGE=$$TEST_LOCAL_REGISTRY/pmem-csi-driver$$(if [ $$TEST_DEPLOYMENTMODE = testing ]; then echo -test; fi):$(IMAGE_VERSION); \
 	) \
 	TEST_CMD='$(TEST_CMD)' \
 	GO='$(GO)' \


### PR DESCRIPTION
This is a combination of different enhancements which together make pre-merge testing faster. Original PR is https://github.com/intel/pmem-csi/pull/487 which had to be reverted because it caused regression in the "devel" builds.

Changes since then:
```
diff --git a/Jenkinsfile b/Jenkinsfile
index 9f26d685..64320c96 100644
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,14 +144,15 @@ pipeline {
                     sh "env; echo Building BUILD_IMAGE=${env.BUILD_IMAGE} for BUILD_TARGET=${env.BUILD_TARGET}, CHANGE_ID=${env.CHANGE_ID}, CACHEBUST=${env.CACHEBUST}."
                     sh "docker build --cache-from ${env.BUILD_IMAGE} --label cachebust=${env.CACHEBUST} --target build --build-arg CACHEBUST=${env.CACHEBUST} -t ${env.BUILD_IMAGE} ."
                     // Create a running container (https://stackoverflow.com/a/38308399). We keep it running
-                    // and just "docker exec" commands in it. withDockerRegistry creates the DOCKER_CONFIG file
-                    // for the private registry.
+                    // and just "docker exec" commands in it. withDockerRegistry creates the DOCKER_CONFIG directory
+                    // and deletes it when done, so we have to make a copy for later use inside the container.
                     withDockerRegistry([ credentialsId: "e16bd38a-76cb-4900-a5cb-7f6aa3aeb22d", url: "https://${REGISTRY_NAME}" ]) {
+                        sh "mkdir -p _work"
+                        sh "cp -a $DOCKER_CONFIG _work/docker-config"
                         sh "docker create --name=${env.BUILD_CONTAINER} \
                                    --volume /var/run/docker.sock:/var/run/docker.sock \
                                    --volume /usr/bin/docker:/usr/bin/docker \
                                    --volume ${WORKSPACE}/..:${WORKSPACE}/.. \
-                                   --volume $DOCKER_CONFIG:/docker-config \
                                    ${env.BUILD_IMAGE} \
                                    sleep infinity"
                     }
@@ -379,6 +380,7 @@ git push origin HEAD:master
             }
         }
 
+        // Pushing images uses the DOCKER_CONFIG set up inside the build container earlier.
         stage('Push images') {
             when {
                 not { changeRequest() }
@@ -386,6 +388,7 @@ git push origin HEAD:master
             }
             steps {
                 // Push PMEM-CSI images without rebuilding them.
+                //
                 // When building a tag, we expect the code to contain that version as image version.
                 // When building a branch, we expect "canary" for the "devel" branch and (currently) don't publish
                 // canary images for other branches.
@@ -397,7 +400,7 @@ git push origin HEAD:master
                         echo \"Skipping the pushing of PMEM-CSI driver images with version \$imageversion because this build is for ${env.BUILD_TARGET}.\"; \
                     fi"
                 // Also push the build image, for later reuse in PR jobs.
-                sh "docker image push ${env.BUILD_IMAGE}"
+                sh "${RunInBuilder()} ${env.BUILD_CONTAINER} docker image push ${env.BUILD_IMAGE}"
             }
         }
     }
@@ -430,7 +433,7 @@ String RunInBuilder() {
     docker exec \
     -e BUILD_IMAGE_ID=${env.CACHEBUST} \
     -e 'BUILD_ARGS=--cache-from ${env.BUILD_IMAGE} --cache-from ${env.PMEM_CSI_IMAGE}' \
-    -e DOCKER_CONFIG=/docker-config \
+    -e DOCKER_CONFIG=${WORKSPACE}/_work/docker-config \
     -e REGISTRY_NAME=${env.REGISTRY_NAME} \
     -e HOME=${WORKSPACE}/.. \
     -e GOPATH=${WORKSPACE}/../gopath \
diff --git a/test/test.make b/test/test.make
index 583e2511..01ef5c78 100644
--- a/test/test.make
+++ b/test/test.make
@@ -122,7 +122,7 @@ run_tests: $(RUN_TEST_DEPS)
 
 # E2E tests which are known to be unsuitable (space separated list of regular expressions).
 TEST_E2E_SKIP =
-TEST_E2E_SKIP_ALL = no-such-test $(TEST_E2E_SKIP)
+TEST_E2E_SKIP_ALL = $(TEST_E2E_SKIP)
 
 # The test's check whether a driver supports multiple nodes is incomplete and does
 # not work for the topology-based single-node access in PMEM-CSI:
@@ -157,8 +157,8 @@ RUN_E2E = KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
        GO='$(GO)' \
        TEST_PKGS='$(shell for i in $(TEST_PKGS); do if ls $$i/*_test.go 2>/dev/null >&2; then echo $$i; fi; done)' \
        $(GO) test -count=1 -timeout 0 -v ./test/e2e \
-                -ginkgo.skip='$(subst $(space),|,$(TEST_E2E_SKIP_ALL))' \
-                -ginkgo.focus='$(subst $(space),|,$(TEST_E2E_FOCUS))' \
+                -ginkgo.skip='$(subst $(space),|,$(strip $(TEST_E2E_SKIP_ALL)))' \
+                -ginkgo.focus='$(subst $(space),|,$(strip $(TEST_E2E_FOCUS)))' \
                 -report-dir=$(TEST_E2E_REPORT_DIR)
 test_e2e: start $(RUN_TEST_DEPS)
        $(RUN_E2E)
```
