### PR TITLE
enhance RemoveObject, fix operator handling of deleted CRs

### DIFF
--- a/pkg/pmem-csi-operator/controller/deployment/deployment_controller.go
+++ b/pkg/pmem-csi-operator/controller/deployment/deployment_controller.go
@@ -146,6 +146,14 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{Requeue: requeue, RequeueAfter: requeueDelayOnError}, err
 	}
 
+	// If the deployment has already been marked for deletion,
+	// then we don't need to do anything for it because the
+	// apiserver is in the process of garbage-collecting all
+	// sub-objects and then will remove it.
+	if deployment.DeletionTimestamp != nil {
+		return reconcile.Result{Requeue: false}, nil
+	}
+
 	d := &PmemCSIDriver{deployment, r.namespace}
 
 	// update status


### PR DESCRIPTION
The operator shouldn't create sub-objects for a CR that is already in the process of being deleted. That and the higher timeout should address the problem in https://cloudnative-k8sci.southcentralus.cloudapp.azure.com/job/pmem-csi/view/change-requests/job/PR-605/1/testReport/junit/fedora-1_16.operator/API/deployment_with_defaults/

```
Unexpected error:
    <*errors.errorString | 0xc00109eee0>: {
        s: "timed out while trying to delete the operator-lvm-production PMEM-CSI deployment",
    }
    timed out while trying to delete the operator-lvm-production PMEM-CSI deployment
occurred
...
