### PR TITLE
operator: do not delete CRD if any deployments are in active

### DIFF
--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -181,7 +181,7 @@ func WaitForPMEMDriver(c *Cluster, namespace string) {
 // statefulsets, driver info, storage classes, etc.).
 func RemoveObjects(c *Cluster, deploymentName string) error {
 	// Try repeatedly, in case that communication with the API server fails temporarily.
-	deadline, cancel := context.WithTimeout(context.Background(), time.Minute)
+	deadline, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -61,8 +61,8 @@ func AddUninstallHook(h UninstallHook) {
 // currently defined as the operator pod in Running phase.
 func WaitForOperator(c *Cluster, namespace string) (operator *v1.Pod) {
 	// TODO(avalluri): At later point of time we should add readiness support
-	// for the operator. Then we can query directoly the operator if its ready.
-	// As interm solution we are just checking Pod.Status.
+	// for the operator. Then we can query directly the operator if its ready.
+	// As intrem solution we are just checking Pod.Status.
 	gomega.Eventually(func() bool {
 		pod, err := c.GetAppInstance("pmem-csi-operator", "", namespace)
 		if err == nil && pod.Status.Phase == v1.PodRunning {

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -486,13 +486,13 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 
 		It("shall be able to use custom CA certificates", func() {
 			caKey, err := pmemtls.NewPrivateKey()
-			Expect(err).ShouldNot(HaveOccurred(), "creatre ca private key")
+			Expect(err).ShouldNot(HaveOccurred(), "create ca private key")
 			regKey, err := pmemtls.NewPrivateKey()
-			Expect(err).ShouldNot(HaveOccurred(), "creatre registry private key")
+			Expect(err).ShouldNot(HaveOccurred(), "create registry private key")
 			nodeControllerKey, err := pmemtls.NewPrivateKey()
-			Expect(err).ShouldNot(HaveOccurred(), "creatre node ocntroller private key")
+			Expect(err).ShouldNot(HaveOccurred(), "create node controller private key")
 			ca, err := pmemtls.NewCA(nil, caKey)
-			Expect(err).ShouldNot(HaveOccurred(), "creatre ca")
+			Expect(err).ShouldNot(HaveOccurred(), "create ca")
 
 			regCert, err := ca.GenerateCertificate("pmem-registry", regKey.Public())
 			Expect(err).ShouldNot(HaveOccurred(), "sign registry key")


### PR DESCRIPTION
Deleting CRD deletes all active resources which result in restarting operator pod deletes the driver. So we only delete CRD if no active deployments found.
    
FIXES: #579