### PR TITLE
release-0.8: disable 0.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ library](https://github.com/pmem/ndctl). In this readme, we use
 *persistent memory* to refer to a non-volatile dual in-line memory
 module (NVDIMM).
 
-The [v0.8.0 release](https://github.com/intel/pmem-csi/releases/latest)
+The [v0.8 release](https://github.com/intel/pmem-csi/releases/latest)
 is the latest feature release and is [regularly updated](docs/DEVELOPMENT.md#release-management) with newer base images
-and bug fixes. The v0.7.0 release will stop receiving updates
-end of October 2020.
+and bug fixes. Older releases are no longer supported.
 
 Documentation is part of the source code for each release and also
 available in rendered form for easier reading:

--- a/test/e2e/versionskew/versionskew.go
+++ b/test/e2e/versionskew/versionskew.go
@@ -39,14 +39,13 @@ import (
 )
 
 const (
-	// base is the release branch used for version skew testing.
-	base = "0.7"
+	// base is the release branch used for version skew testing. Empty if none.
+	base = "0.8"
 )
 
 func baseSupportsKubernetes(ver version.Version) bool {
+	// 0.8 supports the same version as "devel".
 	switch ver {
-	case version.NewVersion(1, 19):
-		return false
 	default:
 		return true
 	}
@@ -170,6 +169,9 @@ func (p *skewTestSuite) DefineTests(driver testsuites.TestDriver, pattern testpa
 	BeforeEach(func() {
 		ver, err := k8sutil.GetKubernetesVersion(f.ClientConfig())
 		framework.ExpectNoError(err, "get Kubernetes version")
+		if base == "" {
+			skipper.Skipf("version skew testing disabled")
+		}
 		if !baseSupportsKubernetes(*ver) {
 			skipper.Skipf("%s not supported by release-%s", ver, base)
 		}


### PR DESCRIPTION
0.7.x was declared obsolete by the end of October when releasing
0.8.0. We no longer need to test or support it.