### PR TITLE
test/e2e/operator: use localhost with closed port for dummy image

### DIFF
--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -46,9 +46,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// We use intentionally use this non-existing driver image
+// We intentionally use this non-existing container registry for driver image
 // because these tests do not actually need a running driver.
-const dummyImage = "unexisting/pmem-csi-driver"
+const dummyImage = "127.0.0.1:270/unexisting/pmem-csi-driver"
 
 func getDeployment(name string) api.PmemCSIDeployment {
 	return api.PmemCSIDeployment{


### PR DESCRIPTION
Use of dummy image name only creates many real requests to docker repo
server. The intent here is to avoid connecting real server if
we know we will fail, and also hopefully we can fail quicker.