### PR TITLE
docs: print all warnings, abort if any were found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ $(addprefix test-kustomize-,$(KUSTOMIZE_OUTPUT)): test-kustomize-%: _work/kustom
 check-go-version-%:
 	@ hack/verify-go-version.sh "$*"
 
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going # Warn about everything, abort with an error at the end.
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _output


### PR DESCRIPTION
When building the docsite, we want to know when new warnings show up,
like malformed file references or new files that aren't included in
the docsite.

Fixes: #638