### PR TITLE
docs: make sure installed tools have a usage priority

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -278,7 +278,7 @@ $ chmod a+x _work/bin/cfssl _work/bin/cfssljson
 - Run certificates set-up script
 
 ``` console
-$ KUBCONFIG="<<your cluster kubeconfig path>>" PATH="$PATH:$PWD/_work/bin" ./test/setup-ca-kubernetes.sh
+$ KUBCONFIG="<<your cluster kubeconfig path>>" PATH="$PWD/_work/bin:$PATH" ./test/setup-ca-kubernetes.sh
 ```
 
 - **Deploy the driver to Kubernetes**


### PR DESCRIPTION
Appending _work/bin to the $PATH can cause errors if there are
incompatible installation of the same tool in $PATH, e.g.
having cfssl older version installed can cause this failure in
certificate creation:
```
  cfssl -loglevel=3 gencert -ca=ca.pem -ca-key=ca-key.pem -
  flag provided but not defined: -loglevel
```

Prepending $PATH with a path to locally installed tools should
make them running even if there are other installations of the
same tools available.