### PR TITLE
Fixes to operator CSV/catalog and example CR

### DIFF
--- a/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
+++ b/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
@@ -43,8 +43,10 @@ spec:
   maturity: alpha
   customresourcedefinitions:
     owned:
-    - kind: Deployment
-      name: deployments.pmem-csi.intel.com
+    - kind: PmemCSIDeployment
+      name: pmemcsideployments.pmem-csi.intel.com
+      displayName: PmemCSIDeployment
+      description: Represents a PMEM-CSI driver deployment in the cluster.
       version: v1beta1
       resources:
       - kind: StatefulSet
@@ -109,23 +111,27 @@ spec:
     $ ipmctl create -goal PersistentMemoryType=AppDirect
     ```
     **Label the cluster nodes that provide persistent memory device(s)**
+
+    You can skip this step if your cluster has [Node Feature Discovery((NFD)](https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html) installed.
     ```
-    $ kubectl label node <your node> storage=pmem
+    $ kubectl label node <your node> feature.node.kubernetes.io/memory-nv.dax="true"
     ```
-    
+
     ## Deploying PMEM-CSI driver
     
     Once after installing the PMEM-CSI operator, you can deploy the PMEM-CSI driver by
     creating an instance of the PMEM-CSI deployment custom resource as shown below:
     ```
     $ kubectl create -f - <<EOF
-    apiVersion: pmem-csi.intel.com/v1alpha1
-    kind: Deployment
+    apiVersion: pmem-csi.intel.com/v1beta1
+    kind: PmemCSIDeployment
     metadata:
       name: pmem-deployment
     spec:
       pmemPercentage: 50
       deviceMode: lvm
+      nodeSelector:
+        feature.node.kubernetes.io/memory-nv.dax: "true"
     EOF
     ```
     For additional configuration options, examples and more information on using the operator,


### PR DESCRIPTION
CSV:
- add missing CRD 'displayName','description' fields.
- Deployment -> PmemCSIDeployment naming changes
- mention NFD usage
example CR:
 - set `storage: pmem` as the default node selector.