### PR TITLE
operator/test: fix update pmemPercentage test failure

### DIFF
--- a/pkg/pmem-csi-operator/controller/deployment/testcases/testcases.go
+++ b/pkg/pmem-csi-operator/controller/deployment/testcases/testcases.go
@@ -69,7 +69,7 @@ func UpdateTests() []UpdateTest {
 			}
 		},
 		"pmemPercentage": func(d *api.Deployment) {
-			d.Spec.PMEMPercentage++
+			d.Spec.PMEMPercentage--
 		},
 		"labels": func(d *api.Deployment) {
 			if d.Spec.Labels == nil {

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -447,7 +447,10 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 						}()
 					}
 
+					By("Mutating deployment...")
 					testcase.Mutate(&deployment)
+					framework.Logf("Deployment after mutation: %+v", deployment.Spec)
+					By("Updating deployment...")
 					deployment = deploy.UpdateDeploymentCR(f, deployment)
 
 					if restart {


### PR DESCRIPTION
Incrementing the default pmemPerencentage of 100 leads to out of
bounds(101) and tests fails as below:

```
Status: "Failure",
Message: "Deployment.pmem-csi.intel.com \"pmem-csi-with-defaults\" is invalid: .... : validation failure list:\nspec.pmemPercentage in body should be less than or equal to 100",
```