### PR TITLE
Reduce logs, cover edge cases in /sys mount check

### DIFF
--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -556,7 +556,6 @@ func (ns *nodeServer) mount(sourcePath, targetPath string, mountOptions []string
 	}
 
 	args = append(args, sourcePath, targetPath)
-	klog.V(4).Infof("mount args: [%v]", args)
 	if _, err := pmemexec.RunCommand("mount", args...); err != nil {
 		return fmt.Errorf("mount filesystem failed: %s", err.Error())
 	}

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -32,9 +32,8 @@ func NewPmemDeviceManagerNdctl() (PmemDeviceManager, error) {
 	// Check is /sys writable. If not then there is no point starting
 	mounts, _ := mount.New("").List()
 	for _, mnt := range mounts {
-		klog.V(5).Infof("NewPmemDeviceManagerNdctl: Check mounts: device=%s path=%s opts=%s",
-			mnt.Device, mnt.Path, mnt.Opts)
 		if mnt.Device == "sysfs" && mnt.Path == "/sys" {
+			klog.V(5).Infof("NewPmemDeviceManagerNdctl: sysfs mount options:%s", mnt.Opts)
 			for _, opt := range mnt.Opts {
 				if opt == "rw" {
 					klog.V(4).Info("NewPmemDeviceManagerNdctl: /sys mounted read-write, good")

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -37,15 +37,15 @@ func NewPmemDeviceManagerNdctl() (PmemDeviceManager, error) {
 			for _, opt := range mnt.Opts {
 				if opt == "rw" {
 					klog.V(4).Info("NewPmemDeviceManagerNdctl: /sys mounted read-write, good")
+					return &pmemNdctl{}, nil
 				} else if opt == "ro" {
 					return nil, fmt.Errorf("FATAL: /sys mounted read-only, can not operate")
 				}
 			}
-			break
+			return nil, fmt.Errorf("FATAL: /sys mount entry exists but does not have neither 'rw' or 'ro' option")
 		}
 	}
-
-	return &pmemNdctl{}, nil
+	return nil, fmt.Errorf("FATAL: /sys mount entry not present")
 }
 
 func (pmem *pmemNdctl) GetCapacity() (uint64, error) {

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -420,6 +420,7 @@ func EnsureDeployment(deploymentName string) *Deployment {
 		cmd.Dir = os.Getenv("REPO_ROOT")
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env,
+			"TEST_DEPLOYMENT_QUIET=quiet",
 			"TEST_DEPLOYMENTMODE="+deployment.DeploymentMode(),
 			"TEST_DEVICEMODE="+string(deployment.Mode))
 		cmd.Stdout = ginkgo.GinkgoWriter

--- a/test/setup-deployment.sh
+++ b/test/setup-deployment.sh
@@ -202,7 +202,8 @@ done
 
 ${KUBECTL} label --overwrite ns kube-system pmem-csi.intel.com/webhook=ignore
 
-cat <<EOF
+if [ "${TEST_DEPLOYMENT_QUIET}" = "" ]; then
+    cat <<EOF
 
 To try out the pmem-csi driver persistent volumes:
    cat deploy/kubernetes-${KUBERNETES_VERSION}/pmem-pvc.yaml | ${KUBECTL} create -f -
@@ -213,19 +214,20 @@ To try out the pmem-csi driver cache volumes:
    cat deploy/kubernetes-${KUBERNETES_VERSION}/pmem-app-cache.yaml | ${KUBECTL} create -f -
 EOF
 
-if [ -e ${DEPLOYMENT_DIRECTORY}/pmem-storageclass-late-binding.yaml ]; then
-    cat <<EOF
+    if [ -e ${DEPLOYMENT_DIRECTORY}/pmem-storageclass-late-binding.yaml ]; then
+        cat <<EOF
 
 To try out the pmem-csi driver persistent volumes with late binding:
    cat deploy/kubernetes-${KUBERNETES_VERSION}/pmem-pvc-late-binding.yaml | ${KUBECTL} create -f -
    cat deploy/kubernetes-${KUBERNETES_VERSION}/pmem-app-late-binding.yaml | ${KUBECTL} create -f -
 EOF
-fi
+    fi
 
-if [ -e ${DEPLOYMENT_DIRECTORY}/pmem-app-ephemeral.yaml ]; then
-    cat <<EOF
+    if [ -e ${DEPLOYMENT_DIRECTORY}/pmem-app-ephemeral.yaml ]; then
+        cat <<EOF
 
 To try out the pmem-csi driver ephemeral volumes:
    cat deploy/kubernetes-${KUBERNETES_VERSION}/pmem-app-ephemeral.yaml | ${KUBECTL} create -f -
 EOF
+    fi
 fi

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -85,9 +85,9 @@ while ! dnf install -y $packages; do
     fi
     cnt=$(($cnt + 1))
     # If it works, proceed immediately. If it fails, sleep and try again without aborting on an error.
-    if ! dnf update -y --refresh; then
+    if ! dnf update -q -y --refresh; then
         sleep 20
-        dnf update -y --refresh || true
+        dnf update -q -y --refresh || true
     fi
 done
 

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -100,7 +100,7 @@ if $INIT_KUBERNETES; then
     # We create /opt/cni/bin containing symlinks for every binary:
     mkdir -p /opt/cni/bin
     for i in /usr/libexec/cni/*; do
-        ln -vs $i /opt/cni/bin/
+        ln -s $i /opt/cni/bin/
     done
 
     # Testing may involve a Docker registry running on the build host (see

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -381,6 +381,7 @@ function init_kubernetes_cluster() (
                 if [ "$SECONDS" -gt "$SSH_TIMEOUT" ]; then
                     die "timeout waiting for ${ip} to reboot with changed kernel parameters"
                 fi
+		sleep 1
             done
         done
     fi


### PR DESCRIPTION
Looking at logs shows few possibilities to reduce redundant or not relevant logs.
While changing /sys detection logging, I discovered this function may return OK in some edge cases where search for mount point or mount option does not match, which is not what we want, so there is one commit improving that part.