### PR TITLE
setup-ca.sh: create missing CA certificates

### DIFF
--- a/test/setup-ca.sh
+++ b/test/setup-ca.sh
@@ -16,10 +16,13 @@ if [ $cfssl_found -eq 0 ]; then
     exit 1
 fi
 
+CADIR=$(dirname ${CA})
+mkdir -p "${CADIR}"
 CA_CRT=$(realpath ${CA}.pem)
 CA_KEY=$(realpath ${CA}-key.pem)
 if ! [ -f ${CA_CRT} -a -f ${CA_KEY} ]; then
-  echo "Generating CA certificate ..."
+  echo "Generating CA certificate in $CADIR ..."
+  (cd "$CADIR" &&
   <<EOF cfssl gencert -initca - | cfssljson -bare $(basename $CA)
 {
     "CN": "pmem-ca",
@@ -30,6 +33,7 @@ if ! [ -f ${CA_CRT} -a -f ${CA_KEY} ]; then
     }
 }
 EOF
+)
 fi
 
 # Generate server and client certificates.


### PR DESCRIPTION
Calling this script fails when no CA directroy/certificates are not found:

```
./test/setup-ca-kubernetes.sh
realpath: /home/tomz/container/openshift/pmem-csi/pmem-csi/_work/pmem-ca/ca.pem: No such file or directory
realpath: /home/tomz/container/openshift/pmem-csi/pmem-csi/_work/pmem-ca/ca-key.pem: No such file or directory
Generating Certificate for 'pmem-registry'(NS=pmem-csi) ...
```