### PR TITLE
Logs cleanup, document logs use in DEVELOPMENT

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,7 @@ Table of Contents
     - [Specific arguments to pmem-vgm](#specific-arguments-to-pmem-vgm)
     - [Specific arguments to pmem-csi-driver](#specific-arguments-to-pmem-csi-driver)
     - [Environment variables](#environment-variables)
+    - [Logging](#logging)
 - [Notes about switching device mode](#notes-about-switching-device-mode)
     - [Going from LVM device mode to direct device mode](#going-from-lvm-device-mode-to-direct-device-mode)
     - [Going from direct device mode to LVM device mode](#going-from-direct-device-mode-to-lvm-device-mode)
@@ -257,6 +258,16 @@ Environment variables
 
 TEST_WORK is used by registry server unit-test code to specify path to certificates in test system. 
 Note, THIS IS NOT USED IN PRODUCTION
+
+Logging
+-------
+
+The klog.Info statements are used via the verbosity checker using the following levels:
+- klog.V(3) - Generic information. Level 3 is the default Info log level in pmem-csi, and example deployment files set this level for production configuration.
+- klog.V(4) - Elevated verbosity messages.
+- klog.V(5) - Even more verbose messages, useful for debugging and issue resolving. This level is used in testing type of deployment examples.
+
+There are also messages using klog.Warning, klog.Error and klog.Fatal, and their formatted counterparts.
 
 Notes about switching device mode
 ================================

--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -235,18 +235,18 @@ func (r *Region) CreateNamespace(opts CreateNamespaceOpts) (*Namespace, error) {
 	if err == nil {
 		switch opts.Mode {
 		case FsdaxMode:
-			klog.V(5).Infof("setting pfn")
+			klog.V(5).Info("setting pfn")
 			err = ns.setPfnSeed(opts.Location, opts.Align)
 		case DaxMode:
-			klog.V(5).Infof("setting dax")
+			klog.V(5).Info("setting dax")
 			err = ns.setDaxSeed(opts.Location, opts.Align)
 		case SectorMode:
-			klog.V(5).Infof("setting btt")
+			klog.V(5).Info("setting btt")
 			err = ns.setBttSeed(opts.SectorSize)
 		}
 	}
 	if err == nil {
-		klog.V(5).Infof("enabling namespace")
+		klog.V(5).Info("enabling namespace")
 		err = ns.Enable()
 	}
 

--- a/pkg/pmem-csi-driver/controllerserver-master.go
+++ b/pkg/pmem-csi-driver/controllerserver-master.go
@@ -335,7 +335,7 @@ func (cs *masterController) ValidateVolumeCapabilities(ctx context.Context, req 
 }
 
 func (cs *masterController) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	klog.V(5).Infof("ListVolumes")
+	klog.V(5).Info("ListVolumes")
 	if err := cs.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_LIST_VOLUMES); err != nil {
 		klog.Errorf("invalid list volumes req: %v", req)
 		return nil, err

--- a/pkg/pmem-csi-driver/controllerserver-master.go
+++ b/pkg/pmem-csi-driver/controllerserver-master.go
@@ -307,7 +307,7 @@ func (cs *masterController) ValidateVolumeCapabilities(ctx context.Context, req 
 
 	_, found := cs.pmemVolumes[req.VolumeId]
 	if !found {
-		return nil, status.Error(codes.NotFound, "No volume found with id %s"+req.VolumeId)
+		return nil, status.Error(codes.NotFound, "No volume found with id "+req.VolumeId)
 	}
 
 	if req.GetVolumeCapabilities() == nil {

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -103,7 +103,7 @@ func NewNodeControllerServer(nodeID string, dm pmdmanager.PmemDeviceManager, sm 
 
 		for _, id := range cleanupList {
 			if err := sm.Delete(id); err != nil {
-				klog.Warningf("Failed to delete stale volume %s from state : %s", id, err.Error())
+				klog.Warningf("Failed to delete stale volume %s from state: %s", id, err.Error())
 			}
 		}
 	}

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -326,7 +326,7 @@ func (cs *nodeControllerServer) ValidateVolumeCapabilities(ctx context.Context, 
 }
 
 func (cs *nodeControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	klog.V(5).Infof("ListVolumes")
+	klog.V(5).Info("ListVolumes")
 	if err := cs.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_LIST_VOLUMES); err != nil {
 		klog.Errorf("invalid list volumes req: %v", req)
 		return nil, err

--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -273,7 +273,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 
 	if vol == nil {
-		return nil, status.Errorf(codes.NotFound, "no volume found with volume id %q'", req.VolumeId)
+		return nil, status.Errorf(codes.NotFound, "no volume found with volume id %q", req.VolumeId)
 	}
 
 	parameters, err := parseVolumeParameters(nodeVolumeParameters, vol.Params)

--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -573,7 +573,7 @@ func determineFilesystemType(devicePath string) (string, error) {
 }
 
 // ensureDirectory checks if the given directory is existing, if not attempts to create it.
-// retruns true, if direcotry pre-exists, otherwise false.
+// retruns true, if directory pre-exists, otherwise false.
 func ensureDirectory(mounter mount.Interface, dir string) (bool, error) {
 	if _, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -224,7 +224,7 @@ func (pmemd *pmemDriver) Run() error {
 	sig := <-c
 	// Here we want to shut down cleanly, i.e. let running
 	// gRPC calls complete.
-	klog.Infof("Caught signal %s, terminating.", sig)
+	klog.V(3).Infof("Caught signal %s, terminating.", sig)
 	s.Stop()
 	s.Wait()
 
@@ -270,14 +270,14 @@ func waitAndWatchConnection(conn *grpc.ClientConn, req *registry.RegisterControl
 		s := conn.GetState()
 		if s == connectivity.Ready {
 			if connectionLost {
-				klog.Info("ReConnected.")
+				klog.V(4).Info("ReConnected.")
 				if err := register(ctx, conn, req); err != nil {
 					klog.Warning(err)
 				}
 			}
 		} else {
 			connectionLost = true
-			klog.Info("Connection state: ", s)
+			klog.V(4).Info("Connection state: ", s)
 		}
 		conn.WaitForStateChange(ctx, s)
 	}

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -37,7 +37,7 @@ func NewPmemDeviceManagerNdctl() (PmemDeviceManager, error) {
 		if mnt.Device == "sysfs" && mnt.Path == "/sys" {
 			for _, opt := range mnt.Opts {
 				if opt == "rw" {
-					klog.V(4).Infof("NewPmemDeviceManagerNdctl: /sys mounted read-write, good")
+					klog.V(4).Info("NewPmemDeviceManagerNdctl: /sys mounted read-write, good")
 				} else if opt == "ro" {
 					return nil, fmt.Errorf("FATAL: /sys mounted read-only, can not operate")
 				}

--- a/pkg/pmem-state/pmem-state.go
+++ b/pkg/pmem-state/pmem-state.go
@@ -50,7 +50,7 @@ var _ StateManager = &fileState{}
 
 // NewFileState instantiates the file state manager with given directory
 // location. It ensures the provided directory exists.
-// Returns error, if fails to create the direcotry incase of not pre-existing.
+// Returns error, if fails to create the directory in case of not pre-existing.
 func NewFileState(directory string) (StateManager, error) {
 	if err := ensureLocation(directory); err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (fs *fileState) Get(id string, dataPtr interface{}) error {
 }
 
 // GetAll retrieves metadata of all volumes found in fileState.location directory.
-// reads all the .json files in fileState.location direcotry and decodes the filedata
+// reads all the .json files in fileState.location directory and decodes the filedata
 func (fs *fileState) GetAll(dataPtr interface{}, f GetAllFunc) error {
 	fs.stateDirLock.Lock()
 	files, err := ioutil.ReadDir(fs.location)

--- a/pkg/pmem-state/pmem-state_test.go
+++ b/pkg/pmem-state/pmem-state_test.go
@@ -85,7 +85,7 @@ var _ = Describe("pmem state", func() {
 			_, err = pmemstate.NewFileState("")
 			Expect(err).To(HaveOccurred())
 
-			_, err = pmemstate.NewFileState("/unknown/base/direcotry/")
+			_, err = pmemstate.NewFileState("/unknown/base/directory/")
 			Expect(err).To(HaveOccurred())
 
 			file, err := ioutil.TempFile("", "pmemstate-file")

--- a/pkg/registryserver/registryserver.go
+++ b/pkg/registryserver/registryserver.go
@@ -81,7 +81,7 @@ func (rs *RegistryServer) ConnectToNodeController(nodeId string) (*grpc.ClientCo
 		return nil, err
 	}
 
-	klog.V(3).Infof("Connecting to node controller : %s", nodeInfo.Endpoint)
+	klog.V(3).Infof("Connecting to node controller: %s", nodeInfo.Endpoint)
 
 	return pmemgrpc.Connect(nodeInfo.Endpoint, rs.clientTLSConfig)
 }


### PR DESCRIPTION
Address log-related issues listed under #497
Started with that:
Do not use Infof() logger if there are no formatted content.

Let's add more under same PR here.
Resolves  #497