### PR TITLE
docs: fix metric query example tables

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1066,8 +1066,8 @@ Available PMEM as percentage:
 pmem_amount_available / pmem_amount_managed
 ```
 
-Result variable | Value | Tags
-----------------|-------|-----
+| Result variable | Value | Tags|
+| ----------------|-------|-----|
 | none | 0.7332986065893997 | instance = 10.42.0.1:10010 |
 |  | | job = pmem-csi-containers |
 |  | | kubernetes_namespace = default |
@@ -1096,8 +1096,8 @@ Number of `CreateVolume` calls in nodes:
 pmem_csi_node_operations_seconds_count{method_name="/csi.v1.Controller/CreateVolume"}
 ```
 
-Result variable | Value | Tags
-----------------|-------|------
+|Result variable | Value | Tags|
+|----------------|-------|------|
 | `pmem_csi_node_operations_seconds_count` | 2 | driver_name = pmem-csi.intel.com |
 | | | grpc_status_code = OK |
 | | | instance = 10.42.0.1:10010 |


### PR DESCRIPTION
Sphinx, in contrast to GitHub, doesn't handle tables where some rows
have | at the start and end and some don't.

Fixes: https://github.com/intel/pmem-csi/issues/803