### PR TITLE
olm-catalog: Drop redundant sections in documentation

### DIFF
--- a/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
+++ b/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
@@ -66,76 +66,12 @@ spec:
     Intel PMEM-CSI is a [CSI](https://github.com/container-storage-interface/spec)
     storage driver for container orchestrators like Kubernetes. It makes local
     persistent memory ([PMEM](https://pmem.io/)) available as a filesystem volume to
-    container applications. It can currently utilize non-volatile memory devices
-    that can be controlled via the [libndctl utility library](https://github.com/pmem/ndctl).
-    *Persistent memory* in this context refers to a non-volatile dual in-line
-    memory module (NVDIMM). See the [PMEM-CSI documentation](https://intel.github.io/pmem-csi/X.Y/README.html)
-    for more details.
-    This is the operator to deploy and manage the [PMEM-CSI](https://intel.github.io/pmem-csi/X.Y/README.html)
+    container applications. This is the operator to deploy and manage the
+    [PMEM-CSI](https://intel.github.io/pmem-csi/X.Y/README.html)
     driver on a Kubernetes cluster.
 
-    ## Prerequisite
-    ### Software required
-    
-    The recommended minimum Linux kernel version for running the PMEM-CSI driver is 4.15.
-    See [Persistent Memory Programming](https://pmem.io/2018/05/15/using_persistent_memory_devices_with_the_linux_device_mapper.html)
-    for more details about supported kernel versions.
-    
-    ### Hardware required
-    
-    Persistent memory device(s) are required for operation. However, some development
-    and testing can be done using [QEMU-emulated](https://docs.pmem.io/persistent-memory/getting-started-guide/creating-development-environments/virtualization/qemu)
-    persistent memory devices.
-    
-    ### Cluster requirements
-    
-    The operator can be installed on any OLM-enabled Kubernetes cluster with version >= 1.15.
-    Make sure that the alpha feature gates _`CSINodeInfo`_ and _`CSIDriverRegistry`_ are enabled
-    in your cluster. The method to configure alpha feature gates may vary, depending on
-    the Kubernetes deployment. It may not be necessary anymore when the feature has reached
-    beta state, which depends on the Kubernetes version.
-    You also need to have the [kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-    already configured to access your cluster.
-    
-    ### Preparing worker nodes
-    
-    **Persistent memory pre-provisioning**
-    
-    The PMEM-CSI driver needs pre-provisioned regions on the NVDIMM device(s).
-    The PMEM-CSI driver itself intentionally leaves that to the administrator who
-    then can decide how much and how PMEM is to be used for PMEM-CSI.
-    When running the Kubernetes cluster and PMEM-CSI on bare metal, the [ipmctl](https://github.com/intel/ipmctl)
-    utility can be used to create regions.
-    Example of creating regions using all NVDIMMs:
-    ```
-    $ ipmctl create -goal PersistentMemoryType=AppDirect
-    ```
-    **Label the cluster nodes that provide persistent memory device(s)**
-
-    You can skip this step if your cluster has [Node Feature Discovery((NFD)](https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html) installed.
-    ```
-    $ kubectl label node <your node> feature.node.kubernetes.io/memory-nv.dax="true"
-    ```
-
-    ## Deploying PMEM-CSI driver
-    
-    Once after installing the PMEM-CSI operator, you can deploy the PMEM-CSI driver by
-    creating an instance of the PMEM-CSI deployment custom resource as shown below:
-    ```
-    $ kubectl create -f - <<EOF
-    apiVersion: pmem-csi.intel.com/v1beta1
-    kind: PmemCSIDeployment
-    metadata:
-      name: pmem-deployment
-    spec:
-      pmemPercentage: 50
-      deviceMode: lvm
-      nodeSelector:
-        feature.node.kubernetes.io/memory-nv.dax: "true"
-    EOF
-    ```
-    For additional configuration options, examples and more information on using the operator,
-    refer to the [PMEM-CSI documentation](https://intel.github.io/pmem-csi/X.Y/README.html)
+    Refer to the [PMEM-CSI documentation](https://intel.github.io/pmem-csi/X.Y/README.html)
+    for more details on deploying and using the PMEM-CSI driver.
 
   icon:
   - mediatype: image/png


### PR DESCRIPTION
The documentation sections like prerequisite and driver deployment
instructions de-duplicates with original PMEM-CSI readme documentation.
Instead we can point to PMEM-CSI documentation.

FIXES #891