### PR TITLE
Overwrite with zero instead of random when shredding

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -629,7 +629,7 @@ the following custom parameters in a storage class:
 
 |key|meaning|optional|values|
 |---|-------|--------|-------------|
-|`eraseAfter`|Clear all data after use and before<br> deleting the volume|Yes|`true` (default),<br> `false`|
+|`eraseAfter`|Clear all data by overwriting with zeroes after use and before<br> deleting the volume|Yes|`true` (default),<br> `false`|
 |`kataContainers`|Prepare volume for use with DAX in Kata Containers.|Yes|`false/0/f/FALSE` (default),<br> `true/1/t/TRUE`|
 
 
@@ -705,7 +705,7 @@ ephemeral volumes. The volume request could use below fields as
 |key|meaning|optional|values|
 |---|-------|--------|-------------|
 |`size`|Size of the requested ephemeral volume as [Kubernetes memory string](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory) ("1Mi" = 1024*1024 bytes, "1e3K = 1000000 bytes)|No||
-|`eraseAfter`|Clear all data after use and before<br> deleting the volume|Yes|`true` (default),<br> `false`|
+|`eraseAfter`|Clear all data by overwriting with zeroes after use and before<br> deleting the volume|Yes|`true` (default),<br> `false`|
 |`kataContainers`|Prepare volume for use in Kata Containers.|Yes|`false/0/f/FALSE` (default),<br> `true/1/t/TRUE`|
 
 Try out ephemeral volume usage with the provided [example


### PR DESCRIPTION
shred default behavior is to write random data, but getting random data is slower than writing zeroes. In my small test with 8G file, I saw write with zeroes being almost twice faster than write with random. shred has option to add zero-fill at the end, but with setting number of random writes to zero, there will be only zero-write pass. 
I want to see how this affects overall test duration.
Also, we may discuss is fill with zeroes actually enough for real operation of the plugin, instead of even more secure fill-with-random style.