### PR TITLE
Olm catalog: Various fixes

### DIFF
--- a/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
+++ b/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
@@ -9,12 +9,13 @@ metadata:
     description: An operator for deploying and managing the PMEM-CSI driver
     repository: https://github.com/intel/pmem-csi/tree/release-X.Y
     support: Intel
-    createAt: 2020-06-25 10:50Z
+    createdAt: 2020-06-25 10:50Z
+    certified: "false"
+    capabilities: Seamless Upgrades
 spec:
   displayName: Operator for PMEM-CSI driver
   provider:
     name: Intel® Corporation
-    url: https://intel.com
   installModes:
   - supported: true
     type: OwnNamespace
@@ -39,6 +40,7 @@ spec:
     name: Patrick Ohly
   - email: amarnath.valluri@intel.com
     name: Amarnath Valluri
+  maturity: alpha
   customresourcedefinitions:
     owned:
     - kind: Deployment

--- a/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
+++ b/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   links:
   - name: PMEM-CSI

--- a/operator/operator.make
+++ b/operator/operator.make
@@ -49,6 +49,7 @@ CRD_DIR=deploy/crd
 KUBECONFIG := $(shell echo $(PWD)/_work/$(CLUSTER)/kube.config)
 
 PATCH_VERSIONS := sed -i -e 's;X\.Y\.Z;$(MAJOR_MINOR_PATCH_VERSION);g' -e 's;X\.Y;$(MAJOR_MINOR_VERSION);g'
+PATCH_DATE := sed -i -e 's;\(.*createdAt: \).*;\1$(shell date +%FT%TZ);g'
 OPERATOR_OUTPUT_DIR := $(CATALOG_DIR)/$(MAJOR_MINOR_PATCH_VERSION)
 
 # Generate CRD and add kustomization support
@@ -64,6 +65,7 @@ operator-generate-catalog: _work/bin/operator-sdk-$(OPERATOR_SDK_VERSION) _work/
 	@_work/kustomize build --load_restrictor=none $(MANIFESTS_DIR) | $< generate packagemanifests --version $(MAJOR_MINOR_PATCH_VERSION) \
 		--kustomize-dir $(MANIFESTS_DIR) --output-dir $(CATALOG_DIR)
 	@$(PATCH_VERSIONS) $(OPERATOR_OUTPUT_DIR)/pmem-csi-operator.clusterserviceversion.yaml
+	@$(PATCH_DATE) $(OPERATOR_OUTPUT_DIR)/pmem-csi-operator.clusterserviceversion.yaml
 
 # Generate OLM bundle. OperatorHub/OLM still does not support bundle format
 # but soon it will move from 'packagemanifests' to 'bundles'.
@@ -72,6 +74,7 @@ operator-generate-bundle: _work/bin/operator-sdk-$(OPERATOR_SDK_VERSION) _work/k
 	@_work/kustomize build --load_restrictor=none $(MANIFESTS_DIR) | $< generate bundle  --version=$(VERSION) \
         --kustomize-dir=$(MANIFESTS_DIR) --output-dir=$(BUNDLE_DIR)
 	@$(PATCH_VERSIONS) $(OPERATOR_OUTPUT_DIR)/pmem-csi-operator.clusterserviceversion.yaml
+	@$(PATCH_DATE) $(OPERATOR_OUTPUT_DIR)/pmem-csi-operator.clusterserviceversion.yaml
 
 operator-clean-crd:
 	rm -rf $(CRD_DIR)

--- a/operator/operator.make
+++ b/operator/operator.make
@@ -48,7 +48,7 @@ CRD_DIR=deploy/crd
 
 KUBECONFIG := $(shell echo $(PWD)/_work/$(CLUSTER)/kube.config)
 
-PATCH_VERSIONS := sed -i -e 's;X.Y.Z;$(MAJOR_MINOR_PATCH_VERSION);g' -e 's;X.Y;$(MAJOR_MINOR_VERSION);g'
+PATCH_VERSIONS := sed -i -e 's;X\.Y\.Z;$(MAJOR_MINOR_PATCH_VERSION);g' -e 's;X\.Y;$(MAJOR_MINOR_VERSION);g'
 OPERATOR_OUTPUT_DIR := $(CATALOG_DIR)/$(MAJOR_MINOR_PATCH_VERSION)
 
 # Generate CRD and add kustomization support

--- a/operator/operator.make
+++ b/operator/operator.make
@@ -41,6 +41,17 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
+OPERATOR_COURIER_VERSION=2.1.10
+OPERATOR_COURIER_IMAGE_TAG=operator-courier:$(OPERATOR_COURIER_VERSION)
+
+_work/operator-courier-$(OPERATOR_COURIER_VERSION):
+	curl -L https://github.com/operator-framework/operator-courier/archive/v$(OPERATOR_COURIER_VERSION).tar.gz | tar -zx -C ./_work
+
+operator-courier-image: _work/operator-courier-$(OPERATOR_COURIER_VERSION)
+ifeq (, $(shell docker images --quiet $(OPERATOR_COURIER_IMAGE_TAG)))
+	@cd $< && docker build -f Dockerfile -t $(OPERATOR_COURIER_IMAGE_TAG) .
+endif
+
 MANIFESTS_DIR=deploy/kustomize/olm-catalog
 CATALOG_DIR=deploy/olm-catalog
 BUNDLE_DIR=deploy/bundle
@@ -66,6 +77,16 @@ operator-generate-catalog: _work/bin/operator-sdk-$(OPERATOR_SDK_VERSION) _work/
 		--kustomize-dir $(MANIFESTS_DIR) --output-dir $(CATALOG_DIR)
 	@$(PATCH_VERSIONS) $(OPERATOR_OUTPUT_DIR)/pmem-csi-operator.clusterserviceversion.yaml
 	@$(PATCH_DATE) $(OPERATOR_OUTPUT_DIR)/pmem-csi-operator.clusterserviceversion.yaml
+	$(MAKE) operator-validate-catalog
+
+VALIDATE_CATALOG = \
+	OUT="$(shell docker run -v $(abspath $(CATALOG_DIR)):/catalog $(OPERATOR_COURIER_IMAGE_TAG) operator-courier verify --ui_validate_io /catalog 2>&1)" ; \
+	echo "$$OUT" | grep -q "^WARNING:"; \
+	if [ $$? -eq 0 ] ; then echo $$OUT ; false; fi
+
+operator-validate-catalog: operator-courier-image
+	@$(VALIDATE_CATALOG)
+
 
 # Generate OLM bundle. OperatorHub/OLM still does not support bundle format
 # but soon it will move from 'packagemanifests' to 'bundles'.

--- a/pkg/apis/pmemcsi/v1alpha1/deployment_types_test.go
+++ b/pkg/apis/pmemcsi/v1alpha1/deployment_types_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -204,7 +204,7 @@ spec:
 			_, _, err = deserializer.Decode(data, nil, crd)
 			Expect(err).ShouldNot(HaveOccurred(), "decode crd file")
 
-			crdProp := crd.Spec.Validation.OpenAPIV3Schema
+			crdProp := crd.Spec.Versions[0].Schema.OpenAPIV3Schema
 			Expect(crdProp).ShouldNot(BeNil(), "Nil CRD schmea")
 			Expect(crdProp.Type).Should(BeEquivalentTo("object"), "Deployment JSON schema type mismatch")
 			spec, ok := crdProp.Properties["spec"]

--- a/test/start-operator.sh
+++ b/test/start-operator.sh
@@ -71,7 +71,7 @@ function deploy_using_olm() {
   fi
 
   # Deploy the operator
-  ${BINDIR}/operator-sdk run packagemanifests --version ${VERSION} ${NAMESPACE} --timeout 3m ${TMP_CATALOG_DIR}
+  ${BINDIR}/operator-sdk run packagemanifests --version ${VERSION} ${NAMESPACE} --install-mode OwnNamespace --timeout 3m ${TMP_CATALOG_DIR}
 }
 
 function deploy_using_yaml() {


### PR DESCRIPTION
Various fixes to generated CVS:
 - add missing mandatory fields.
 - set date of CVS to the current date.
 - make 'AllNamespaces' install mode to false.
 - fix an issue in version patching.