### PR TITLE
operator: set operator's log verbosity level

### DIFF
--- a/deploy/bindata_generated.go
+++ b/deploy/bindata_generated.go
@@ -103,7 +103,7 @@ func deployKubernetes117DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.17/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611248679, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.17/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611767272, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -123,7 +123,7 @@ func deployKubernetes117LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.17/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611248682, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.17/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611767274, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -143,7 +143,7 @@ func deployKubernetes118DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611248689, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611767282, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -163,7 +163,7 @@ func deployKubernetes118LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611248692, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611767284, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -183,7 +183,7 @@ func deployKubernetes119AlphaDirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/direct/pmem-csi.yaml", size: 13239, mode: os.FileMode(436), modTime: time.Unix(1611248720, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/direct/pmem-csi.yaml", size: 13239, mode: os.FileMode(436), modTime: time.Unix(1611767312, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -203,7 +203,7 @@ func deployKubernetes119AlphaLvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/lvm/pmem-csi.yaml", size: 13173, mode: os.FileMode(436), modTime: time.Unix(1611248722, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/lvm/pmem-csi.yaml", size: 13173, mode: os.FileMode(436), modTime: time.Unix(1611767314, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -223,7 +223,7 @@ func deployKubernetes119DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611248700, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611767292, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -243,7 +243,7 @@ func deployKubernetes119LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611248702, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611767294, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -263,7 +263,7 @@ func deployKubernetes120DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.20/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611248710, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.20/direct/pmem-csi.yaml", size: 12925, mode: os.FileMode(436), modTime: time.Unix(1611767302, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -283,7 +283,7 @@ func deployKubernetes120LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.20/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611248712, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.20/lvm/pmem-csi.yaml", size: 12859, mode: os.FileMode(436), modTime: time.Unix(1611767304, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/deploy/kustomize/operator/operator.yaml
+++ b/deploy/kustomize/operator/operator.yaml
@@ -135,6 +135,8 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
           - /usr/local/bin/pmem-csi-operator
+          - -v=3
+          - -vmodule=*=3
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/deploy/operator/pmem-csi-operator.yaml
+++ b/deploy/operator/pmem-csi-operator.yaml
@@ -160,6 +160,8 @@ spec:
       containers:
       - command:
         - /usr/local/bin/pmem-csi-operator
+        - -v=3
+        - -vmodule=*=3
         env:
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/test/start-operator.sh
+++ b/test/start-operator.sh
@@ -64,6 +64,9 @@ function deploy_using_olm() {
   if [ "${TEST_OPERATOR_DEPLOYMENT_LABEL}" != "" ]; then
     sed -i -r "/labels:$/{N; s|(\n\s+)(.*)|\1pmem-csi.intel.com/deployment: ${TEST_OPERATOR_DEPLOYMENT_LABEL}\1\2| }" ${CSV_FILE}
   fi
+  if [ "{TEST_OPERATOR_LOGLEVEL}" != "" ]; then
+      sed -i -e "s;-v=.*;-v=${TEST_OPERATOR_LOGLEVEL};g" -e "s;-vmodule=.*;-vmodule=*=${TEST_OPERATOR_LOGLEVEL};g" ${CSV_FILE}
+  fi
 
   NAMESPACE=""
   if [ "${TEST_OPERATOR_NAMESPACE}" != "" ]; then
@@ -107,6 +110,10 @@ EOF
     ${SSH} "sed -ie 's;\(namespace: \)pmem-csi$;\1${TEST_OPERATOR_NAMESPACE};g' $tmpdir/operator.yaml"
     # replace webservice secret dns names
     ${SSH} "sed -ie 's;pmem-csi.svc;${TEST_OPERATOR_NAMESPACE}.svc;g' $tmpdir/operator.yaml"
+  fi
+
+  if [ "${TEST_OPERATOR_LOGLEVEL}" != "" ]; then
+    ${SSH} "sed -i -e 's;-ve=.*;-v=*=${TEST_OPERATOR_LOGLEVEL};g' -e 's;-vmodule=.*;-vmodule=*=${TEST_OPERATOR_LOGLEVEL};g' $tmpdir/operator.yaml"
   fi
 
   ${SSH} "cat > $tmpdir/kustomization.yaml" <<EOF

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -114,6 +114,10 @@ fi
 # itself.
 : ${TEST_OPERATOR_NAMESPACE:=pmem-csi}
 
+# Log verbosity level used for operator deployed by
+# ./test/start-operator.sh script.
+: ${TEST_OPERATOR_LOGLEVEL:=5}
+
 # A value for the pmem-csi.intel.com/deployment label that is
 # set for all objects created by test/start-operator.sh.
 : ${TEST_OPERATOR_DEPLOYMENT_LABEL:=operator}


### PR DESCRIPTION
Operator running in e2e tests was not showing any logs, and the reason is
that there is no log verbosity level set for the operator deployment.
The default level is 0 which suppress all informative logs.

The generated operator manifest is set to log level 3, and the test
script updates it with the TEST_OPERATOR_LOGLEVEL environment value,
which defaults to 5.