### PR TITLE
pmem-csi-driver: Set tls.Config minversion to 1.2

### DIFF
--- a/pkg/pmem-grpc/grpc.go
+++ b/pkg/pmem-grpc/grpc.go
@@ -85,9 +85,11 @@ func LoadServerTLS(caFile, certFile, keyFile, peerName string) (*tls.Config, err
 	}
 
 	return &tls.Config{
-		Certificates: []tls.Certificate{*peerCert},
-		ClientCAs:    certPool,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:    tls.VersionTLS12,
+		Renegotiation: tls.RenegotiateNever,
+		Certificates:  []tls.Certificate{*peerCert},
+		ClientCAs:     certPool,
+		ClientAuth:    tls.RequireAndVerifyClientCert,
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			// Common name check when accepting a connection from a client.
 			if peerName == "" {
@@ -116,9 +118,11 @@ func LoadClientTLS(caFile, certFile, keyFile, peerName string) (*tls.Config, err
 	}
 	klog.V(3).Infof("Using Servername: %s", peerName)
 	return &tls.Config{
-		ServerName:   peerName,
-		Certificates: []tls.Certificate{*peerCert},
-		RootCAs:      certPool,
+		MinVersion:    tls.VersionTLS12,
+		Renegotiation: tls.RenegotiateNever,
+		ServerName:    peerName,
+		Certificates:  []tls.Certificate{*peerCert},
+		RootCAs:       certPool,
 	}, nil
 }
 


### PR DESCRIPTION
TLS versions prior to 1.2 are not secure enough, with this change we adjust
minimum supported version in our server/client configuration to 1.2 this
means both registry and node-controller servers authenticate clients
witch supports tls >= v1.2.
    
This change also disables renegotiation which was discovered as insecure
and easy to exploit.
    
Below `namp` result ensures that the node controller supports only v1.2 ciphers:
    
 ```
$nmap --script +ssl-enum-ciphers -p 10001 172.17.0.4
    
Starting Nmap 7.60 ( https://nmap.org ) at 2020-02-24 16:09 EET
Nmap scan report for 172.17.0.4
Host is up (0.00021s latency).
    
PORT      STATE SERVICE
0001/tcp open  scp-config
| ssl-enum-ciphers:
|   TLSv1.2:
|     ciphers:
|       TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|       TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|     compressors:
|       NULL
|     cipher preference: client
|     warnings:
|       64-bit block cipher 3DES vulnerable to SWEET32 attack
|_  least strength: C
    
 Nmap done: 1 IP address (1 host up) scanned in 0.27 seconds
 ```
