### PR TITLE
Jenkinsfile: Add "throw" statement to break pipeline on error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -529,6 +529,8 @@ void TestInVM(deviceMode, deploymentMode, distro, distroVersion, kubernetesVersi
         echo "Handling exception, get pod state and kubelet logs:"
         sh "_work/${env.CLUSTER}/ssh.0 kubectl get pods --all-namespaces -o wide"
         sh "for cmd in `ls _work/${env.CLUSTER}/ssh.*`; do \$cmd sudo journalctl -u kubelet; done"
+        // regular error handling
+        throw exc
     } finally {
         // Each test run produces junit_*.xml files with testsuite name="PMEM E2E suite".
         // To make test names unique in the Jenkins UI, we rename that test suite per run,


### PR DESCRIPTION
Recently added exception handler caused continue-on-error.