### PR TITLE
test: include docker0 interface address in no_proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 # tests using that address try to go through the proxy.
 HTTP_PROXY=$(shell echo "$${HTTP_PROXY:-$${http_proxy}}")
 HTTPS_PROXY=$(shell echo "$${HTTPS_PROXY:-$${https_proxy}}")
-NO_PROXY=$(shell echo "$${NO_PROXY:-$${no_proxy}},$$(ip addr | grep inet6 | grep /64 | sed -e 's;.*inet6 \(.*\)/64 .*;\1;' | tr '\n' ','; ip addr | grep -w inet | grep /24 | sed -e 's;.*inet \(.*\)/24 .*;\1;' | tr '\n' ',')",0.0.0.0,10.0.2.15)
+NO_PROXY=$(shell echo "$${NO_PROXY:-$${no_proxy}},$$(ip addr | grep inet6 | grep /64 | sed -e 's;.*inet6 \(.*\)/64 .*;\1;' | tr '\n' ','; ip addr | grep -w inet | grep -e '/\(24\|16\|8\)' | sed -e 's;.*inet \(.*\)/\(24\|16\|8\) .*;\1;' | tr '\n' ',')",0.0.0.0,10.0.2.15)
 export HTTP_PROXY HTTPS_PROXY NO_PROXY
 
 REGISTRY_NAME?=$(shell . test/test-config.sh && echo $${TEST_BUILD_PMEM_REGISTRY})


### PR DESCRIPTION
The default IP address for reaching the developer Docker registry
comes from "ip addr show dev docker0" which happens to be a /16
subnet:

```
9: docker0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether 02:42:79:6d:15:b3 brd ff:ff:ff:ff:ff:ff
    inet 172.17.42.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:79ff:fe6d:15b3/64 scope link
       valid_lft forever preferred_lft forever
```

Because the code which extended no_proxy only checked for /24 subnets,
this address 172.17.42.1 was not automatically included.

Reported by @devimc in https://github.com/kata-containers/runtime/issues/2262#issuecomment-575620216.
