### PR TITLE
Adjustments to E2E tests to decrease CI test run time

### DIFF
--- a/test/test.make
+++ b/test/test.make
@@ -152,6 +152,10 @@ TEST_E2E_SKIP_ALL += should.access.volume.from.different.nodes
 # Test is flawed and will become optional soon (probably csi-test 3.2.0): https://github.com/kubernetes-csi/csi-test/pull/258
 TEST_E2E_SKIP_ALL += NodeUnpublishVolume.*should.fail.when.the.volume.is.missing
 
+# Do not run driver stress tests in direct mode, they are consuming more time(~17m per test)
+# The reason is shredding the ndctl device is consuming most of the time.
+TEST_E2E_SKIP_ALL += direct.*.E2E.late.binding.stress.test
+
 # Add all Kubernetes version-specific suppressions.
 TEST_E2E_SKIP_ALL += $(TEST_E2E_SKIP_$(shell cat _work/$(CLUSTER)/kubernetes.version))
 

--- a/test/test.make
+++ b/test/test.make
@@ -191,7 +191,7 @@ RUN_E2E = KUBECONFIG=`pwd`/_work/$(CLUSTER)/kube.config \
 	) \
 	TEST_CMD='$(TEST_CMD)' \
 	GO='$(GO)' \
-	TEST_PKGS='$(shell for i in $(TEST_PKGS); do if ls $$i/*_test.go 2>/dev/null >&2; then echo $$i; fi; done)' \
+	TEST_PKGS='$(shell for i in ./pkg/pmem-device-manager ./pkg/imagefile/test; do if ls $$i/*_test.go 2>/dev/null >&2; then echo $$i; fi; done)' \
 	$(GO) test -count=1 -timeout 0 -v ./test/e2e -args \
                 -v=5 \
                 -ginkgo.skip='$(subst $(space),|,$(strip $(subst @,$(space),$(TEST_E2E_SKIP_ALL))))' \


### PR DESCRIPTION
- skip driver late-binding stress tests in direct mode - supposed to save ~40m
- limit running package manager and imagefile unit tests part of E2E tests - supposed to save ~10m