### PR TITLE
pmem-state: do not allow tampering of state file data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.2.0 // indirect
-	go.uber.org/zap v1.11.0 // indirect
+	go.uber.org/zap v1.11.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343
 	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -83,7 +83,11 @@ func NewNodeControllerServer(nodeID string, dm pmdmanager.PmemDeviceManager, sm 
 		}
 		cleanupList := []string{}
 		v := &nodeVolume{}
-		err = sm.GetAll(v, func(id string) bool {
+		err = sm.GetAll(v, func(id string, e error) bool {
+			if e != nil {
+				klog.Warningf("failed to load volume info for id %q from state: %v", id, e)
+				return true
+			}
 			// See if the device data stored at StateManager is still valid
 			for _, devInfo := range devices {
 				if devInfo.VolumeId == id {

--- a/runtime-deps.csv
+++ b/runtime-deps.csv
@@ -1,4 +1,5 @@
 Go,https://github.com/golang/go,9051
+buffer,https://go.uber.org/zap/buffer
 client_golang,https://github.com/prometheus/client_golang
 golang-protobuf,https://github.com/golang/protobuf
 google uuid,https://github.com/google/uuid

--- a/test/test.make
+++ b/test/test.make
@@ -109,6 +109,7 @@ RUNTIME_DEPS += sed \
 	-e 's;\(github.com/prometheus/procfs\);prometheus_procfs,https://\1;' \
 	-e 's;\(github.com/spf13/pflag\);github.com\\spf13\\pflag,https://\1;' \
 	-e 's;\(github.com/vgough/grpc-proxy\);grpc-proxy,https://\1;' \
+	-e 's;\(go.uber.org/zap/buffer\);buffer,https://\1;' \
 	-e 's;gomodules.xyz/jsonpatch/v.*;gomodules jsonpatch,https://github.com/gomodules/jsonpatch;' \
 	-e 's;gopkg.in/fsnotify.*;golang-github-fsnotify-fsnotify,https://github.com/fsnotify/fsnotify;' \
 	-e 's;gopkg.in/inf\.v.*;go-inf,https://github.com/go-inf/inf;' \


### PR DESCRIPTION
Driver's state should not be altered outside of the driver. So added an
integrity check to state data. StateManager computes the hash for the
data being saved and stores the generated hash along with the data.

This change is not backward compatible and breaks loading of older state
files which have no hash information.