### PR TITLE
test: Kubernetes 1.19.1 without EndpointSlices

### DIFF
--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -62,7 +62,7 @@ EOF
         1.16) packages+=" kubelet-1.16.9-0 kubeadm-1.16.9-0 kubectl-1.16.9-0";;
         1.17) packages+=" kubelet-1.17.5-0 kubeadm-1.17.5-0 kubectl-1.17.5-0";;
         1.18) packages+=" kubelet-1.18.2-0 kubeadm-1.18.2-0 kubectl-1.18.2-0";;
-        1.19) packages+=" kubelet-1.19.0-0 kubeadm-1.19.0-0 kubectl-1.19.0-0";;
+        1.19) packages+=" kubelet-1.19.1-0 kubeadm-1.19.1-0 kubectl-1.19.1-0";;
         *) echo >&2 "Kubernetes version ${TEST_KUBERNETES_VERSION} not supported, package list in $0 must be updated."; exit 1;;
     esac
     packages+=" --disableexcludes=kubernetes"

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -148,13 +148,12 @@ fi
 : ${TEST_KUBERNETES_FLAVOR:=}
 
 # Kubernetes feature gates to enable/disable.
-# EndpointSlice is disabled because of https://github.com/kubernetes/kubernetes/issues/91287
-# 1.19 should have a fix and also needs it to be enabled because without it,
-# kube-proxy is unhappy ("failed to list *v1beta1.EndpointSlice") and fails to
-# set up IP forwarding rules.
+# EndpointSlice is disabled because of https://github.com/kubernetes/kubernetes/issues/91287 (Kubernetes
+# < 1.19) and because there were random connection failures to node ports during sanity
+# testing (Kubernetes 1.19.0)
 : ${TEST_FEATURE_GATES:=CSINodeInfo=true,CSIDriverRegistry=true,CSIBlockVolume=true,CSIInlineVolume=true\
-$(case ${TEST_KUBERNETES_VERSION} in 1.1[0-5]|1.19) ;; *) echo ',EndpointSlice=false';; esac)\
-$(case ${TEST_KUBERNETES_VERSION} in 1.19) echo ',CSIStorageCapacity=true,GenericEphemeralVolume=true';; esac)\
+$(case ${TEST_KUBERNETES_VERSION} in 1.1[0-5]) ;; *) echo ',EndpointSlice=false';; esac)\
+$(case ${TEST_KUBERNETES_VERSION} in 1.19) echo ',CSIStorageCapacity=true,GenericEphemeralVolume=true,EndpointSliceProxying=false';; esac)\
 }
 
 # If non-empty, the version of Kata Containers which is to be installed


### PR DESCRIPTION
Kubernetes 1.19.1 may have some relevant bug fixes. More importantly,
EndpointSlices are now also disabled for it by disabling the feature
that uses them in kube-proxy. That part was missing before, causing
kube-proxy to fail.

Perhaps this will increase stability of Kubernetes 1.19 testing. There
have been random failures recently during sanity testing where
connecting to the node port failed.