### PR TITLE
operator/deploy: Fix for OpenShift

### DIFF
--- a/deploy/bindata_generated.go
+++ b/deploy/bindata_generated.go
@@ -99,7 +99,7 @@ func deployKubernetes115DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.15/direct/pmem-csi.yaml", size: 9629, mode: os.FileMode(436), modTime: time.Unix(1592811532, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.15/direct/pmem-csi.yaml", size: 9629, mode: os.FileMode(436), modTime: time.Unix(1597915617, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -119,7 +119,7 @@ func deployKubernetes115LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.15/lvm/pmem-csi.yaml", size: 9578, mode: os.FileMode(436), modTime: time.Unix(1592811532, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.15/lvm/pmem-csi.yaml", size: 9578, mode: os.FileMode(436), modTime: time.Unix(1597915617, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -139,7 +139,7 @@ func deployKubernetes116DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.16/direct/pmem-csi.yaml", size: 9682, mode: os.FileMode(436), modTime: time.Unix(1592811533, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.16/direct/pmem-csi.yaml", size: 9682, mode: os.FileMode(436), modTime: time.Unix(1597915618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -159,7 +159,7 @@ func deployKubernetes116LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.16/lvm/pmem-csi.yaml", size: 9631, mode: os.FileMode(436), modTime: time.Unix(1592811533, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.16/lvm/pmem-csi.yaml", size: 9631, mode: os.FileMode(436), modTime: time.Unix(1597915618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -179,7 +179,7 @@ func deployKubernetes117DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.17/direct/pmem-csi.yaml", size: 9682, mode: os.FileMode(436), modTime: time.Unix(1592811533, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.17/direct/pmem-csi.yaml", size: 9682, mode: os.FileMode(436), modTime: time.Unix(1597915618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -199,7 +199,7 @@ func deployKubernetes117LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.17/lvm/pmem-csi.yaml", size: 9631, mode: os.FileMode(436), modTime: time.Unix(1592811533, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.17/lvm/pmem-csi.yaml", size: 9631, mode: os.FileMode(436), modTime: time.Unix(1597915618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func deployKubernetes118DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 9682, mode: os.FileMode(436), modTime: time.Unix(1592811533, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 9682, mode: os.FileMode(436), modTime: time.Unix(1597915618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -239,7 +239,7 @@ func deployKubernetes118LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 9631, mode: os.FileMode(436), modTime: time.Unix(1592811533, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 9631, mode: os.FileMode(436), modTime: time.Unix(1597915618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/deploy/kustomize/operator/operator.yaml
+++ b/deploy/kustomize/operator/operator.yaml
@@ -32,14 +32,6 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - apps
-  resourceNames:
-  - pmem-csi-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
@@ -84,6 +76,7 @@ rules:
   resources:
   - deployments
   - deployments/status
+  - deployments/finalizers
   verbs:
   - '*'
 ---

--- a/deploy/operator/pmem-csi-operator.yaml
+++ b/deploy/operator/pmem-csi-operator.yaml
@@ -32,14 +32,6 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - apps
-  resourceNames:
-  - pmem-csi-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
@@ -84,6 +76,7 @@ rules:
   resources:
   - deployments
   - deployments/status
+  - deployments/finalizers
   verbs:
   - '*'
 ---


### PR DESCRIPTION
On OpenShift clusters operator fails to create deployment sub-resources
with below error:
I0819 15:01:16.792903       1 deployment_controller.go:255] Creating 'default/pmem-deployment-registry-secrets' of type '*v1.Secret'
I0819 15:01:16.803108       1 deployment_controller.go:169] Requeue: true, error: secrets "pmem-deployment-registry-secrets" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil># Please enter the commit message for your changes. Lines starting

This change fixes the wrongly placed 'deployments/fainalizers'.