### PR TITLE
go-1.15-2 + certificate generation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -252,8 +252,8 @@ Controller([RegistryServer](#node-registry-server),
 NodeControllers([NodeControllerServer](#node-controller-server)) is
 protected by mutual TLS. Both client and server must identify
 themselves and the certificate they present must be trusted. The
-common name in each certificate is used to identify the different
-components. The following common names have a special meaning:
+host name in each certificate is used to identify the different
+components. The following host names have a special meaning:
 
 - `pmem-registry` is used by the [RegistryServer](#node-registry-server).
 - `pmem-node-controller` is used by [NodeControllerServers](#node-controller-server)

--- a/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
+++ b/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
@@ -446,13 +446,13 @@ func validateCertificates(caCert, regKey, regCert, ncKey, ncCert []byte) error {
 	server := grpcserver.NewNonBlockingGRPCServer()
 	path := path.Join(tmp, "socket")
 	if err := server.Start("unix://"+path, regCfg, nil); err != nil {
-		return err
+		return fmt.Errorf("registry certificate: %w", err)
 	}
 	defer server.ForceStop()
 
 	conn, err := tls.Dial("unix", path, clientCfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("node certificate: %w", err)
 	}
 
 	conn.Close()

--- a/pkg/pmem-csi-operator/pmem-tls/tls.go
+++ b/pkg/pmem-csi-operator/pmem-tls/tls.go
@@ -17,7 +17,6 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
 )
@@ -196,9 +195,7 @@ func NewCACertificate(key *rsa.PrivateKey) (*x509.Certificate, error) {
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		IsCA:                  true,
 		BasicConstraintsValid: true,
-		Subject: pkix.Name{
-			CommonName: "pmem-csi operator root certificate authority",
-		},
+		DNSNames:              []string{"pmem-csi", "ca"},
 	}
 	certBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
 	*tmpl = x509.Certificate{}
@@ -232,9 +229,7 @@ func (ca *CA) generateCertificate(cn string, notBefore, notAfter time.Time, key 
 		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		Subject: pkix.Name{
-			CommonName: cn,
-		},
+		DNSNames:     []string{cn},
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, key, ca.prKey)

--- a/pkg/pmem-csi-operator/pmem-tls/tls_test.go
+++ b/pkg/pmem-csi-operator/pmem-tls/tls_test.go
@@ -138,6 +138,6 @@ func TestPmemTLS(t *testing.T) {
 		isValid := cert.NotAfter.Equal(validity) || cert.NotAfter.After(validity)
 		assert.Equal(t, isValid, true, "invalid certificate validity(%v) expected least %v", cert.NotAfter, validity)
 
-		assert.Equal(t, cert.Subject.CommonName, "test-cert", "mismatched common name")
+		assert.Contains(t, cert.DNSNames, "test-cert", "mismatched common name")
 	})
 }

--- a/test/setup-ca.sh
+++ b/test/setup-ca.sh
@@ -15,9 +15,10 @@ if [ $cfssl_found -eq 0 ]; then
 fi
 
 # Generate CA certificates.
-<<EOF cfssl -loglevel=3 gencert -initca - | cfssljson -bare ca
+<<EOF cfssl gencert -initca - | cfssljson -bare ca
 {
     "CN": "$CA",
+    "hosts": [ "$CA" ],
     "key": {
         "algo": "rsa",
         "size": 2048
@@ -29,7 +30,7 @@ EOF
 DEFAULT_CNS="pmem-registry pmem-node-controller"
 CNS="${DEFAULT_CNS} ${EXTRA_CNS:=""}"
 for name in ${CNS}; do
-  <<EOF cfssl -loglevel=3 gencert -ca=ca.pem -ca-key=ca-key.pem - | cfssljson -bare $name
+  <<EOF cfssl gencert -ca=ca.pem -ca-key=ca-key.pem - | cfssljson -bare $name
 {
     "CN": "$name",
     "hosts": [

--- a/test/test.make
+++ b/test/test.make
@@ -217,8 +217,9 @@ _work/%/.ca-stamp: test/setup-ca.sh _work/.setupcfssl-stamp
 
 _work/.setupcfssl-stamp:
 	rm -rf _work/bin
-	curl -L https://pkg.cfssl.org/R1.2/cfssl_linux-amd64 -o _work/bin/cfssl --create-dirs
-	curl -L https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64 -o _work/bin/cfssljson --create-dirs
+	curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o _work/bin/cfssl --create-dirs
+	curl -L https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64 -o _work/bin/cfssljson --create-dirs
+
 	chmod a+x _work/bin/cfssl _work/bin/cfssljson
 	touch $@
 


### PR DESCRIPTION
Using of certificate CommonName is deprecated in Go-1.15.

Made changes to the self-signed certificate generation and client certificate
verification code so that now they work on DNSNames instead of CommonName.
    
Whereas the certificate generation using `cfssl` tools in`setup-ca.sh`
script already setting the hostname(s) which is good enough for us.
`cfssl` treats as an error if no Subject set, so keep setting the CN.
    
Also updated to the latest cfssl release - v1.4.1