### PR TITLE
XFS: disable reflink

### DIFF
--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -508,7 +508,9 @@ func (ns *nodeServer) provisionDevice(device *pmdmanager.PmemDeviceInfo, fsType 
 		args = []string{"-b 4096", "-F", device.Path}
 	} else if fsType == "xfs" {
 		cmd = "mkfs.xfs"
-		args = []string{"-b", "size=4096", "-f", device.Path}
+		// reflink and DAX are mutually exclusive
+		// (http://man7.org/linux/man-pages/man8/mkfs.xfs.8.html).
+		args = []string{"-b", "size=4096", "-m", "reflink=0", "-f", device.Path}
 	} else {
 		return fmt.Errorf("Unsupported filesystem '%s'. Supported filesystems types: 'xfs', 'ext4'", fsType)
 	}


### PR DESCRIPTION
A update of Clear Linux from 32020 to 32050 replaces xfstools 5.0.0
with 5.4.0 and that enables reflink by default. "-o dax" and reflink
are mutually exclusive, so we now have to override the default.

(cherry picked from commit 77374b875527d463d4f875116954b49ad4403596)