### PR TITLE
Ginkgo timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,10 +248,12 @@ pipeline {
 
         stage('testing 1.18') {
             options {
-                timeout(time: 240, unit: "MINUTES")
+                timeout(time: 20, unit: "MINUTES")
             }
             steps {
-                TestInVM("fedora", "", "1.18", "Top.Level..[[:alpha:]]*-production[[:space:]]")
+                withEnv(['TEST_E2E_ARGS=-ginkgo.timeout=10m']) {
+                    TestInVM("fedora", "", "1.18", "Top.Level..[[:alpha:]]*-production[[:space:]]")
+                }
             }
         }
 

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -554,6 +554,10 @@ func EnsureDeployment(deploymentName string) *Deployment {
 
 	ginkgo.BeforeEach(func() {
 		ginkgo.By(fmt.Sprintf("preparing for test %q", ginkgo.CurrentGinkgoTestDescription().FullTestText))
+		if deploymentName != "lvm-production" {
+			framework.Failf("fake error for deployment %q", deploymentName)
+		}
+
 		c, err := NewCluster(f.ClientSet, f.DynamicClient)
 
 		// Remember list of volumes before test, using out-of-band host commands (i.e. not CSI API).

--- a/test/test.make
+++ b/test/test.make
@@ -142,7 +142,7 @@ run_tests: $(RUN_TEST_DEPS)
 	$(RUN_TESTS)
 
 # E2E tests which are known to be unsuitable (space or @ separated list of regular expressions).
-TEST_E2E_SKIP =
+TEST_E2E_SKIP ?=
 TEST_E2E_SKIP_ALL = $(TEST_E2E_SKIP)
 
 # The test's check whether a driver supports multiple nodes is incomplete and does
@@ -176,7 +176,7 @@ TEST_E2E_SKIP_1.15 += Testpattern:.Ephemeral-volume Testpattern:.inline.ephemera
 TEST_E2E_SKIP_ALL += $(TEST_E2E_SKIP_$(shell cat _work/$(CLUSTER)/kubernetes.version))
 
 # E2E tests which are to be executed (space separated list of regular expressions, default is all that aren't skipped).
-TEST_E2E_FOCUS =
+TEST_E2E_FOCUS ?=
 
 foobar:
 	echo TEST_E2E_SKIP_$(shell cat _work/$(CLUSTER)/kubernetes.version)
@@ -185,10 +185,10 @@ foobar:
 
 # E2E Junit output directory (default empty = none). junit_<ginkgo node>.xml files will be written there,
 # i.e. usually just junit_01.xml.
-TEST_E2E_REPORT_DIR=
+TEST_E2E_REPORT_DIR ?=
 
 # Additional e2e.test arguments, like -ginkgo.failFast.
-TEST_E2E_ARGS =
+TEST_E2E_ARGS ?=
 
 empty:=
 space:= $(empty) $(empty)


### PR DESCRIPTION
We have had several cases recently where testing ran into the Jenkins timeout for the testing step. Usually that's because some tests ran much slower than usual and probably timed out. But because Jenkins aborts the e2e.test program, we don't get the JUnit test file and thus have to resort to log reading to figure out which tests ran resp. failed.

By setting a Ginkgo timeout that is a bit smaller than the Jenkins timeout, we should be able to avoid this.