### PR TITLE
test-cluster: Switch to calico CNI on fedora

### DIFF
--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -61,8 +61,9 @@ networking:
   podSubnet: \"10.244.0.0/16\""
 	;;
     fedora)
-	# Use weave on Fedora. Nothing to add to kubeconfig.
-	podnetworkingurl=https://cloud.weave.works/k8s/net?k8s-version=$k8sversion
+	# Use Calico on Fedora as it is the only CNI plugin that is tested by kubeadm.
+	# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network
+	podnetworkingurl=https://docs.projectcalico.org/manifests/calico.yaml
 	;;
     *)
 	echo "ERROR: unsupported distro=$distro"


### PR DESCRIPTION
Seems like weave-net CNI fails to start some time as observer in
https://cloudnative-k8sci.southcentralus.cloudapp.azure.com/blue/rest/organizations/jenkins/pipelines/pmem-csi/branches/devel/runs/302/nodes/88/steps/151/log/?start=0:
```
[2021-01-21T08:42:56.118Z] kube-system              kube-scheduler-pmem-csi-govm-master            1/1     Running             0          23s   172.17.0.4   pmem-csi-govm-master    <none>           <none>
[2021-01-21T08:42:56.119Z] kube-system              weave-net-m6pb4                                1/2     CrashLoopBackOff    1          21s   172.17.0.4   pmem-csi-govm-master    <none>           <none>
```

And the Calico CNI plugin is used by kubeadm for its E2E testing, so
this is more suitable option than weave-net for our test cluster.