### PR TITLE
test: always test with a fresh cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -434,6 +434,7 @@ void TestInVM(distro, distroVersion, kubernetesVersion, skipIfPR) {
                            loggers=; \
                            atexit () { set -x; kill \$loggers; kill \$( ps --no-header -o %p ); }; \
                            trap atexit EXIT; \
+                           make stop && \
                            make start && \
                            _work/${env.CLUSTER}/ssh.0 kubectl get pods --all-namespaces -o wide && \
                            for pod in ${env.LOGGING_PODS}; do \


### PR DESCRIPTION
After removing the "reuse cluster" logic in
https://github.com/intel/pmem-csi/pull/548, the same cluster was used
throughout all steps, so instead of testing on the desired OS, the
tests just ran again on the initial one.

A potentially running cluster is intentionally torn down before
testing because that way we can avoid the tear down after the last
step. We don't need to do it then because the whole VM will go down.