### PR TITLE
deploy: fix 1.14 and 1.15, webhook was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,9 +1005,10 @@ kubectl label ns kube-system pmem-csi.intel.com/webhook=ignore
 ```
 
 This special label is configured in [the provided web hook
-definition](./deploy/kustomize/webhook/webhook.yaml). It can also be
-used to let individual pods bypass the webhook by adding that label.
-The CA gets configured explicitly, which is supported for webhooks.
+definition](./deploy/kustomize/webhook/webhook.yaml). On Kubernetes >=
+1.15, it can also be used to let individual pods bypass the webhook by
+adding that label. The CA gets configured explicitly, which is
+supported for webhooks.
 
 ``` sh
 mkdir my-webhook

--- a/deploy/kubernetes-1.14/webhook
+++ b/deploy/kubernetes-1.14/webhook
@@ -1,0 +1,1 @@
+../kustomize/webhook-1.14

--- a/deploy/kubernetes-1.15/webhook
+++ b/deploy/kubernetes-1.15/webhook
@@ -1,0 +1,1 @@
+../kustomize/webhook

--- a/deploy/kustomize/webhook-1.14/kustomization.yaml
+++ b/deploy/kustomize/webhook-1.14/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - webhook.yaml

--- a/deploy/kustomize/webhook-1.14/webhook.yaml
+++ b/deploy/kustomize/webhook-1.14/webhook.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: pmem-csi-hook
+webhooks:
+  - name: pod-hook.pmem-csi.intel.com
+    namespaceSelector:
+      matchExpressions:
+      - key: pmem-csi.intel.com/webhook
+        operator: NotIn
+        values: ["ignore"]
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        name: pmem-csi-scheduler
+        namespace: default
+        path: /pod/mutate
+      caBundle:
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]

--- a/deploy/kustomize/webhook/kustomization.yaml
+++ b/deploy/kustomize/webhook/kustomization.yaml
@@ -1,2 +1,6 @@
+# It would be nicer to patch webhook-1.14 here, but that leads to
+# complications in test/setup-deployment.sh because it cannot deal
+# with kustomizations which aren't self-contained. As webhook-1.14 is going
+# to become unsupported soon, it's better to keep webhook simple.
 resources:
   - webhook.yaml

--- a/test/setup-deployment.sh
+++ b/test/setup-deployment.sh
@@ -79,6 +79,16 @@ data:
 EOF
 
 echo "$KUBERNETES_VERSION" > $WORK_DIRECTORY/kubernetes.version
+case "$KUBERNETES_VERSION" in
+    1.1[01234])
+        # We cannot exclude the PMEM-CSI pods from the webhook because objectSelector
+        # was only added in 1.15. Instead, we exclude the entire "default" namespace.
+        # This means our normal test applications also don't use it, but our normal
+        # instructions for checking that PMEM-CSI works still apply.
+        ${KUBECTL} label --overwrite ns default pmem-csi.intel.com/webhook=ignore
+        ;;
+esac
+
 for deploy in ${DEPLOY[@]}; do
     path="${DEPLOYMENT_DIRECTORY}/${deploy}"
     if [ -f "$path" ]; then


### PR DESCRIPTION
PR #530 broke deployment on 1.14 and 1.15 because it made all
components of a deployment mandatory but didn't add the "webhook"
link.