### PR TITLE
pmem-csi-operator: delete obsolete objects of a deployment

### DIFF
--- a/deploy/kustomize/operator/operator.yaml
+++ b/deploy/kustomize/operator/operator.yaml
@@ -4,6 +4,12 @@ metadata:
   name: pmem-csi-operator
   namespace: default
 ---
+#
+# These RBAC rules must be kept in sync with the
+# AllObjectTypes list defined in
+# pkg/pmem-csi-operator/controller/deployment/controller_driver.go.
+# So that operator could list/get/delete the resources
+# that were obsolete.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/pkg/apis/pmemcsi/v1alpha1/deployment_types.go
+++ b/pkg/apis/pmemcsi/v1alpha1/deployment_types.go
@@ -391,6 +391,21 @@ func (d *Deployment) GetHyphenedName() string {
 	return strings.ReplaceAll(d.GetName(), ".", "-")
 }
 
+// GetOwnerReference returns self owner reference could be used by other object
+// to add this deployment to it's owner reference list.
+func (d *Deployment) GetOwnerReference() metav1.OwnerReference {
+	blockOwnerDeletion := true
+	isController := true
+	return metav1.OwnerReference{
+		APIVersion:         d.APIVersion,
+		Kind:               d.Kind,
+		Name:               d.GetName(),
+		UID:                d.GetUID(),
+		BlockOwnerDeletion: &blockOwnerDeletion,
+		Controller:         &isController,
+	}
+}
+
 func GetDeploymentCRDSchema() *apiextensions.JSONSchemaProps {
 	One := float64(1)
 	Hundred := float64(100)


### PR DESCRIPTION
Different operator releases might result in obsolete sub-resources that were created for a deployment.  Operator shall detect these obsolete objects if any and delete them in the reconcile loop.
    
There is no direct API to detect all the objects owned by an object. So, we solve this by annotating the Deployment CR with the list of object types & names, and the version of the operator that reconciled. On operator upgrade/degrade we check if any pre-deployed objects are still valid.
    
FIXES #595