### PR TITLE
CA secrets

### DIFF
--- a/test/setup-ca-kubernetes.sh
+++ b/test/setup-ca-kubernetes.sh
@@ -1,0 +1,60 @@
+#!/bin/sh -e
+
+# This script generates certificates using setup-ca.sh and converts them into
+# the Kubernetes secrets that the PMEM-CSI deployments rely upon for
+# securing communication between PMEM-CSI components. Existing secrets
+# are updated with new certificates when running it again.
+
+# The script needs a functional kubectl that uses the target cluster.
+: ${KUBECTL:=kubectl}
+
+# The directory containing setup-ca*.sh.
+: ${TEST_DIRECTORY:=$(dirname $(readlink -f $0))}
+
+
+tmpdir=`mktemp -d`
+trap 'rm -r $tmpdir' EXIT
+
+# Generate certificates. They are not going to be needed again and will
+# be deleted together with the temp directory.
+WORKDIR="$tmpdir" "$TEST_DIRECTORY/setup-ca.sh"
+
+# This reads a file and encodes it for use in a secret.
+read_key () {
+    base64 -w 0 "$1"
+}
+
+# Read certificate files and turn them into Kubernetes secrets.
+#
+# -caFile (controller and all nodes)
+CA=$(read_key "$tmpdir/ca.pem")
+# -certFile (controller)
+REGISTRY_CERT=$(read_key "$tmpdir/pmem-registry.pem")
+# -keyFile (controller)
+REGISTRY_KEY=$(read_key "$tmpdir/pmem-registry-key.pem")
+# -certFile (same for all nodes)
+NODE_CERT=$(read_key "$tmpdir/pmem-node-controller.pem")
+# -keyFile (same for all nodes)
+NODE_KEY=$(read_key "$tmpdir/pmem-node-controller-key.pem")
+
+${KUBECTL} apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pmem-csi-registry-secrets
+type: kubernetes.io/tls
+data:
+    ca.crt: ${CA}
+    tls.crt: ${REGISTRY_CERT}
+    tls.key: ${REGISTRY_KEY}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pmem-csi-node-secrets
+type: Opaque
+data:
+    ca.crt: ${CA}
+    tls.crt: ${NODE_CERT}
+    tls.key: ${NODE_KEY}
+EOF

--- a/test/setup-ca.sh
+++ b/test/setup-ca.sh
@@ -15,7 +15,7 @@ if [ $cfssl_found -eq 0 ]; then
 fi
 
 # Generate CA certificates.
-<<EOF cfssl gencert -initca - | cfssljson -bare ca
+<<EOF cfssl -loglevel=3 gencert -initca - | cfssljson -bare ca
 {
     "CN": "$CA",
     "key": {
@@ -29,7 +29,7 @@ EOF
 DEFAULT_CNS="pmem-registry pmem-node-controller"
 CNS="${DEFAULT_CNS} ${EXTRA_CNS:=""}"
 for name in ${CNS}; do
-  <<EOF cfssl gencert -ca=ca.pem -ca-key=ca-key.pem - | cfssljson -bare $name
+  <<EOF cfssl -loglevel=3 gencert -ca=ca.pem -ca-key=ca-key.pem - | cfssljson -bare $name
 {
     "CN": "$name",
     "hosts": [
@@ -42,5 +42,3 @@ for name in ${CNS}; do
 }
 EOF
 done
-
-echo "Generated certificates can be located at: $WORKDIR"


### PR DESCRIPTION
We still had (and need) documentation for creating the Kubernetes secrets with `setup-ca-kubernetes.sh`. The removal of that script in https://github.com/intel/pmem-csi/pull/535 broke that.

This PR re-introduces the script in a version which uses `setup-ca.sh` and cleans up the output of that helper script such that normal execution just prints:
```
$ test/setup-ca-kubernetes.sh
secret/pmem-csi-registry-secrets configured
secret/pmem-csi-node-secrets configured
```
