### PR TITLE
test: allow webhook failures during testing

### DIFF
--- a/test/setup-deployment.sh
+++ b/test/setup-deployment.sh
@@ -197,9 +197,6 @@ EOF
 - op: replace
   path: /webhooks/0/clientConfig/service/namespace
   value: ${TEST_DRIVER_NAMESPACE}
-- op: replace
-  path: /webhooks/0/failurePolicy
-  value: Fail # This is not the default anymore in PMEM-CSI, but for testing we want it.
 EOF
                 ;;
         esac


### PR DESCRIPTION
The webhook was kept as mandatory for testing when relaxing the
default, with the rationale being that we want to know if it starts
failing. But we do get test flakes because of that. Normally, pod
creation would get retried, it's just that many E2E tests don't do
that.

It's better to let the tests run and cover testing of the webhook
through WaitForPMEMDriver which explicitly creates a pod and verifies
that the webhook was invoked.