### PR TITLE
pmem-csi-driver: fix race condition

### DIFF
--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -707,8 +707,8 @@ func (ns *nodeServer) mount(sourcePath, targetPath string, mountOptions []string
 // given id and returns the device manager which creates that volume.
 func (ns *nodeServer) getDeviceManagerForVolume(id string) (pmdmanager.PmemDeviceManager, error) {
 
-	vol, ok := ns.cs.pmemVolumes[id]
-	if !ok {
+	vol := ns.cs.getVolumeByID(id)
+	if vol == nil {
 		return nil, fmt.Errorf("unknown volume: %s", id)
 	}
 


### PR DESCRIPTION
Concurrent access of the map elements without locking resulted in
panic:

```
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1: fatal error: concurrent map read and map write
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1:
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1: goroutine 339 [running]:
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1: runtime.throw(0x19dbd0d, 0x21)
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1: 	/go/src/runtime/panic.go:1116 +0x72 fp=0xc0002a7408 sp=0xc0002a73d8 pc=0x43d432
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1: runtime.mapaccess2_faststr(0x1796d00, 0xc0001d5e60, 0xc00046cc00, 0x3f, 0x122, 0x0)
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1: 	/go/src/runtime/map_faststr.go:116 +0x4a5 fp=0xc0002a7478 sp=0xc0002a7408 pc=0x419e65
[2021-01-21T18:14:33.903Z] pmem-csi-intel-com-node-86n58/pmem-driver@pmem..ker1: github.com/intel/pmem-csi/pkg/pmem-csi-driver.(*nodeServer).getDeviceManagerForVolume(0xc00022dcc0, 0xc00046cc00, 0x3f, 0x0, 0x1a234d9, 0x62, 0xc0002a77d8)
```

Call dedicated get method instead of accessing the map element directly
where mutex locking was in place.

FIXES #862