### PR TITLE
use NFD for node labelling

### DIFF
--- a/deploy/common/pmem-app-block-volume.yaml
+++ b/deploy/common/pmem-app-block-volume.yaml
@@ -30,8 +30,6 @@ spec:
       volumeMounts:
         - name: data
           mountPath: /data
-  nodeSelector:
-    storage: pmem
   volumes:
   - name: my-csi-device
     persistentVolumeClaim:

--- a/deploy/common/pmem-csi.intel.com_v1alpha1_deployment_cr.yaml
+++ b/deploy/common/pmem-csi.intel.com_v1alpha1_deployment_cr.yaml
@@ -5,5 +5,8 @@ metadata:
 spec:
   deviceMode: "lvm"
   nodeSelector:
-    storage: "pmem"
+    # When using Node Feature Discovery (NFD):
+    feature.node.kubernetes.io/memory-nv.dax: "true"
+    # When using manual node labeling with that label:
+    # storage: pmem
 

--- a/docs/autotest.md
+++ b/docs/autotest.md
@@ -56,8 +56,11 @@ virtual machines.
 The first node is the Kubernetes master without
 persistent memory.
 The other three nodes are worker nodes with one emulated 32GB NVDIMM each.
-After the cluster has been formed, `make start` adds `storage=pmem` label
-to the worker nodes and deploys the PMEM-CSI driver.
+After the cluster has been formed, `make start` installs [NFD](https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html) to label
+the worker nodes. The PMEM-CSI driver can be installed with
+`test/setup-deployment.sh`, but will also be installed as needed by
+the E2E test suite.
+
 Once `make start` completes, the cluster is ready for interactive use via
 `kubectl` inside the virtual machine. Alternatively, you can also
 set `KUBECONFIG` as shown at the end of the `make start` output

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -932,6 +932,10 @@ func (d *Deployment) GetDriverDeployment() api.Deployment {
 			// PMEM must be used for LVM, otherwise other tests cannot
 			// run after the LVM driver was deployed once.
 			PMEMPercentage: 50,
+			NodeSelector: map[string]string{
+				// Provided by NFD.
+				"feature.node.kubernetes.io/memory-nv.dax": "true",
+			},
 		},
 	}
 }

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -927,9 +927,7 @@ func (d *Deployment) GetDriverDeployment() api.Deployment {
 			Labels: map[string]string{
 				deploymentLabel: d.Label(),
 			},
-			// TODO: replace pmemcsidriver.DeviceMode with api.DeviceMode everywhere
-			// and remove this cast here.
-			DeviceMode: api.DeviceMode(d.Mode),
+			DeviceMode: d.Mode,
 			// As in setup-deployment.sh, only 50% of the available
 			// PMEM must be used for LVM, otherwise other tests cannot
 			// run after the LVM driver was deployed once.

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -385,6 +385,10 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 							Spec: api.DeploymentSpec{
 								DeviceMode:     from,
 								PMEMPercentage: 50,
+								NodeSelector: map[string]string{
+									// Provided by NFD.
+									"feature.node.kubernetes.io/memory-nv.dax": "true",
+								},
 							},
 						}
 

--- a/test/setup-deployment.sh
+++ b/test/setup-deployment.sh
@@ -157,6 +157,22 @@ EOF
   value: "--pmemPercentage=50"
 EOF
                 fi
+
+                # Always use the configured label for selecting nodes.
+                ${SSH} "cat >>'$tmpdir/my-deployment/kustomization.yaml'" <<EOF
+  - target:
+      group: apps
+      version: v1
+      kind: DaemonSet
+      name: pmem-csi-node
+    path: node-label-patch.yaml
+EOF
+                ${SSH} "cat >>'$tmpdir/my-deployment/node-label-patch.yaml'" <<EOF
+- op: add
+  path: /spec/template/spec/nodeSelector
+  value:
+     {$(echo "${TEST_PMEM_NODE_LABEL}" | sed -e 's/\(.*\)=\(.*\)/\1: "\2"/')}
+EOF
                 ;;
             scheduler)
                 # Change port number via JSON patch.

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -424,12 +424,6 @@ function init_kubernetes_cluster() (
         sed -e 's/.*: v\([0-9]*\)\.\([0-9]*\)\..*/\1.\2/' \
         >"${CLUSTER_DIRECTORY}/kubernetes.version"
 
-    # Allow all pods to run also on the master node *and* prevent the PMEM-CSI controller
-    # from running on the normal nodes. Workaround for networking issues on
-    # Clear Linux (https://github.com/intel/pmem-csi/issues/555).
-    ssh $SSH_ARGS ${CLOUD_USER}@${master_ip} kubectl taint nodes pmem-csi-${CLUSTER}-master node-role.kubernetes.io/master:NoSchedule-
-    ssh $SSH_ARGS ${CLOUD_USER}@${master_ip} kubectl label node -l storage=pmem pmem-csi.intel.com/controller=no
-
     kubernetes_usage
 )
 

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -147,6 +147,10 @@ fi
 # match the directory suffix, i.e. start with a hyphen.
 : ${TEST_KUBERNETES_FLAVOR:=}
 
+# The label and its value that identifies the nodes with PMEM.
+# The default is the label set by NFD.
+: ${TEST_PMEM_NODE_LABEL:=feature.node.kubernetes.io/memory-nv.dax=true}
+
 # Kubernetes feature gates to enable/disable.
 # EndpointSlice is disabled because of https://github.com/kubernetes/kubernetes/issues/91287 (Kubernetes
 # < 1.19) and because there were random connection failures to node ports during sanity


### PR DESCRIPTION
By using NFD we ensure that the integration with it works as intended.

TODO:
- [X] documentation
- [X] clean up commits (split out removal of Clear Linux workaround)
- [x] ensure that downgrade tests work - they probably don't, because the node labels prevent running the older version

Fixes: issue #747 