### PR TITLE
docs: fix shell session quoting

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -244,7 +244,7 @@ a complete list of supported properties.
 
 Here is a minimal example driver deployment created with a custom resource:
 
-``` console
+``` ShellSession
 $ kubectl create -f - <<EOF
 apiVersion: pmem-csi.intel.com/v1alpha1
 kind: Deployment

--- a/examples/memcached.md
+++ b/examples/memcached.md
@@ -393,14 +393,14 @@ to account for filesystem overhead:
 $ kubectl create ns demo
 namespace/demo created
 
-$ cat <<EOF >memcached.conf
-memory-file = /data/memcached-memory-file
-memory-limit = 450
-EOF
+$ echo "memory-file = /data/memcached-memory-file" >memcached.conf
+$ echo "memory-limit = 450" >>memcached.conf
 
 $ kubectl create configmap -n demo mc-pmem-conf --from-file=memcached.conf
 configmap/mc-pmem-conf created
+```
 
+``` ShellSession
 $ kubectl create -f - <<EOF
 apiVersion: kubedb.com/v1alpha1
 kind: Memcached
@@ -429,8 +429,6 @@ spec:
       volumeAttributes:
         size: 500Mi
 EOF
-
-memcached.kubedb.com/memcd-pmem created
 ```
 
 The resulting pods then have one additional data volume:


### PR DESCRIPTION
`console` copies just the commands and not their output, but doesn't
handle EOF. `ShellSession` copies everything, including EOF. We need
to be careful about using these correctly, otherwise the copy button
doesn't work as intended.

One limitation is that we cannot mix commands with output and commands
with EOF in the same code block.

Fixes: #773