### PR TITLE
Operator deployment changes for supporting version skew tests

### DIFF
--- a/hack/set-version.sh
+++ b/hack/set-version.sh
@@ -14,5 +14,5 @@ if [ $# != 1 ] || [ "$1" = "?" ] || [ "$1" = "--help" ]; then
 fi
 
 sed -i -e "s;\(IMAGE_VERSION?*=\|intel/pmem-[^ ]*:\)[^ ^;/]*;\1$1;g" $(git grep -l 'IMAGE_VERSION?*=\|intel/pmem-[^ ]*:' Makefile test/*.sh deploy)
-sed -i -e "s;/pmem-csi-driver\([^ ]*\):[^ {}]*;/pmem-csi-driver\1:$1;g" test/test-config.sh
+sed -i -e "s;/pmem-csi-driver\([^ ]*\):[^ {}]*;/pmem-csi-driver\1:$1;g" -e "s;\(TEST_PMEM_IMAGE_TAG:=\)canary;\1$1;g" test/test-config.sh
 sed -i -e "s;github.com/intel/pmem-csi/raw/[^/]*/;github.com/intel/pmem-csi/raw/$1/;g" docs/*.md

--- a/test/start-operator.sh
+++ b/test/start-operator.sh
@@ -100,6 +100,9 @@ EOF
   if [ "${TEST_PMEM_REGISTRY}" != "" ]; then
      ${SSH} sed -ie "s^intel/pmem^${TEST_PMEM_REGISTRY}/pmem^g" "$tmpdir/operator.yaml"
   fi
+  if [ "${TEST_PMEM_IMAGE_TAG}" != "" ]; then
+    ${SSH} sed -ie "'s^\(/pmem-csi-driver:\).*^\1${TEST_PMEM_IMAGE_TAG}^g' $tmpdir/operator.yaml"
+  fi
   if [ "${TEST_IMAGE_PULL_POLICY}" != "" ]; then
     ${SSH} "sed -ie 's;\(imagePullPolicy: \).*;\1${TEST_IMAGE_PULL_POLICY};g' $tmpdir/operator.yaml"
   fi

--- a/test/test-config.sh
+++ b/test/test-config.sh
@@ -43,6 +43,10 @@ fi
 # This is needed for "make push-images".
 : ${TEST_BUILD_PMEM_REGISTRY:=localhost:5000}
 
+# The PMEM-CSI driver/operator container image tag to use.
+# This is used by version skew tests to set the driver/operator version.
+: ${TEST_PMEM_IMAGE_TAG:=canary}
+
 # Additional insecure registries (for example, my-registry:5000),
 # separated by spaces. The default local registry above is always
 # marked as insecure and does not need to be listed.


### PR DESCRIPTION
In order to upgrade/downgrade the operator:
- the `stop-operator.sh` script must support removing the operator without deleting the CRD and namespace.
- the `start-operator.sh` script must support choosing the specific operator image version.