### PR TITLE
test: fix version skew testing on Kubernetes 1.20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,7 @@ pipeline {
                 // This runs most tests and thus gets to use the initial worker immediately.
                 stage('1.19') {
                     options {
-                        timeout(time: 540, unit: "MINUTES")
+                        timeout(time: 14, unit: "HOURS")
                     }
                     steps {
                         TestInVM("", "fedora", "", "1.19", "Top.Level..[[:alpha:]]*-production[[:space:]]")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,27 +179,16 @@ pipeline {
         stage('Testing') {
             parallel {
                 // This runs most tests and thus gets to use the initial worker immediately.
-                stage('1.20') {
-                    options {
-                        timeout(time: 540, unit: "MINUTES")
-                    }
-                    steps {
-                        TestInVM("", "fedora", "", "1.20", "Top.Level..[[:alpha:]]*-production[[:space:]]")
-                    }
-                }
-
-                // All others set up their own worker.
                 stage('1.19') {
                     options {
                         timeout(time: 540, unit: "MINUTES")
                     }
-                    agent {
-                        label "pmem-csi"
-                    }
                     steps {
-                        TestInVM("fedora-1.19", "fedora", "", "1.19", "Top.Level..[[:alpha:]]*-production[[:space:]]")
+                        TestInVM("", "fedora", "", "1.19", "Top.Level..[[:alpha:]]*-production[[:space:]]")
                     }
                 }
+
+                // All others set up their own worker.
                 stage('1.18') {
                     when { not { changeRequest() } }
                     options {

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -1011,6 +1011,13 @@ func EnsureDeploymentNow(f *framework.Framework, deployment *Deployment) {
 				// root.
 				err = os.Symlink("../../_work", workRoot+"/_work")
 				framework.ExpectNoError(err, "symlink the _work directory")
+
+				// We can deploy older PMEM-CSI on Kubernetes 1.20, but we have to add the symlinks
+				// for it because they are expected by the setup-deploy.sh script.
+				if os.Getenv("TEST_KUBERNETES_VERSION") == "1.20" {
+					err = os.Symlink("kubernetes-1.19", workRoot+"/deploy/kubernetes-1.20")
+					framework.ExpectNoError(err, "symlink for Kubernetes 1.20")
+				}
 			}
 			cmd := exec.Command("test/setup-deployment.sh")
 			cmd.Dir = root


### PR DESCRIPTION
Skew testing broke when introducing 1.20 because older PMEM-CSI
releases didn't have a deployment directory for it. A symlink to 1.19
works because that deployment is okay also for 1.20.