### PR TITLE
Operator: emitting events on deployment

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -231,7 +231,11 @@ Spec:
       Memory:  100Mi
 Status:
   Phase:  Running
-Events:   <none>
+Events:
+  Type    Reason         Age                From               Message
+  ----    ------         ----               ----               -------
+  Normal  NewDeployment  34s                pmem-csi-operator  Processing new driver deployment
+  Normal  Running        2s (x10 over 26s)  pmem-csi-operator  Driver deployment successful
 
 
 $ kubectl get po
@@ -878,6 +882,13 @@ The possible `phase` values and their meaning are as below:
 
 <sup>1</sup> This check has not been implemented yet. Instead, the deployment goes straight to `Running` after creating sub-resources.
 <sup>2</sup> Failure reason is supposed to be carried by one of additional `DeploymentStatus` field, but not implemented yet.
+
+#### Deployment Events
+
+The PMEM-CSI operator posts events on the progress of a `Deployment`. If the
+deployment is in the `Failed` state, then one can look into the event(s) using
+`kubectl describe` on that deployment for the detailed failure reason.
+
 
 > **Note on multiple deployments**
 >

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	k8s.io/component-base v0.19.0-rc.4
 	k8s.io/klog v1.0.0
 	k8s.io/kube-scheduler v0.19.0-rc.4
-	k8s.io/kubectl v0.19.0-rc.4 // indirect
+	k8s.io/kubectl v0.19.0-rc.4
 	k8s.io/kubernetes v1.19.0-rc.4
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	// Master is required because only that supports Kubernetes 1.18.

--- a/pkg/apis/pmemcsi/v1alpha1/deployment_types.go
+++ b/pkg/apis/pmemcsi/v1alpha1/deployment_types.go
@@ -133,6 +133,15 @@ func init() {
 }
 
 const (
+	// EventReasonNew new driver deployment found
+	EventReasonNew = "NewDeployment"
+	// EventReasonRunning driver has been successfully deployed
+	EventReasonRunning = "Running"
+	// EventReasonFailed driver deployment failed, Event.Message holds detailed information
+	EventReasonFailed = "Failed"
+)
+
+const (
 	// DefaultLogLevel default logging level used for the driver
 	DefaultLogLevel = uint16(5)
 	// DefaultImagePullPolicy default image pull policy for all the images used by the deployment

--- a/pkg/pmem-csi-operator/controller/controller.go
+++ b/pkg/pmem-csi-operator/controller/controller.go
@@ -8,6 +8,7 @@ package controller
 
 import (
 	"github.com/intel/pmem-csi/pkg/version"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -22,6 +23,8 @@ type ControllerOptions struct {
 	DriverImage string
 	// Config kubernetes config used
 	Config *rest.Config
+	// EventClient events client to use for recording events
+	EventsClient v1.EventInterface
 }
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager

--- a/pkg/pmem-csi-operator/main.go
+++ b/pkg/pmem-csi-operator/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
 	"github.com/intel/pmem-csi/pkg/apis"
@@ -101,12 +102,18 @@ func Main() int {
 		return 1
 	}
 
+	cs, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		pmemcommon.ExitError("failed to get in-cluster client: %v", err)
+		return 1
+	}
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr, controller.ControllerOptions{
-		Config:      mgr.GetConfig(),
-		Namespace:   namespace,
-		K8sVersion:  *ver,
-		DriverImage: driverImage,
+		Config:       mgr.GetConfig(),
+		Namespace:    namespace,
+		K8sVersion:   *ver,
+		DriverImage:  driverImage,
+		EventsClient: cs.CoreV1().Events(""),
 	}); err != nil {
 		pmemcommon.ExitError("Failed to add controller to manager: ", err)
 		return 1


### PR DESCRIPTION
Currently, we are generating 'NewDeployment', 'Running' and 'Failed'
events on a deployment. Event.Message will hold a detailed failure
reason.
    
 We might consider generating more detailed events as the deployment
 progress, which we can implement based on this change.
    
 FIXES #542