### PR TITLE
Jenkinsfile: archive artifacts before junit step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -550,7 +550,7 @@ void TestInVM(worker, distro, distroVersion, kubernetesVersion, skipIfPR) {
                     diff $i build/reports/$testrun.xml || true
                fi
            done'''
-        junit 'build/reports/**/*.xml'
         archiveArtifacts('**/joblog-*')
+        junit 'build/reports/**/*.xml'
     }
 }


### PR DESCRIPTION
Sometimes, junit step does not find reports and this
causes break of execution and some artifacts may get lost.
Let's archive artifacts before junit step.