### PR TITLE
Rename pmem -> csi (variables and fields)

### DIFF
--- a/pkg/grpc-server/server.go
+++ b/pkg/grpc-server/server.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/klog"
 )
 
-type PmemService interface {
+type Service interface {
 	// RegisterService will be called by NonBlockingGRPCServer whenever
 	// its about to start a grpc server on an endpoint.
 	RegisterService(s *grpc.Server)
@@ -32,7 +32,7 @@ func NewNonBlockingGRPCServer() *NonBlockingGRPCServer {
 	return &NonBlockingGRPCServer{}
 }
 
-func (s *NonBlockingGRPCServer) Start(endpoint string, tlsConfig *tls.Config, services ...PmemService) error {
+func (s *NonBlockingGRPCServer) Start(endpoint string, tlsConfig *tls.Config, services ...Service) error {
 	if endpoint == "" {
 		return fmt.Errorf("endpoint cannot be empty")
 	}

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -42,7 +42,7 @@ type nodeControllerServer struct {
 }
 
 var _ csi.ControllerServer = &nodeControllerServer{}
-var _ grpcserver.PmemService = &nodeControllerServer{}
+var _ grpcserver.Service = &nodeControllerServer{}
 
 var nodeVolumeMutex = keymutex.NewHashed(-1)
 
@@ -173,7 +173,7 @@ func (cs *nodeControllerServer) CreateVolume(ctx context.Context, req *csi.Creat
 
 	topology = append(topology, &csi.Topology{
 		Segments: map[string]string{
-			PmemDriverTopologyKey: cs.nodeID,
+			DriverTopologyKey: cs.nodeID,
 		},
 	})
 

--- a/pkg/pmem-csi-driver/identityserver.go
+++ b/pkg/pmem-csi-driver/identityserver.go
@@ -19,7 +19,7 @@ type identityServer struct {
 	pluginCaps []*csi.PluginCapability
 }
 
-var _ grpcserver.PmemService = &identityServer{}
+var _ grpcserver.Service = &identityServer{}
 
 func NewIdentityServer(name, version string) (*identityServer, error) {
 	return &identityServer{

--- a/pkg/pmem-csi-driver/main.go
+++ b/pkg/pmem-csi-driver/main.go
@@ -78,7 +78,7 @@ func Main() int {
 	}
 
 	config.Version = version
-	driver, err := GetPMEMDriver(config)
+	driver, err := GetCSIDriver(config)
 	if err != nil {
 		pmemcommon.ExitError("failed to initialize driver", err)
 		return 1

--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -62,7 +62,7 @@ type nodeServer struct {
 }
 
 var _ csi.NodeServer = &nodeServer{}
-var _ grpcserver.PmemService = &nodeServer{}
+var _ grpcserver.Service = &nodeServer{}
 
 func NewNodeServer(cs *nodeControllerServer, mountDirectory string) *nodeServer {
 	return &nodeServer{
@@ -90,7 +90,7 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		NodeId: ns.cs.nodeID,
 		AccessibleTopology: &csi.Topology{
 			Segments: map[string]string{
-				PmemDriverTopologyKey: ns.cs.nodeID,
+				DriverTopologyKey: ns.cs.nodeID,
 			},
 		},
 	}, nil

--- a/pkg/pmem-csi-driver/pmem-csi-driver_test.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver_test.go
@@ -15,10 +15,9 @@ import (
 	"os"
 	"testing"
 
+	pmemgrpc "github.com/intel/pmem-csi/pkg/pmem-grpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/intel/pmem-csi/pkg/pmem-grpc"
 )
 
 var (
@@ -51,7 +50,7 @@ build_info{version="foo-bar-test"} 1
 	for n, c := range cases {
 		t.Run(n, func(t *testing.T) {
 			path := "/metrics2"
-			pmemd, err := GetPMEMDriver(Config{
+			pmemd, err := GetCSIDriver(Config{
 				Mode:          Controller,
 				DriverName:    "pmem-csi",
 				NodeID:        "testnode",


### PR DESCRIPTION
This is a first step in generalizing current APIs.
Renamed variables and fields of pkg/pmem-csi-driver/ and some of its depdendencies.

Avoided renaming files to keep git history cleaner.