### PR TITLE
Fedora containerd

### DIFF
--- a/test/setup-clear-govm.sh
+++ b/test/setup-clear-govm.sh
@@ -179,16 +179,6 @@ EOF
             ln -s $i /opt/cni/bin/
         done
 
-        # Switch to systemd cgroup driver (https://kubernetes.io/docs/setup/production-environment/container-runtimes/#cgroup-drivers):
-        # "Changing the settings such that your container runtime and kubelet use systemd as the cgroup driver stabilized the system."
-        # It's already the default in cri-o in recent Clear Linux. Docker and containerd might need further work.
-        #
-        # Not sure which file is used on Clear Linux, simply set both.
-        for config in /etc/default/kubelet /etc/sysconfig/kubelet; do
-            mkdir -p $(dirname $config)
-            echo 'KUBELET_EXTRA_ARGS=--cgroup-driver=systemd' >$config
-        done
-
         # Reconfiguration done, start daemons. Starting kubelet must wait until kubeadm has created
         # the necessary config files.
         systemctl daemon-reload

--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -120,6 +120,13 @@ sudo sh -c 'cat >/var/lib/scheduler/scheduler-policy.cfg' <<EOF
 }
 EOF
 
+# We always use systemd. Auto-detected for Docker, but not for other
+# CRIs
+# (https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#configure-cgroup-driver-used-by-kubelet-on-control-plane-node).
+kubeadm_config_kubelet="$kubeadm_config_kubelet
+cgroupDriver: systemd
+"
+
 kubeadm_config_kubelet="$kubeadm_config_kubelet
 featureGates:
 $(list_gates)"

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -27,7 +27,7 @@ fi
 #
 # cri-o is the default on Clear Linux because that is supported better
 # and Docker elsewhere because we can install it easily.
-: ${TEST_CRI:=$(case ${TEST_DISTRO} in clear) echo crio;; *) echo docker;; esac)}
+: ${TEST_CRI:=$(case ${TEST_DISTRO} in clear) echo crio;; *) echo containerd;; esac)}
 
 # A local registry running on the build host, aka localhost:5000.
 # In order to reach it from inside the virtual cluster, we need


### PR DESCRIPTION
Using containerd directly should be simpler and allows us to test Kata
Containers also with Fedora.

Fixes: #671 