### PR TITLE
deploy: remove redundant -vmodule operator parameter

### DIFF
--- a/deploy/bindata_generated.go
+++ b/deploy/bindata_generated.go
@@ -101,7 +101,7 @@ func deployKubernetes118DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 12996, mode: os.FileMode(436), modTime: time.Unix(1615816305, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 12996, mode: os.FileMode(420), modTime: time.Unix(1617810598, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -121,7 +121,7 @@ func deployKubernetes118LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 12930, mode: os.FileMode(436), modTime: time.Unix(1615816308, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 12930, mode: os.FileMode(420), modTime: time.Unix(1617810599, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -141,7 +141,7 @@ func deployKubernetes119AlphaDirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/direct/pmem-csi.yaml", size: 13310, mode: os.FileMode(436), modTime: time.Unix(1615816335, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/direct/pmem-csi.yaml", size: 13310, mode: os.FileMode(420), modTime: time.Unix(1617810613, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func deployKubernetes119AlphaLvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/lvm/pmem-csi.yaml", size: 13244, mode: os.FileMode(436), modTime: time.Unix(1615816338, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/lvm/pmem-csi.yaml", size: 13244, mode: os.FileMode(420), modTime: time.Unix(1617810614, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -181,7 +181,7 @@ func deployKubernetes119DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19/direct/pmem-csi.yaml", size: 12996, mode: os.FileMode(436), modTime: time.Unix(1615816315, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19/direct/pmem-csi.yaml", size: 12996, mode: os.FileMode(420), modTime: time.Unix(1617810603, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -201,7 +201,7 @@ func deployKubernetes119LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19/lvm/pmem-csi.yaml", size: 12930, mode: os.FileMode(436), modTime: time.Unix(1615816318, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19/lvm/pmem-csi.yaml", size: 12930, mode: os.FileMode(420), modTime: time.Unix(1617810604, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -221,7 +221,7 @@ func deployKubernetes120DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.20/direct/pmem-csi.yaml", size: 12996, mode: os.FileMode(436), modTime: time.Unix(1615816325, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.20/direct/pmem-csi.yaml", size: 12996, mode: os.FileMode(420), modTime: time.Unix(1617810608, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -241,7 +241,7 @@ func deployKubernetes120LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.20/lvm/pmem-csi.yaml", size: 12930, mode: os.FileMode(436), modTime: time.Unix(1615816328, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.20/lvm/pmem-csi.yaml", size: 12930, mode: os.FileMode(420), modTime: time.Unix(1617810609, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -261,7 +261,7 @@ func deployKustomizeWebhookWebhookYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kustomize/webhook/webhook.yaml", size: 1196, mode: os.FileMode(436), modTime: time.Unix(1615542737, 0)}
+	info := bindataFileInfo{name: "deploy/kustomize/webhook/webhook.yaml", size: 1196, mode: os.FileMode(420), modTime: time.Unix(1615969377, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -281,7 +281,7 @@ func deployKustomizeSchedulerSchedulerServiceYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kustomize/scheduler/scheduler-service.yaml", size: 277, mode: os.FileMode(436), modTime: time.Unix(1615542737, 0)}
+	info := bindataFileInfo{name: "deploy/kustomize/scheduler/scheduler-service.yaml", size: 277, mode: os.FileMode(420), modTime: time.Unix(1615969377, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/deploy/kustomize/operator/operator.yaml
+++ b/deploy/kustomize/operator/operator.yaml
@@ -136,7 +136,6 @@ spec:
           command:
           - /usr/local/bin/pmem-csi-operator
           - -v=3
-          - -vmodule=*=3
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/deploy/operator/pmem-csi-operator.yaml
+++ b/deploy/operator/pmem-csi-operator.yaml
@@ -161,7 +161,6 @@ spec:
       - command:
         - /usr/local/bin/pmem-csi-operator
         - -v=3
-        - -vmodule=*=3
         env:
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/test/start-operator.sh
+++ b/test/start-operator.sh
@@ -65,7 +65,7 @@ function deploy_using_olm() {
     sed -i -r "/labels:$/{N; s|(\n\s+)(.*)|\1pmem-csi.intel.com/deployment: ${TEST_OPERATOR_DEPLOYMENT_LABEL}\1\2| }" ${CSV_FILE}
   fi
   if [ "{TEST_OPERATOR_LOGLEVEL}" != "" ]; then
-      sed -i -e "s;-v=.*;-v=${TEST_OPERATOR_LOGLEVEL};g" -e "s;-vmodule=.*;-vmodule=*=${TEST_OPERATOR_LOGLEVEL};g" ${CSV_FILE}
+      sed -i -e "s;-v=.*;-v=${TEST_OPERATOR_LOGLEVEL};g" ${CSV_FILE}
   fi
 
   NAMESPACE=""
@@ -113,7 +113,7 @@ EOF
   fi
 
   if [ "${TEST_OPERATOR_LOGLEVEL}" != "" ]; then
-    ${SSH} "sed -i -e 's;-ve=.*;-v=*=${TEST_OPERATOR_LOGLEVEL};g' -e 's;-vmodule=.*;-vmodule=*=${TEST_OPERATOR_LOGLEVEL};g' $tmpdir/operator.yaml"
+    ${SSH} "sed -i -e 's;-v=.*;-v=${TEST_OPERATOR_LOGLEVEL};g' $tmpdir/operator.yaml"
   fi
 
   ${SSH} "cat > $tmpdir/kustomization.yaml" <<EOF


### PR DESCRIPTION
It's set such that it replicates the semantic of the simpler -v
parameter and and then just causes more overhead in klog. In addition,
setting -v was broken because
's;-ve=.*;-v=*=${TEST_OPERATOR_LOGLEVEL};g' didn't match.