### PR TITLE
test: dump docker logs for failed govm cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -460,6 +460,13 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
         up ourselves. "make stop" was hanging and waiting for these processes to
         exit even though there were from a different "docker exec" invocation.
 
+        The default QEMU cpu enables nested virtualization with "-cpu
+        host".  However, that fails on some Azure machines
+        (`qemu-system-x86_64: error: failed to set MSR 0x48b to
+        0x1582e00000000`,
+        https://www.mail-archive.com/qemu-devel@nongnu.org/msg665051.html),
+        so for now we disable VMX with -vmx.
+
         TODO: test in parallel (on different nodes? single node didn't work,
         https://github.com/intel/pmem-CSI/pull/309#issuecomment-504659383)
         */
@@ -478,6 +485,7 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
                   -e TEST_DEPLOYMENTMODE=${deploymentMode} \
                   -e TEST_CHECK_SIGNED_FILES=false \
                   -e TEST_CHECK_KVM=false \
+                  -e TEST_QEMU_CPU=host,-vmx \
                   -e TEST_DISTRO=${distro} \
                   -e TEST_DISTRO_VERSION=${distroVersion} \
                   -e TEST_KUBERNETES_VERSION=${kubernetesVersion} \

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -23,12 +23,9 @@ CLOUD="${CLOUD:-true}"
 FLAVOR="${FLAVOR:-medium}" # actual memory size and CPUs selected below
 SSH_KEY="${SSH_KEY:-${RESOURCES_DIRECTORY}/id_rsa}"
 SSH_PUBLIC_KEY="${SSH_KEY}.pub"
-# -cpu host enables nested virtualization (required for Kata Containers).
-# The build host must have the kvm_intel module loaded with
-# nested=1 (see https://wiki.archlinux.org/index.php/KVM#Nested_virtualization).
 KVM_CPU_OPTS="${KVM_CPU_OPTS:-\
  -m ${TEST_NORMAL_MEM_SIZE}M,slots=${TEST_MEM_SLOTS},maxmem=$((${TEST_NORMAL_MEM_SIZE} + ${TEST_PMEM_MEM_SIZE}))M -smp ${TEST_NUM_CPUS} \
- -cpu host \
+ -cpu ${TEST_QEMU_CPU} \
  -machine pc,accel=kvm,nvdimm=on}"
 EXTRA_QEMU_OPTS="${EXTRA_QWEMU_OPTS:-\
  -object memory-backend-file,id=mem1,share=${TEST_PMEM_SHARE},\

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -436,6 +436,21 @@ function cleanup() (
         govm list
         echo "Docker status:"
         docker ps
+        # Pick one restarting container from the current govm cluster and dump its log, if one exists.
+        # We only need one log, other containers are probably failing for the same reason.
+        restarting=$(for i in ${NODES}; do
+                        docker ps --filter status=restarting --filter name=govm.$(id -u -n).$i --format '{{.ID}}'
+                    done | head -n 1)
+        if [ "$restarting" ]; then
+            name=$(docker ps --filter id=$restarting --format '${{.Names}}')
+            echo "Docker container $name is restarting, here's why (docker log):"
+            docker logs $restarting | sed -e "s/^/$name: /"
+        else
+            # Fall back to master node if nothing was restarting.
+            name=govm.$(id -u -n).${NODES[0]}
+            echo "Docker log for $name:"
+            docker logs $name | sed -e "s/^/$name: /"
+        fi
         for vm in $(govm list -f '{{select (filterRegexp . "Name" "^'$(node_filter ${NODES[@]})'$") "Name"}}'); do
             govm remove "$vm"
         done

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -70,6 +70,13 @@ fi
 # Number of CPUS in QEMU VM. Must be at least 2 for Kubernetes.
 : ${TEST_NUM_CPUS:=2}
 
+# QEMU -cpu parameter.
+#
+# "host" enables nested virtualization (required for Kata Containers).
+# The build host must have the kvm_intel module loaded with
+# nested=1 (see https://wiki.archlinux.org/index.php/KVM#Nested_virtualization).
+: ${TEST_QEMU_CPU:=host}
+
 # The etcd instance running on the master node can be configured to
 # store its data on a separate disk. This is the path to an existing
 # file of the desired size which will then be passed into the master


### PR DESCRIPTION
When the machines don't come up, we need the "docker logs" output to
understand why.