### PR TITLE
test: use Kubernetes 1.18 by default

### DIFF
--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -131,7 +131,7 @@ fi
 # is installed instead of the latest one. Ignored when
 # using Clear Linux as OS because with Clear Linux we have
 # to use the Kubernetes version that ships with it.
-: ${TEST_KUBERNETES_VERSION:=1.16}
+: ${TEST_KUBERNETES_VERSION:=1.18}
 
 # Kubernetes node port number
 # (https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)


### PR DESCRIPTION
This isn't relevant for the CI, but developers running
"TEST_DISTRO=fedora make start" probably will want the latest
supported Kubernetes.