### PR TITLE
operator: load TLS CA bundle also when handling sub-object changes

### DIFF
--- a/pkg/deployments/load_test.go
+++ b/pkg/deployments/load_test.go
@@ -51,7 +51,7 @@ func TestLoadObjects(t *testing.T) {
 					Name: "pmem-csi.example.org",
 				},
 			}
-			objects, err = deployments.LoadAndCustomizeObjects(testCase.Kubernetes, testCase.DeviceMode, namespace, deployment)
+			objects, err = deployments.LoadAndCustomizeObjects(testCase.Kubernetes, testCase.DeviceMode, namespace, deployment, nil)
 			if assert.NoError(t, err, "load and customize yaml") {
 				assert.NotEmpty(t, objects, "have customized objects")
 

--- a/pkg/pmem-csi-operator/controller/deployment/deployment_controller_test.go
+++ b/pkg/pmem-csi-operator/controller/deployment/deployment_controller_test.go
@@ -356,7 +356,7 @@ func TestDeploymentController(t *testing.T) {
 			if wasUpdated {
 				rv = nil
 			}
-			_, err := validate.DriverDeployment(tc.c, testK8sVersion, testNamespace, *dep, rv)
+			_, err := validate.DriverDeployment(tc.ctx, tc.c, testK8sVersion, testNamespace, *dep, rv)
 			require.NoError(tc.t, err, "validate deployment")
 			validateEvents(tc, dep, expectedEvents)
 		}

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -425,7 +425,7 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 			// Ensure that the driver is running consistently
 			resourceVersions := map[string]string{}
 			Consistently(func() error {
-				final, err := validate.DriverDeployment(client, k8sver, d.Namespace, deployment, resourceVersions)
+				final, err := validate.DriverDeployment(ctx, client, k8sver, d.Namespace, deployment, resourceVersions)
 				if final {
 					framework.Failf("final error during driver validation after restarting: %v", err)
 				}


### PR DESCRIPTION
When handling change or delete events for sub-objects, in particular
MutatingWebhookConfig, a pmemCSIDeployment was created and used
without loading the TLS secret, resulting in a MutatingWebhookConfig
which had an empty CA bundle. That in turn led to:

   failed calling webhook "pod-hook.pmem-csi.intel.com": Post "https://second-pmem-csi-intel-com-scheduler.default.svc:443/pod/mutate?timeout=30s": x509: certificate signed by unknown authority