### PR TITLE
0.8: build: avoid installing Python3

### DIFF
--- a/hack/python3-fake-debian-package
+++ b/hack/python3-fake-debian-package
@@ -1,0 +1,12 @@
+# This file is used with equivs-build to create a fake python3
+# package that then gets installed to satisfy the xfsprogs
+# dependency on Python3.
+
+Section: misc
+Priority: optional
+Standards-Version: 3.9.2
+
+Package: python3
+Version: 100:100.0
+Provides: python3:any
+Description: fake Python3 package


### PR DESCRIPTION
Python3 is needed by xfsprogs only for a single script that we don't
need at runtime. Therefore we can avoid installing this rather large
package and its dependency by providing "python3:any" with an empty
stub package.

(cherry picked from commit 26c4eb559865ca7a4b1663003a9737ba9b7995ca)