### PR TITLE
Put back "fsdax" as part of VG names

### DIFF
--- a/pkg/pmem-common/vgname.go
+++ b/pkg/pmem-common/vgname.go
@@ -11,5 +11,9 @@ import (
 )
 
 func VgName(bus *ndctl.Bus, region *ndctl.Region) string {
-	return bus.DeviceName() + region.DeviceName()
+	// Hard-coded string to indicate all namespaces are in "FSDAX" mode.
+	nsmode := "fsdax"
+	// This is present to avoid API break: names used to indicate nsmode
+	// before the sector-mode support was dropped.
+	return bus.DeviceName() + region.DeviceName() + nsmode
 }

--- a/pkg/pmem-common/vgname.go
+++ b/pkg/pmem-common/vgname.go
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 Intel Coporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pmemcommon
+
+import (
+	"github.com/intel/pmem-csi/pkg/ndctl"
+)
+
+func VgName(bus *ndctl.Bus, region *ndctl.Region) string {
+	return bus.DeviceName() + region.DeviceName()
+}

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/intel/pmem-csi/pkg/ndctl"
+	pmemcommon "github.com/intel/pmem-csi/pkg/pmem-common"
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
 	"k8s.io/klog"
 )
@@ -47,7 +48,7 @@ func NewPmemDeviceManagerLVM() (PmemDeviceManager, error) {
 	volumeGroups := []string{}
 	for _, bus := range ctx.GetBuses() {
 		for _, r := range bus.ActiveRegions() {
-			vgname := vgName(bus, r)
+			vgname := pmemcommon.VgName(bus, r)
 			if _, err := pmemexec.RunCommand("vgs", vgname); err != nil {
 				klog.V(5).Infof("NewPmemDeviceManagerLVM: VG %v non-existent, skip", vgname)
 			} else {
@@ -221,10 +222,6 @@ func listDevices(volumeGroups ...string) (map[string]*PmemDeviceInfo, error) {
 		return nil, fmt.Errorf("lvs failure : %v", err)
 	}
 	return parseLVSOutput(output)
-}
-
-func vgName(bus *ndctl.Bus, region *ndctl.Region) string {
-	return bus.DeviceName() + region.DeviceName()
 }
 
 //lvs options "lv_name,lv_path,lv_size,lv_free"

--- a/pkg/pmem-vgm/main.go
+++ b/pkg/pmem-vgm/main.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/intel/pmem-csi/pkg/ndctl"
-	"github.com/intel/pmem-csi/pkg/pmem-common"
+	pmemcommon "github.com/intel/pmem-csi/pkg/pmem-common"
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
 )
 
@@ -52,16 +52,12 @@ func prepareVolumeGroups(ctx *ndctl.Context) {
 		klog.V(5).Infof("CheckVG: Bus: %v", bus.DeviceName())
 		for _, r := range bus.ActiveRegions() {
 			klog.V(5).Infof("Region: %v", r.DeviceName())
-			vgName := vgName(bus, r)
+			vgName := pmemcommon.VgName(bus, r)
 			if err := createVolumesForRegion(r, vgName); err != nil {
 				klog.Errorf("Failed volumegroup creation: %s", err.Error())
 			}
 		}
 	}
-}
-
-func vgName(bus *ndctl.Bus, region *ndctl.Region) string {
-	return bus.DeviceName() + region.DeviceName()
 }
 
 func createVolumesForRegion(r *ndctl.Region, vgName string) error {


### PR DESCRIPTION
The removal of "fsdax" part in VG names which was made
in connection with "drop sector-mode", introduced
potential API break if VG name was created before change
and used with code after change.
It is safer to put back "fsdax" part of VG name,
it remains hard-coded in all names now, but still
indicates correctly that namespaces are in FSDAX mode.