### PR TITLE
test: relax TLS error check even further

### DIFF
--- a/pkg/registryserver/registryserver_test.go
+++ b/pkg/registryserver/registryserver_test.go
@@ -174,7 +174,7 @@ var _ = Describe("pmem registry", func() {
 		)
 
 		// gRPC returns all kinds of errors when TLS fails.
-		badConnectionRE := "authentication handshake failed: remote error: tls: bad certificate|all SubConns are in TransientFailure|rpc error: code = Unavailable desc = connection closed|rpc error: code = Unavailable desc = tls: use of closed connection|transport: failed to write client preface: write .*: write: broken pipe"
+		badConnectionRE := "authentication handshake failed: remote error: tls: bad certificate|all SubConns are in TransientFailure|rpc error: code = Unavailable"
 
 		// This covers different scenarios for connections to the registry.
 		cases := []struct {


### PR DESCRIPTION
Yet another error text appeared in CI testing ("rpc error: code =
Unavailable desc = write unix @->pmem-registry.sock: write: broken
pipe").

Instead of checking for specific error texts, all "rpc error: code =
Unavailable" errors are now accepted.