### PR TITLE
doc: resolve docsite warnings for Kata Containers PR

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -8,6 +8,7 @@
         ".tox",
 	    "_work",
         "deploy/kustomize",
+        "third-party",
         "test/test-config.d",
         "pkg/scheduler"
     ],

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -417,6 +417,9 @@ warning in the build. This document has a ``toctree`` in:
 1. ``index.rst``
 2.  ``examples/readme.rst``
 
+Files or directories that are intentionally not referenced can be excluded
+in [`conf.json`](/conf.json).
+
 NOTE: Though GitHub can parse reST files, the ``toctree`` directive is Sphinx
 specific, so it is not understood by GitHub. ``examples/readme.rst`` is a good
 example. Adding the ``:hidden:`` argument to the ``toctree`` directive means

--- a/docs/install.md
+++ b/docs/install.md
@@ -426,13 +426,13 @@ Error: container create failed: QMP command failed: not enough space, currently 
 ```
 
 The examples for usage of Kata Containers [with
-ephemeral](../deploy/common/pmem-kata-app-ephemeral.yaml) and
-[persistent](../deploy/common/pmem-kata-app.yaml) volumes use the pod
+ephemeral](/deploy/common/pmem-kata-app-ephemeral.yaml) and
+[persistent](/deploy/common/pmem-kata-app.yaml) volumes use the pod
 label. They assume that the `kata-qemu` runtime class [is
 installed](https://github.com/kata-containers/packaging/tree/1.11.0-rc0/kata-deploy#run-a-sample-workload).
 
 For the QEMU test cluster,
-[`setup-kata-containers.sh`](../test/setup-kata-containers.sh) can be
+[`setup-kata-containers.sh`](/test/setup-kata-containers.sh) can be
 used to install Kata Containers. However, this currently only works on
 Clear Linux because on Fedora, the Docker container runtime is used
 and Kata Containers does not support that one.
@@ -440,7 +440,7 @@ and Kata Containers does not support that one.
 
 ### Ephemeral inline volumes
 
-Volume requests [embedded in the pod spec]() are provisioned as
+Volume requests [embedded in the pod spec](https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html#example-of-inline-csi-pod-spec) are provisioned as
 ephemeral volumes. The volume request could use below fields as
 [`volumeAttributes`](https://kubernetes.io/docs/concepts/storage/volumes/#csi):
 


### PR DESCRIPTION
The Kata Containers PR (https://github.com/intel/pmem-csi/pull/500)
and tightening docsite
validation (https://github.com/intel/pmem-csi/pull/640) were merged
independently without retesting, which broke "devel" because some of
the changes for Kata Containers caused warnings which are now errors.