### PR TITLE
e2e GetHostVolumes: Add sort of ndctl entries, simplify.

### DIFF
--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -1035,9 +1035,10 @@ func GetHostVolumes(d *deploy.Deployment) map[string][]string {
 		hdr = "LVM Volumes"
 	case pmemcsidriver.Direct:
 		// ndctl produces multiline block. We want one line per namespace.
-		// Remove double quotes, delete lines dev:xyz and blockdev:xyz as these elems may change after reboot,
-		// remove newlines, then insert one at the end, clean some more.
-		cmd = "sudo ndctl list |tr -d '\"' |grep -v '^    dev:' |grep	-v '^    blockdev:' |tr -d '\n' |tr ']' '\n' |tr -d '[{}' |tr -d ' '"
+		// Pick uuid, mode, size for comparison. Note that sorting changes the order so lines
+		// are not grouped by volume, but keeping volume order would need more complex parsing
+		// and this is not meant to be pretty-printed for human, just to detect the change.
+		cmd = "sudo ndctl list |tr -d '\"' |egrep 'uuid|mode|^ *size' |sort |tr -d ' \n'"
 		hdr = "Namespaces"
 	}
 	result := make(map[string][]string)


### PR DESCRIPTION
The volume list by ndctl order may change. Use simplified approach
that does not pretty-print for human reader, but detects the changes
(what we really need here) and makes it ireport-order-independent via sort.

Resolves: #577