### PR TITLE
test: fix retry after error

### DIFF
--- a/test/e2e/pod/logs.go
+++ b/test/e2e/pod/logs.go
@@ -23,7 +23,7 @@ func Logs(ctx context.Context, client kubernetes.Interface, namespace, pod, cont
 		if err == nil {
 			return
 		}
-		if ctx.Err() == nil {
+		if ctx.Err() != nil {
 			return "", fmt.Errorf("waiting for pod log of container %s in pod %s/%s: %v: %v", container, namespace, pod, ctx.Err(), err)
 		}
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
Because of == instead of != no retries were attempted.