### PR TITLE
exec: cleanly separate stdout/stderr

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -32,27 +32,59 @@ func Run(cmd *exec.Cmd) (string, error) {
 	klog.V(4).Infof("Executing: %s", cmd)
 
 	r, w := io.Pipe()
+	r2, w2 := io.Pipe()
 	cmd.Stdout = w
-	cmd.Stderr = w
-	buffer := new(bytes.Buffer)
-	r2 := io.TeeReader(r, buffer)
+	cmd.Stderr = w2
+	var stdout, both bytes.Buffer
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		scanner := bufio.NewScanner(r2)
-		for scanner.Scan() {
-			klog.V(5).Infof("%s: %s", cmd.Path, scanner.Text())
-		}
-	}()
+	wg.Add(2)
+	// Collect stdout and stderr separately. Storing in the
+	// combined buffer is a bit racy, but we need to know which
+	// output is stdout.
+	go dumpOutput(&wg, r, []io.Writer{&stdout, &both}, cmd.Path+": stdout: ")
+	go dumpOutput(&wg, r2, []io.Writer{&both}, cmd.Path+": stderr: ")
 	err := cmd.Run()
 	w.Close()
+	w2.Close()
 	wg.Wait()
-	klog.V(4).Infof("%s terminated, with %d bytes of output and error %v", cmd.Path, buffer.Len(), err)
+	klog.V(4).Infof("%s terminated, with %d bytes of stdout, %d of combined output and error %v", cmd.Path, stdout.Len(), both.Len(), err)
 
-	output := string(buffer.Bytes())
-	if err != nil {
-		err = fmt.Errorf("command %q failed: %v\nOutput: %s", cmd, err, output)
+	switch {
+	case err != nil && both.Len() > 0:
+		err = fmt.Errorf("%q: command failed: %v\nCombined stderr/stdout output: %s", cmd, err, string(both.Bytes()))
+	case err != nil:
+		err = fmt.Errorf("%q: command failed with no output: %v", cmd, err)
 	}
-	return output, err
+	return string(stdout.Bytes()), err
+}
+
+func dumpOutput(wg *sync.WaitGroup, in io.Reader, out []io.Writer, prefix string) {
+	defer wg.Done()
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		for _, o := range out {
+			o.Write(scanner.Bytes())
+			o.Write([]byte("\n"))
+		}
+		klog.V(5).Infof("%s%s", prefix, scanner.Text())
+	}
+}
+
+// CmdResult always returns an informative description of what command ran and what the
+// outcome (stdout+stderr, exit code if any) was. Logging is left entirely to the caller.
+func CmdResult(cmd string, args ...string) string {
+	c := exec.Command(cmd, args...)
+	output, err := c.CombinedOutput()
+	result := fmt.Sprintf("%q:", c)
+	switch {
+	case err != nil && len(output) == 0:
+		result += fmt.Sprintf(" command failed with no output: %v", err)
+	case err != nil:
+		result += fmt.Sprintf(" command failed: %v\nOutput:\n%s", err, string(output))
+	case len(output) > 0:
+		result += fmt.Sprintf("\n%s", output)
+	default:
+		result += " no output"
+	}
+	return result
 }


### PR DESCRIPTION
Commit 40ba3555a43fa2aa8aa1f081af1f2386edda4dd8 intentionally captured
stderr in the output because earlier it was hard to understand why LVM
commands failed. However, we now learned the some error messages can
be safely ignored and not doing so broke LVM mode: when /dev/sda is
unreadable, "vgs" prints a line about it on stderr, but the output on
stdout is fine.

Now we capture both output streams separately, log both, but only
return stdout to the caller.

The TestResult call is unrelated to that fix and will be used for
additional debugging in another PR. It gets added here because it can
use the same test cases and is related.

Fixes: #925