### PR TITLE
check TLS settings

### DIFF
--- a/deploy/kubernetes-1.14/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/direct/pmem-csi.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.14/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/direct/pmem-csi.yaml
@@ -286,7 +286,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/direct/testing/pmem-csi.yaml
@@ -322,7 +322,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.14/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/lvm/pmem-csi.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.14/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/lvm/pmem-csi.yaml
@@ -284,7 +284,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.14/lvm/testing/pmem-csi.yaml
@@ -320,7 +320,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct-testing.yaml
@@ -322,7 +322,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.14/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-direct.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key
@@ -286,7 +286,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm-testing.yaml
@@ -320,7 +320,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.14/pmem-csi-lvm.yaml
@@ -284,7 +284,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kubernetes-1.16/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/pmem-csi.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/pmem-csi.yaml
@@ -286,7 +286,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
@@ -322,7 +322,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
@@ -284,7 +284,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
@@ -320,7 +320,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
@@ -322,7 +322,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.16/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct.yaml
@@ -286,7 +286,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       nodeSelector:
         storage: pmem
       volumes:

--- a/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
@@ -263,7 +263,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
@@ -149,7 +149,7 @@ metadata:
   name: pmem-csi-controller-testing
 spec:
   ports:
-  - port: 10001
+  - port: 10002
   selector:
     app: pmem-csi-controller
   type: NodePort
@@ -221,7 +221,7 @@ spec:
           name: plugin-socket-dir
       - args:
         - -s
-        - tcp-listen:10001,fork,reuseaddr
+        - tcp-listen:10002,fork,reuseaddr
         - unix-connect:/csi/csi-controller.sock
         image: alpine/socat:1.0.3
         name: socat

--- a/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
@@ -320,7 +320,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
@@ -233,7 +233,7 @@ spec:
         - -endpoint=$(CSI_ENDPOINT)
         - -nodeid=$(KUBE_NODE_NAME)
         - -controllerEndpoint=tcp://$(KUBE_POD_IP):10001
-        - -registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)
+        - -registryEndpoint=tcp://pmem-csi-controller:10000
         - -caFile=/certs/ca.crt
         - -certFile=/certs/tls.crt
         - -keyFile=/certs/tls.key

--- a/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
@@ -284,7 +284,6 @@ spec:
           name: pmem-state-dir
         - mountPath: /registration
           name: registration-dir
-      hostNetwork: true
       initContainers:
       - command:
         - /usr/local/bin/pmem-ns-init

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -96,7 +96,6 @@ spec:
     spec:
       nodeSelector:
         storage: pmem
-      hostNetwork: true
       containers:
       - name: pmem-driver
         imagePullPolicy: Always

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -108,7 +108,7 @@ spec:
                   "-endpoint=$(CSI_ENDPOINT)",
                   "-nodeid=$(KUBE_NODE_NAME)",
                   "-controllerEndpoint=tcp://$(KUBE_POD_IP):10001",
-                  "-registryEndpoint=$(PMEM_CSI_CONTROLLER_PORT_10000_TCP)",
+                  "-registryEndpoint=tcp://pmem-csi-controller:10000",
                   "-caFile=/certs/ca.crt",
                   "-certFile=/certs/tls.crt",
                   "-keyFile=/certs/tls.key",

--- a/deploy/kustomize/testing/controller-socat-patch.yaml
+++ b/deploy/kustomize/testing/controller-socat-patch.yaml
@@ -5,7 +5,7 @@
     image: alpine/socat:1.0.3
     args:
     - -s
-    - tcp-listen:10001,fork,reuseaddr
+    - tcp-listen:10002,fork,reuseaddr
     - unix-connect:/csi/csi-controller.sock
     volumeMounts:
     - mountPath: /csi

--- a/deploy/kustomize/testing/socat.yaml
+++ b/deploy/kustomize/testing/socat.yaml
@@ -7,7 +7,7 @@ spec:
   selector:
     app: pmem-csi-controller
   ports:
-  - port: 10001 # port inside the pod where controller-socat-path.yaml forwards the csi.sock
+  - port: 10002 # port inside the pod where controller-socat-path.yaml forwards the csi.sock
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/pkg/pmem-device-manager/pmd-manager_test.go
+++ b/pkg/pmem-device-manager/pmd-manager_test.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 
 	pmemexec "github.com/intel/pmem-csi/pkg/pmem-exec"
@@ -61,6 +62,9 @@ func runTests(mode string) {
 			dm, err = NewPmemDeviceManagerLVMForVGs([]string{vg.name})
 		} else {
 			dm, err = NewPmemDeviceManagerNdctl()
+			if err != nil && strings.Contains(err.Error(), "/sys mounted read-only") {
+				Skip("/sys mounted read-only, cannot test direct mode")
+			}
 		}
 		Expect(err).Should(BeNil(), "Failed to create LVM device manager")
 

--- a/pkg/pmem-grpc/grpc.go
+++ b/pkg/pmem-grpc/grpc.go
@@ -101,6 +101,7 @@ func LoadServerTLS(caFile, certFile, keyFile, peerName string) (*tls.Config, err
 					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
 					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 					tls.TLS_RSA_WITH_RC4_128_SHA,
+					tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
 					tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
 					tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 					tls.TLS_RSA_WITH_AES_128_CBC_SHA,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -32,6 +32,7 @@ import (
 	// test sources
 	_ "github.com/intel/pmem-csi/test/e2e/gotests"
 	_ "github.com/intel/pmem-csi/test/e2e/storage"
+	_ "github.com/intel/pmem-csi/test/e2e/tls"
 )
 
 func TestMain(m *testing.M) {

--- a/test/e2e/pod/exec.go
+++ b/test/e2e/pod/exec.go
@@ -57,5 +57,5 @@ func RunInPod(f *framework.Framework, rootdir string, items []string, command st
 	framework.ExpectNoError(err, "command failed in namespace %s, pod/container %s/%s:\nstderr:\n%s\nstdout:%s\n",
 		namespace, pod, container, stderr, stdout)
 	fmt.Fprintf(GinkgoWriter, "stderr:\n%s\nstdout:\n%s",
-		stdout, stderr)
+		stderr, stdout)
 }

--- a/test/e2e/pod/exec.go
+++ b/test/e2e/pod/exec.go
@@ -18,7 +18,7 @@ import (
 
 // RunInPod optionally tars up some files or directories, unpacks them in a container,
 // and executes a shell command. Any error is treated as test failure.
-func RunInPod(f *framework.Framework, rootdir string, items []string, command string, namespace, pod, container string) {
+func RunInPod(f *framework.Framework, rootdir string, items []string, command string, namespace, pod, container string) (string, string) {
 	var input io.Reader
 	var cmdPrefix string
 	if len(items) > 0 {
@@ -58,4 +58,6 @@ func RunInPod(f *framework.Framework, rootdir string, items []string, command st
 		namespace, pod, container, stderr, stdout)
 	fmt.Fprintf(GinkgoWriter, "stderr:\n%s\nstdout:\n%s",
 		stderr, stdout)
+
+	return stdout, stderr
 }

--- a/test/e2e/tls/nmap-ssl-enum-ciphers.patch
+++ b/test/e2e/tls/nmap-ssl-enum-ciphers.patch
@@ -1,0 +1,17 @@
+Without this patch, nmap skips cipers using ECDHE.
+https://github.com/nmap/nmap/issues/1187#issuecomment-587031079
+
+diff -c /usr/share/nmap/scripts/ssl-enum-ciphers.nse.orig /usr/share/nmap/scripts/ssl-enum-ciphers.nse
+*** /usr/share/nmap/scripts/ssl-enum-ciphers.nse.orig	2020-03-06 09:41:59.657722734 +0000
+--- /usr/share/nmap/scripts/ssl-enum-ciphers.nse	2020-03-06 09:43:24.982459541 +0000
+***************
+*** 516,521 ****
+--- 516,523 ----
+    return {
+      -- Claim to support common elliptic curves
+      ["elliptic_curves"] = tls.EXTENSION_HELPERS["elliptic_curves"](tls.DEFAULT_ELLIPTIC_CURVES),
++     -- Claim to support every EC point format
++     ["ec_point_formats"] = tls.EXTENSION_HELPERS["ec_point_formats"](sorted_keys(tls.EC_POINT_FORMATS)),
+      -- Enable SNI if a server name is available
+      ["server_name"] = tlsname and tls.EXTENSION_HELPERS["server_name"](tlsname),
+    }

--- a/test/e2e/tls/tls.go
+++ b/test/e2e/tls/tls.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2019 Intel Corporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tls
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	pmempod "github.com/intel/pmem-csi/test/e2e/pod"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+)
+
+var _ = Describe("TLS", func() {
+	f := framework.NewDefaultFramework("tls")
+
+	// All of the following pod names, namespaces and ports match
+	// those in the current deployment files.
+
+	var nodePod *v1.Pod
+	BeforeEach(func() {
+		// Find one node driver pod.
+		label := labels.SelectorFromSet(labels.Set(map[string]string{"app": "pmem-csi-node"}))
+		pods, err := f.ClientSet.CoreV1().Pods("default").List(metav1.ListOptions{LabelSelector: label.String()})
+		framework.ExpectNoError(err, "list PMEM-CSI node pods")
+		Expect(pods.Items).NotTo(BeEmpty(), "have PMEM-CSI node pods")
+		nodePod = &pods.Items[0]
+	})
+
+	Context("controller", func() {
+		It("is secure", func() {
+			checkTLS(f, "pmem-csi-controller-0.pmem-csi-controller.default")
+		})
+	})
+	Context("node", func() {
+		It("is secure", func() {
+			checkTLS(f, nodePod.Status.PodIP)
+		})
+	})
+})
+
+func checkTLS(f *framework.Framework, server string) {
+	containerName := "nmap"
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      containerName,
+			Namespace: f.Namespace.Name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "nmap",
+					Image:   os.Getenv("PMEM_CSI_IMAGE"),
+					Command: []string{"sleep", "1000000"},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+
+	By(fmt.Sprintf("Creating pod %s", pod.Name))
+	ns := f.Namespace.Name
+	podClient := f.PodClientNS(ns)
+	createdPod := podClient.Create(pod)
+	defer func() {
+		By("delete the pod")
+		podClient.DeleteSync(createdPod.Name, &metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
+	}()
+	podErr := e2epod.WaitForPodRunningInNamespace(f.ClientSet, createdPod)
+	framework.ExpectNoError(podErr, "running pod")
+
+	By("scanning ports")
+	// We have to patch nmap because of https://github.com/nmap/nmap/issues/1187#issuecomment-587031079.
+	output, _ := pmempod.RunInPod(f, os.Getenv("REPO_ROOT")+"/test/e2e/tls", []string{"nmap-ssl-enum-ciphers.patch"},
+		strings.Join([]string{
+			fmt.Sprintf("https_proxy=%s swupd bundle-add nmap patch >&2", os.Getenv("HTTPS_PROXY")),
+			"patch /usr/share/nmap/scripts/ssl-enum-ciphers.nse <nmap-ssl-enum-ciphers.patch",
+			fmt.Sprintf("nmap --script +ssl-enum-ciphers --open -Pn %s 2>&1", server),
+		},
+			" && "),
+		ns, pod.Name, containerName)
+
+	// Now analyze all ports and the ciphers found for them.
+	// The output will be something like this:
+	//   Nmap scan report for pmem-csi-controller-0.pmem-csi-controller.default (10.44.0.1)
+	//   Host is up (0.00013s latency).
+	//   rDNS record for 10.44.0.1: pmem-csi-controller-0.pmem-csi-controller.default.svc.cluster.local
+	//   Not shown: 997 closed ports
+	//   PORT      STATE SERVICE
+	//   8000/tcp  open  http-alt
+	//   | ssl-enum-ciphers:
+	//   |   TLSv1.0:
+	//   |     ciphers:
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (ecdh_x25519) - A
+	//   |     compressors:
+	//   |       NULL
+	//   |     cipher preference: server
+	//   |   TLSv1.1:
+	//   |     ciphers:
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (ecdh_x25519) - A
+	//   |     compressors:
+	//   |       NULL
+	//   |     cipher preference: server
+	//   |   TLSv1.2:
+	//   |     ciphers:
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (ecdh_x25519) - A
+	//   |     compressors:
+	//   |       NULL
+	//   |     cipher preference: server
+	//   |_  least strength: A
+	//   10000/tcp open  snet-sensor-mgmt
+	//   | ssl-enum-ciphers:
+	//   |   TLSv1.2:
+	//   |     ciphers:
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
+	//   |       TLS_ECDHE_ECDSA_WITH_RC4_128_SHA (ecdh_x25519) - C
+	//   |     compressors:
+	//   |       NULL
+	//   |     cipher preference: client
+	//   |     warnings:
+	//   |       Broken cipher RC4 is deprecated by RFC 7465
+	//   |_  least strength: C
+	//   10002/tcp open  documentum
+	//   MAC Address: D2:82:BC:59:C9:CC (Unknown)
+	//
+	//   Nmap done: 1 IP address (1 host up) scanned in 0.34 seconds
+
+	// We need the full strings if the comparison below fails.
+	old := format.TruncatedDiff
+	defer func() {
+		format.TruncatedDiff = old
+	}()
+	format.TruncatedDiff = false
+
+	re := regexp.MustCompile(`(?m)^([[:digit:]]+)/.* open .*\n((?:^\|.*\n)*)`)
+	ports := re.FindAllStringSubmatch(output, -1)
+	Expect(ports).NotTo(BeEmpty(), "ports found")
+	for _, entry := range ports {
+		port, ciphers := entry[1], entry[2]
+		if port == "10002" {
+			// The socat debugging port. Can be ignored.
+			continue
+		}
+		// All other ports must use TLS, with exactly the
+		// ciphers that we want enabled. All of them should be rated A.
+		// The exact output depends a bit on the version of nmap and of
+		// Go that is being used for building PMEM-CSI, so this list
+		// may have to be adapted when changing either of these.
+		Expect(ciphers).To(Equal(`| ssl-enum-ciphers: 
+|   TLSv1.2: 
+|     ciphers: 
+|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 (ecdh_x25519) - A
+|       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
+|       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
+|       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
+|     compressors: 
+|       NULL
+|     cipher preference: client
+|_  least strength: A
+`), "ciphers for port %s in %s", port, server)
+	}
+}

--- a/test/e2e/tls/tls.go
+++ b/test/e2e/tls/tls.go
@@ -166,9 +166,18 @@ func checkTLS(f *framework.Framework, server string) {
 		}
 		// All other ports must use TLS, with exactly the
 		// ciphers that we want enabled. All of them should be rated A.
-		// The exact output depends a bit on the version of nmap and of
-		// Go that is being used for building PMEM-CSI, so this list
-		// may have to be adapted when changing either of these.
+		//
+		// The exact output depends on:
+		// - the version of nmap (locked on release branches by fixing the Clear Linux
+		//   release, varies on development branches)
+		// - the version of Go that is being used for building PMEM-CSI (locked
+		//   in our Dockerfile)
+		// - the generated keys and thus the deployment method (the
+		//   current list is for "make start" and keys created with
+		//   test/setup-ca.sh, which in turn uses cfssl as installed
+		//   by test/test.make, at least in the CI)
+		//
+		// This list may have to be adapted when changing either of these.
 		Expect(ciphers).To(Equal(`| ssl-enum-ciphers: 
 |   TLSv1.2: 
 |     ciphers: 


### PR DESCRIPTION
The recent tightening of TLS ciphers came without automated testing and turned out to be surprisingly hard to test manually due to bugs in nmap.

This PR simplifies the deployment a bit and then adds full port scanning (not just currently known ports!) and checking of the TLS settings.
