### PR TITLE
release-0.8: disable 0.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ module (NVDIMM).
 
 The [v0.8.0 release](https://github.com/intel/pmem-csi/releases/latest)
 is the latest feature release and is [regularly updated](docs/DEVELOPMENT.md#release-management) with newer base images
-and bug fixes. The v0.7.0 release will stop receiving updates
-end of October 2020.
+and bug fixes. Older releases are no longer supported.
 
 Documentation is part of the source code for each release and also
 available in rendered form for easier reading:


### PR DESCRIPTION
0.7.x was declared obsolete by the end of October when releasing
0.8.0. We no longer need to test or support it.