### PR TITLE
release preparations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,15 @@ OUTPUT_DIR=_output
 .DELETE_ON_ERROR:
 
 ifeq ($(VERSION), )
-VERSION=$(shell git describe --long --dirty --tags --match='v*')
+VERSION:=$(shell git describe --long --dirty --tags --match='v*')
 endif
+
+# VERSION is of the format vX.Y.Z[-<number of commits>-<short hash>|<suffix>].
+# For the SDK we need just X.Y.Z.
+MAJOR_MINOR_PATCH_VERSION:=$(shell echo $(VERSION) | cut -f1 -d'-' | sed -e 's/^v//')
+
+# Sometimes just X.Y is needed.
+MAJOR_MINOR_VERSION:=$(shell echo $(MAJOR_MINOR_PATCH_VERSION) | sed -e 's/\([0-9]*\.[0-9]*\)\..*/\1/')
 
 # Sanitize proxy settings (accept upper and lower case, set and export upper
 # case) and add local machine to no_proxy because some tests may use a

--- a/deploy/common/pmem-app-generic-ephemeral.yaml
+++ b/deploy/common/pmem-app-generic-ephemeral.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: my-frontend
-      image: intel/pmem-csi-driver-test:v0.7.14
+      image: intel/pmem-csi-driver-test:canary
       command: [ "sleep", "100000" ]
       volumeMounts:
       - mountPath: "/data"

--- a/hack/set-version.sh
+++ b/hack/set-version.sh
@@ -13,5 +13,6 @@ if [ $# != 1 ] || [ "$1" = "?" ] || [ "$1" = "--help" ]; then
     exit 1
 fi
 
-sed -i -e "s;\(IMAGE_VERSION?*=\|intel/pmem-[^ ]*:\)[^ ]*;\1$1;g" $(git grep -l 'IMAGE_VERSION?*=\|intel/pmem-[^ ]*:' Makefile test/*.sh deploy)
+sed -i -e "s;\(IMAGE_VERSION?*=\|intel/pmem-[^ ]*:\)[^ ^;/]*;\1$1;g" $(git grep -l 'IMAGE_VERSION?*=\|intel/pmem-[^ ]*:' Makefile test/*.sh deploy)
 sed -i -e "s;/pmem-csi-driver\([^ ]*\):[^ {}]*;/pmem-csi-driver\1:$1;g" test/test-config.sh
+sed -i -e "s;github.com/intel/pmem-csi/raw/[^/]*/;github.com/intel/pmem-csi/raw/$1/;g" docs/*.md

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -618,10 +618,15 @@ func findDriver(c *Cluster) (*Deployment, error) {
 	deployment.Namespace = list.Items[0].Namespace
 
 	// Derive the version from the image tag. The annotation doesn't include it.
+	// If the version matches what we are currently testing, then we skip
+	// the version (i.e. "current version" == "no explicit version").
 	for _, container := range list.Items[0].Spec.Template.Spec.Containers {
 		m := imageVersion.FindStringSubmatch(container.Image)
 		if m != nil {
-			deployment.Version = m[1]
+			m2 := imageVersion.FindStringSubmatch(os.Getenv("PMEM_CSI_IMAGE"))
+			if m2 == nil || m2[1] != m[1] {
+				deployment.Version = m[1]
+			}
 			break
 		}
 	}


### PR DESCRIPTION
Trying to release v0.8.0 revealed a few issues around versioning. With these changes, doing a v0.8.0 should be smoother.
