### PR TITLE
deploy: fix kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,14 @@ KUSTOMIZE_INPUT := $(shell [ ! -d deploy/kustomize ] || find deploy/kustomize -t
 # The "testing" flavor of the generated files contains both
 # the loglevel changes and enables coverage data collection.
 KUSTOMIZE_OUTPUT :=
+KUSTOMIZE_OUTPUT += deploy/kubernetes-1.15/pmem-csi-direct.yaml
+KUSTOMIZATION_deploy/kubernetes-1.15/pmem-csi-direct.yaml = deploy/kustomize/kubernetes-1.15-direct
+KUSTOMIZE_OUTPUT += deploy/kubernetes-1.15/pmem-csi-lvm.yaml
+KUSTOMIZATION_deploy/kubernetes-1.15/pmem-csi-lvm.yaml = deploy/kustomize/kubernetes-1.15-lvm
+KUSTOMIZE_OUTPUT += deploy/kubernetes-1.15/pmem-csi-direct-testing.yaml
+KUSTOMIZATION_deploy/kubernetes-1.15/pmem-csi-direct-testing.yaml = deploy/kustomize/kubernetes-1.15-direct-coverage
+KUSTOMIZE_OUTPUT += deploy/kubernetes-1.15/pmem-csi-lvm-testing.yaml
+KUSTOMIZATION_deploy/kubernetes-1.15/pmem-csi-lvm-testing.yaml = deploy/kustomize/kubernetes-1.15-lvm-coverage
 KUSTOMIZE_OUTPUT += deploy/kubernetes-1.16/pmem-csi-direct.yaml
 KUSTOMIZATION_deploy/kubernetes-1.16/pmem-csi-direct.yaml = deploy/kustomize/kubernetes-1.16-direct
 KUSTOMIZE_OUTPUT += deploy/kubernetes-1.16/pmem-csi-lvm.yaml

--- a/deploy/kubernetes-1.15/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.15/direct/pmem-csi.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kubernetes-1.15/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.15/direct/testing/pmem-csi.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.15/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.15/lvm/pmem-csi.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kubernetes-1.15/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.15/lvm/testing/pmem-csi.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.15/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.15/pmem-csi-direct-testing.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.15/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.15/pmem-csi-direct.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kubernetes-1.15/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.15/pmem-csi-lvm-testing.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.15/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.15/pmem-csi-lvm.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kubernetes-1.15/pmem-csi.yaml
+++ b/deploy/kubernetes-1.15/pmem-csi.yaml
@@ -1,1 +1,0 @@
-pmem-csi-lvm.yaml

--- a/deploy/kubernetes-1.16/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/pmem-csi.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/direct/testing/pmem-csi.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/pmem-csi.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.16/lvm/testing/pmem-csi.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct-testing.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.16/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-direct.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm-testing.yaml
@@ -251,6 +251,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         - -v=5
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always

--- a/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.16/pmem-csi-lvm.yaml
@@ -231,6 +231,8 @@ spec:
         - --csi-address=/csi/csi-controller.sock
         - --feature-gates=Topology=true
         - --strict-topology=true
+        - --timeout=5m
+        - --strict-topology=true
         image: quay.io/k8scsi/csi-provisioner:v1.2.1
         imagePullPolicy: Always
         name: external-provisioner

--- a/deploy/kustomize/kubernetes-1.15-direct-coverage/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15-direct-coverage/kustomization.yaml
@@ -1,0 +1,22 @@
+bases:
+- ../kubernetes-1.15-direct-testing/
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../testing/controller-coverage-patch.yaml
+
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../testing/node-coverage-patch.yaml
+
+images:
+- name: intel/pmem-csi-driver
+  newName: intel/pmem-csi-driver-test
+

--- a/deploy/kustomize/kubernetes-1.15-direct-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15-direct-testing/kustomization.yaml
@@ -1,0 +1,28 @@
+bases:
+- ../kubernetes-1.15-direct/
+- ../testing/
+
+commonLabels:
+  pmem-csi.intel.com/deployment: direct-testing
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../testing/controller-socat-patch.yaml
+
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../testing/args-two-containers-patch.yaml
+
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../testing/args-two-containers-patch.yaml

--- a/deploy/kustomize/kubernetes-1.15-direct/README.md
+++ b/deploy/kustomize/kubernetes-1.15-direct/README.md
@@ -1,0 +1,3 @@
+# Kubernetes v1.15 Direct Mode specific changes
+
+This overlay configures the driver to use direct mode.

--- a/deploy/kustomize/kubernetes-1.15-direct/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15-direct/kustomization.yaml
@@ -1,0 +1,15 @@
+# Turns generic Kubernetes 1.15 deployment into deployment for direct mode.
+
+bases:
+- ../kubernetes-1.15/
+
+commonLabels:
+  pmem-csi.intel.com/deployment: direct-production
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../patches/direct-patch.yaml

--- a/deploy/kustomize/kubernetes-1.15-lvm-coverage/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15-lvm-coverage/kustomization.yaml
@@ -1,0 +1,31 @@
+bases:
+- ../kubernetes-1.15-lvm-testing/
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../testing/controller-coverage-patch.yaml
+
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../testing/node-coverage-patch.yaml
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../testing/lvm-coverage-patch.yaml
+
+images:
+- name: intel/pmem-csi-driver
+  newName: intel/pmem-csi-driver-test
+- name: intel/pmem-ns-init
+  newName: intel/pmem-ns-init-test
+- name: intel/pmem-vgm
+  newName: intel/pmem-vgm-test

--- a/deploy/kustomize/kubernetes-1.15-lvm-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15-lvm-testing/kustomization.yaml
@@ -1,0 +1,35 @@
+bases:
+- ../kubernetes-1.15-lvm/
+- ../testing/
+
+commonLabels:
+  pmem-csi.intel.com/deployment: lvm-testing
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../testing/controller-socat-patch.yaml
+
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../testing/args-two-containers-patch.yaml
+
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../testing/args-two-containers-patch.yaml
+
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../testing/args-two-initcontainers-patch.yaml

--- a/deploy/kustomize/kubernetes-1.15-lvm/README.md
+++ b/deploy/kustomize/kubernetes-1.15-lvm/README.md
@@ -1,0 +1,3 @@
+# Kubernetes v1.15 LVM Mode specific changes
+
+This overlay configures the driver to use LVM mode.

--- a/deploy/kustomize/kubernetes-1.15-lvm/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15-lvm/kustomization.yaml
@@ -1,0 +1,15 @@
+# Turns generic Kubernetes 1.15 deployment into deployment for LVM mode.
+
+bases:
+- ../kubernetes-1.15/
+
+commonLabels:
+  pmem-csi.intel.com/deployment: lvm-production
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: DaemonSet
+    name: pmem-csi-node
+  path: ../patches/lvm-patch.yaml

--- a/deploy/kustomize/kubernetes-1.15/README.md
+++ b/deploy/kustomize/kubernetes-1.15/README.md
@@ -1,0 +1,5 @@
+# Kubernetes v1.15 specific changes
+
+This overlay adds the actual version numbers of the sidecars and the
+corresponding RBAC rules such that the base deployment matches
+https://github.com/kubernetes-csi/csi-driver-host-path/tree/master/deploy/kubernetes-1.15

--- a/deploy/kustomize/kubernetes-1.15/driverinfo-beta.yaml
+++ b/deploy/kustomize/kubernetes-1.15/driverinfo-beta.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: pmem-csi.intel.com
+spec:
+  attachRequired: false
+  podInfoOnMount: true

--- a/deploy/kustomize/kubernetes-1.15/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15/kustomization.yaml
@@ -1,0 +1,27 @@
+bases:
+- ../driver
+- rbac
+
+resources:
+- driverinfo-beta.yaml
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../patches/strict-topology-patch.yaml
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: pmem-csi-controller
+  path: ../patches/external-provisioner-timeout-patch.yaml
+
+# The RBAC files must match the image versions.
+images:
+- name: quay.io/k8scsi/csi-provisioner
+  newTag: v1.2.1
+- name: quay.io/k8scsi/csi-node-driver-registrar
+  newTag: v1.1.0

--- a/deploy/kustomize/kubernetes-1.15/rbac/README.md
+++ b/deploy/kustomize/kubernetes-1.15/rbac/README.md
@@ -1,0 +1,9 @@
+# Kubernetes v1.15 RBAC specific changes
+
+These are the necessary RBAC rules for the sidecar containers that we
+use for Kubernetes 1.15. They are (almost) verbatim copies of the
+upstream files (because kustomize cannot download them), with just the
+ServiceAccount definitions deleted. We could also keep those, they
+simply wouldn't be used.
+
+All other modifications are made with kustomize.

--- a/deploy/kustomize/kubernetes-1.15/rbac/external-provisioner-rbac.yaml
+++ b/deploy/kustomize/kubernetes-1.15/rbac/external-provisioner-rbac.yaml
@@ -1,0 +1,98 @@
+# From https://raw.githubusercontent.com/kubernetes-csi/external-provisioner/v1.1.0/deploy/kubernetes/rbac.yaml
+# with ServiceAccount stripped.
+
+# This YAML file contains all RBAC objects that are necessary to run external
+# CSI provisioner.
+#
+# In production, each CSI driver deployment has to be customized:
+# - to avoid conflicts, use non-default namespace and different names
+#   for non-namespaced entities like the ClusterRole
+# - decide whether the deployment replicates the external CSI
+#   provisioner, in which case leadership election must be enabled;
+#   this influences the RBAC setup, see below
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-runner
+rules:
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  # - apiGroups: [""]
+  #   resources: ["secrets"]
+  #   verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Provisioner must be able to work with endpoints in current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: default
+  name: external-provisioner-cfg
+rules:
+# Only one of the following rules for endpoints or leases is required based on
+# what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-role-cfg
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: csi-provisioner
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: external-provisioner-cfg
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kustomize/kubernetes-1.15/rbac/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.15/rbac/kustomization.yaml
@@ -1,0 +1,22 @@
+namePrefix: pmem-csi-
+
+# We have to use local files, see https://github.com/kubernetes-sigs/kustomize/issues/970.
+# The content of these files must match the image versions in the parent kustomize.yaml.
+resources:
+- external-provisioner-rbac.yaml
+
+# We use the upstream [Cluster]RoleBinding and just replace
+# the account name.
+patchesJson6902:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: csi-provisioner-role
+  path: ../../patches/controller-role-patch.yaml
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: RoleBinding
+    name: csi-provisioner-role-cfg
+  path: ../../patches/controller-role-patch.yaml

--- a/deploy/kustomize/patches/external-provisioner-timeout-patch.yaml
+++ b/deploy/kustomize/patches/external-provisioner-timeout-patch.yaml
@@ -1,0 +1,4 @@
+# Add -timeout to external-controller in second container.
+- op: add
+  path: /spec/template/spec/containers/1/args/0
+  value: "--timeout=5m"

--- a/deploy/kustomize/patches/strict-topology-patch.yaml
+++ b/deploy/kustomize/patches/strict-topology-patch.yaml
@@ -1,0 +1,4 @@
+# Select strict topoloy. The external-provisioner must be in container #1.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--strict-topology=true"


### PR DESCRIPTION
Commit f4b7d552d0aedb615cbed35fa9d29b5ce0cbe43f removed the conversion
of deploy/kustomize input files into the 1.14 output files without
introducing the creation of the 1.15 output files. As a result,
changing for example deploy/kustomize/driver/pmem-csi.yaml and then
running "make kustomize" no longer had an effect.

deploy/kubernetes-1.15/pmem-csi.yaml was added in
a2ea982e6ac0e7e1bde5ef2df88c8ae346672101, probably by mistake. It's
not a generated file and shouldn't be there.