### PR TITLE
Re-enable k8s 1.20 testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,16 +179,27 @@ pipeline {
         stage('Testing') {
             parallel {
                 // This runs most tests and thus gets to use the initial worker immediately.
-                stage('1.19') {
+                stage('1.20') {
                     options {
                         timeout(time: 14, unit: "HOURS")
                     }
                     steps {
-                        TestInVM("", "fedora", "", "1.19", "Top.Level..[[:alpha:]]*-production[[:space:]]")
+                        TestInVM("", "fedora", "", "1.20", "Top.Level..[[:alpha:]]*-production[[:space:]]")
                     }
                 }
 
                 // All others set up their own worker.
+                stage('1.19') {
+                    options {
+                        timeout(time: 540, unit: "MINUTES")
+                    }
+                    agent {
+                        label "pmem-csi"
+                    }
+                    steps {
+                        TestInVM("fedora-1.19", "fedora", "", "1.19", "Top.Level..[[:alpha:]]*-production[[:space:]]")
+                    }
+                }
                 stage('1.18') {
                     when { not { changeRequest() } }
                     options {

--- a/test/setup-fedora-govm.sh
+++ b/test/setup-fedora-govm.sh
@@ -63,7 +63,7 @@ EOF
         1.17) packages+=" kubelet-1.17.5-0 kubeadm-1.17.5-0 kubectl-1.17.5-0";;
         1.18) packages+=" kubelet-1.18.2-0 kubeadm-1.18.2-0 kubectl-1.18.2-0";;
         1.19) packages+=" kubelet-1.19.1-0 kubeadm-1.19.1-0 kubectl-1.19.1-0";;
-        1.20) packages+=" kubelet-1.20.2-0 kubeadm-1.20.2-0 kubectl-1.20.2-0";;
+        1.20) packages+=" kubelet-1.20.4-0 kubeadm-1.20.4-0 kubectl-1.20.4-0";;
         *) echo >&2 "Kubernetes version ${TEST_KUBERNETES_VERSION} not supported, package list in $0 must be updated."; exit 1;;
     esac
     packages+=" --disableexcludes=kubernetes"


### PR DESCRIPTION
Kubernetes v1.20.2 has a [regression](https://github.com/kubernetes/kubernetes/issues/97288), which resulted in the slowness of CI builds. This got addressed in later releases. 

By moving to 1.20.4 we could re-enable 1.20 testing.
    
FIXES: #88