### PR TITLE
Jenkinsfile: do not run ps and kill based on that set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -484,7 +484,7 @@ void TestInVM(worker, distro, distroVersion, kubernetesVersion, skipIfPR) {
                   ${env.BUILD_CONTAINER} \
                   bash -c 'set -x; \
                            loggers=; \
-                           atexit () { set -x; kill \$loggers; kill \$( ps --no-header -o %p ); }; \
+                           atexit () { set -x; kill \$loggers; }; \
                            trap atexit EXIT; \
                            make stop && \
                            make start && \


### PR DESCRIPTION
After move to use Debian as base image, we do not have 'ps'
installed so that part always failed. As jobs seem to run
without trouble, let's remove this part.

Resolves: #791