### PR TITLE
test: avoid running controller and node drivers on same node

### DIFF
--- a/test/setup-deployment.sh
+++ b/test/setup-deployment.sh
@@ -113,12 +113,34 @@ patchesJson6902:
       version: v1
       kind: StatefulSet
       name: pmem-csi-controller
-    path: scheduler-patch.yaml
+    path: controller-patch.yaml
 EOF
-                ${SSH} "cat >'$tmpdir/my-deployment/scheduler-patch.yaml'" <<EOF
+                ${SSH} "cat >'$tmpdir/my-deployment/controller-patch.yaml'" <<EOF
 - op: add
   path: /spec/template/spec/containers/0/command/-
   value: "--schedulerListen=:8000" # Exposed to kube-scheduler via the pmem-csi-scheduler service.
+- op: add
+  path: /spec/template/spec/affinity
+  value:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          # Do *not* run controller on worker nodes with PMEM. This is
+          # a workaround for a particular issue on Clear Linux where network
+          # configuration randomly fails such that the driver which runs on the same
+          # node as the controller cannot connect to the controller
+          # (https://github.com/intel/pmem-csi/issues/555).
+          - key: storage
+            operator: NotIn
+            values:
+            - pmem
+- op: add
+  path: /spec/template/spec/tolerations
+  value:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
 EOF
                 if [ "${TEST_DEVICEMODE}" = "lvm" ]; then
                     # Test these options and kustomization by injecting some non-default values.


### PR DESCRIPTION
We haven't found a good solution for the networking issues on Clear
Linux (https://github.com/intel/pmem-csi/issues/555) that plague our
periodic builds.

As a workaround, ensuring that the controller runs on the master node
and thus never on the same node as a node driver avoids the
problematic case.