### PR TITLE
test Kubernetes 1.17 on Clear Linux 32080

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,10 +35,10 @@ pipeline {
           use the Clear Linux kubelet, and a more recent kubelet than
           the control plane is unsupported.
         */
-
-        CLEAR_LINUX_VERSION_1_16 = "31760" // latest version right now
-
+        CLEAR_LINUX_VERSION_1_17 = "32080" // current release at the moment
+        CLEAR_LINUX_VERSION_1_16 = "31760"
         CLEAR_LINUX_VERSION_1_15 = "31070"
+
         /* 29890 broke networking
         (https://github.com/clearlinux/distribution/issues/904). In
         29880, Docker forgets containers after a system restart
@@ -335,13 +335,13 @@ pipeline {
             }
         }
 
-        stage('production 1.16, Clear Linux') {
+        stage('production 1.17, Clear Linux') {
             options {
                 timeout(time: 90, unit: "MINUTES")
                 retry(2)
             }
             steps {
-                TestInVM("lvm", "production", "clear", "${env.CLEAR_LINUX_VERSION_1_16}", "")
+                TestInVM("lvm", "production", "clear", "${env.CLEAR_LINUX_VERSION_1_17}", "")
             }
         }
 

--- a/deploy/kubernetes-1.17
+++ b/deploy/kubernetes-1.17
@@ -1,0 +1,1 @@
+kubernetes-1.16


### PR DESCRIPTION
We don't need to change anything for Kubernetes 1.17 except adding a
symlink so that "make start" knows which deployment files to use.