### PR TITLE
test: enable stress test again

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -108,10 +108,7 @@ var _ = deploy.DescribeForAll("E2E", func(d *deploy.Deployment) {
 			TestDynamicLateBindingProvisioning(f.ClientSet, &claim, "latebinding")
 		})
 
-		// This test is pending because pod startup itself failed
-		// occasionally for reasons that are out of our control
-		// (https://github.com/clearlinux/distribution/issues/966).
-		PIt("stress test", func() {
+		It("stress test [Slow]", func() {
 			// We cannot test directly whether pod and
 			// volume were created on the same node by
 			// chance or because the code enforces it.


### PR DESCRIPTION
We no longer test on the platform (Clear Linux) which had problems
passing the test, so now it may be possible to use it again.

Another issue was that the increased usage of the PMEM data files on the build host caused it to run out of filesystem space. This was fixed by increasing the VM's disk.


Fixes: https://github.com/intel/pmem-csi/issues/685