### PR TITLE
Dev-manager canUse calc: fix operator order

### DIFF
--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -309,7 +309,7 @@ const (
 func setupNS(r *ndctl.Region, percentage uint) error {
 	align := GB
 	realalign := align * r.InterleaveWays()
-	canUse := uint64(percentage) * (r.Size() / 100)
+	canUse := uint64(percentage) * r.Size() / 100
 	klog.V(3).Infof("Create fsdax-namespaces in %v, allowed %d %%, real align %d:\ntotal       : %16d\navail       : %16d\ncan use     : %16d",
 		r.DeviceName(), percentage, realalign, r.Size(), r.AvailableSize(), canUse)
 	// Subtract sizes of existing active namespaces with currently handled mode and owned by pmem-csi


### PR DESCRIPTION
Division as integer and then multiply, sheds off some value
from canUse size, and later when we align down by Align size,
we will lose whole alignment block because of that.
This creates issue where 1st run leaves one realAlign-sized block
unallocated, but 2nd start on same node will find it and create
a new relatively small namespace.