### PR TITLE
Revert "test: enable stress test again"

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -108,7 +108,10 @@ var _ = deploy.DescribeForAll("E2E", func(d *deploy.Deployment) {
 			TestDynamicLateBindingProvisioning(f.ClientSet, &claim, "latebinding")
 		})
 
-		It("stress test [Slow]", func() {
+		// This test is pending because it triggers volumes leaks
+		// in PMEM-CSI (https://github.com/intel/pmem-csi/issues/823).
+		// We need to fix those before enabling the test again.
+		PIt("stress test", func() {
 			// We cannot test directly whether pod and
 			// volume were created on the same node by
 			// chance or because the code enforces it.


### PR DESCRIPTION
This reverts commit b9079bedf12ee888b2fae77a90303ce4e244ca57.

The test works and triggers volume leaks, which then fails our test
and branch build jobs (https://github.com/intel/pmem-csi/issues/823).
We have to disable it until we have a fix.