### PR TITLE
test: retrieve metrics with port forwarding instead of socat

### DIFF
--- a/test/e2e/metrics/metrics.go
+++ b/test/e2e/metrics/metrics.go
@@ -7,10 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package gotests
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -19,9 +19,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/klogr"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/intel/pmem-csi/test/e2e/deploy"
+	"github.com/intel/pmem-csi/test/e2e/pod"
 )
 
 // We only need to test this in one deployment because the tests
@@ -61,17 +63,10 @@ var _ = deploy.Describe("direct-testing", "direct-testing-metrics", "", func(d *
 		pods, err := f.ClientSet.CoreV1().Pods(d.Namespace).List(context.Background(), metav1.ListOptions{})
 		framework.ExpectNoError(err, "list pods")
 
-		// We cannot connect to the node port directly from
-		// outside of the cluster. Instead of setting up
-		// port-forwarding, we rely on having socat in the
-		// "testing" deployment. We just need to find one of
-		// those pods...
-		socatPods, err := f.ClientSet.CoreV1().Pods(d.Namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: "app.kubernetes.io/name in ( pmem-csi-node-testing )",
-		})
-		framework.ExpectNoError(err, "list socat pods")
-		Expect(pods.Items).NotTo(BeEmpty(), "at least one socat pod should be running")
-		socatPod := socatPods.Items[0]
+		transport := pod.NewTransport(klogr.New().WithName("port forwarding"), f.ClientSet, f.ClientConfig())
+		client := http.Client{
+			Transport: transport,
+		}
 
 		test := func() {
 			numPods := 0
@@ -92,43 +87,26 @@ var _ = deploy.Describe("direct-testing", "direct-testing-metrics", "", func(d *
 							Expect(ip).ToNot(BeEmpty(), "have pod IP")
 							Expect(portNum).ToNot(Equal(0), "have container port")
 
-							// We use HTTP 1.0 to prevent the server from sending the response in chunks.
-							// That way we don't need to decode the response...
-							request := fmt.Sprintf(`GET /metrics HTTP/1.0
-Host: %s:%d
-User-Agent: e2e/1.0
-Accept: */*
-
-`, ip, portNum)
-							options := framework.ExecOptions{
-								Command: []string{
-									"socat",
-									"STDIO",
-									fmt.Sprintf("TCP:%s:%d", ip, portNum),
-								},
-								Namespace:     socatPod.Namespace,
-								PodName:       socatPod.Name,
-								Stdin:         bytes.NewBufferString(request),
-								CaptureStdout: true,
-								CaptureStderr: true,
-							}
-							stdout, stderr, err := f.ExecWithOptions(options)
-							framework.ExpectNoError(err, "command failed in namespace %s, pod %s:\nstderr:\n%s\nstdout:%s\n",
-								socatPod.Namespace, socatPod.Name, stderr, stdout)
+							url := fmt.Sprintf("http://%s.%s:%d/metrics",
+								pod.Namespace, pod.Name, port.ContainerPort)
+							resp, err := client.Get(url)
+							framework.ExpectNoError(err, "GET failed")
+							data, err := ioutil.ReadAll(resp.Body)
+							framework.ExpectNoError(err, "read GET response")
 							name := pod.Name + "/" + container.Name
 							if strings.HasPrefix(container.Name, "pmem") {
-								Expect(stdout).To(ContainSubstring("go_threads "), name)
-								Expect(stdout).To(ContainSubstring("process_open_fds "), name)
+								Expect(data).To(ContainSubstring("go_threads "), name)
+								Expect(data).To(ContainSubstring("process_open_fds "), name)
 								if !strings.Contains(pod.Name, "controller") {
 									// Only the node driver implements CSI and manages volumes.
-									Expect(stdout).To(ContainSubstring("csi_plugin_operations_seconds "), name)
-									Expect(stdout).To(ContainSubstring("pmem_amount_available "), name)
-									Expect(stdout).To(ContainSubstring("pmem_amount_managed "), name)
-									Expect(stdout).To(ContainSubstring("pmem_amount_max_volume_size "), name)
-									Expect(stdout).To(ContainSubstring("pmem_amount_total "), name)
+									Expect(data).To(ContainSubstring("csi_plugin_operations_seconds "), name)
+									Expect(data).To(ContainSubstring("pmem_amount_available "), name)
+									Expect(data).To(ContainSubstring("pmem_amount_managed "), name)
+									Expect(data).To(ContainSubstring("pmem_amount_max_volume_size "), name)
+									Expect(data).To(ContainSubstring("pmem_amount_total "), name)
 								}
 							} else {
-								Expect(stdout).To(ContainSubstring("csi_sidecar_operations_seconds "), name)
+								Expect(data).To(ContainSubstring("csi_sidecar_operations_seconds "), name)
 							}
 						}
 					}

--- a/test/e2e/pod/dial.go
+++ b/test/e2e/pod/dial.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 Intel Corporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// NewTransport creates a transport which uses the port forward dialer.
+// URLs must use <namespace>.<pod>:<port> as host.
+func NewTransport(logger logr.Logger, client kubernetes.Interface, restConfig *rest.Config) *http.Transport {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+			dialer := NewDialer(client, restConfig)
+			a, err := ParseAddr(addr)
+			if err != nil {
+				return nil, err
+			}
+			return dialer.DialContainerPort(ctx, logger, *a)
+		},
+	}
+}
+
+// NewDialer creates a dialer that supports connecting to container ports.
+func NewDialer(client kubernetes.Interface, restConfig *rest.Config) *Dialer {
+	return &Dialer{
+		client:     client,
+		restConfig: restConfig,
+	}
+}
+
+// Dialer holds the relevant parameters that are independent of a particular connection.
+type Dialer struct {
+	client     kubernetes.Interface
+	restConfig *rest.Config
+}
+
+// DialContainerPort connects to a certain container port in a pod.
+func (d *Dialer) DialContainerPort(ctx context.Context, logger logr.Logger, addr Addr) (conn net.Conn, finalErr error) {
+	restClient := d.client.CoreV1().RESTClient()
+	restConfig := d.restConfig
+	if restConfig.GroupVersion == nil {
+		restConfig.GroupVersion = &schema.GroupVersion{}
+	}
+	if restConfig.NegotiatedSerializer == nil {
+		restConfig.NegotiatedSerializer = scheme.Codecs
+	}
+
+	// The setup code around the actual portforward is from
+	// https://github.com/kubernetes/kubernetes/blob/c652ffbe4a29143623a1aaec39f745575f7e43ad/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+	req := restClient.Post().
+		Resource("pods").
+		Namespace(addr.Namespace).
+		Name(addr.PodName).
+		SubResource("portforward")
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create round tripper: %v", err)
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
+	streamConn, _, err := dialer.Dial(portforward.PortForwardProtocolV1Name)
+	if err != nil {
+		return nil, fmt.Errorf("dialer failed: %v", err)
+	}
+	requestID := "1"
+	defer func() {
+		if finalErr != nil {
+			streamConn.Close()
+		}
+	}()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", addr.Port))
+	headers.Set(v1.PortForwardRequestIDHeader, requestID)
+
+	// We're not writing to this stream, just reading an error message from it.
+	// This happens asynchronously.
+	errorStream, err := streamConn.CreateStream(headers)
+	if err != nil {
+		return nil, fmt.Errorf("error creating error stream: %v", err)
+	}
+	errorStream.Close()
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			logger.Error(err, "error reading from error stream")
+		case len(message) > 0:
+			logger.Error(errors.New(string(message)), "an error occurred connecting to the remote port")
+		}
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := streamConn.CreateStream(headers)
+	if err != nil {
+		return nil, fmt.Errorf("error creating data stream: %v", err)
+	}
+
+	return &stream{
+		Stream:     dataStream,
+		streamConn: streamConn,
+	}, nil
+}
+
+// Addr contains all relevant parameters for a certain port in a pod.
+// The container should be running before connections are attempted,
+// otherwise the connection will fail.
+type Addr struct {
+	Namespace, PodName string
+	Port               int
+}
+
+var _ net.Addr = Addr{}
+
+func (a Addr) Network() string {
+	return "port-forwarding"
+}
+
+func (a Addr) String() string {
+	return fmt.Sprintf("%s.%s:%d", a.Namespace, a.PodName, a.Port)
+}
+
+func ParseAddr(addr string) (*Addr, error) {
+	parts := addrRegex.FindStringSubmatch(addr)
+	if parts == nil {
+		return nil, fmt.Errorf("%q: must match the format <namespace>.<pod>:<port number>", addr)
+	}
+	port, _ := strconv.Atoi(parts[3])
+	return &Addr{
+		Namespace: parts[1],
+		PodName:   parts[2],
+		Port:      port,
+	}, nil
+}
+
+var addrRegex = regexp.MustCompile(`^([^\.]+)\.([^:]+):(\d+)$`)
+
+type stream struct {
+	addr Addr
+	httpstream.Stream
+	streamConn httpstream.Connection
+}
+
+var _ net.Conn = &stream{}
+
+func (s *stream) Close() error {
+	s.Stream.Close()
+	s.streamConn.Close()
+	return nil
+}
+
+func (s *stream) LocalAddr() net.Addr {
+	return LocalAddr{}
+}
+
+func (s *stream) RemoteAddr() net.Addr {
+	return s.addr
+}
+
+func (s *stream) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (s *stream) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (s *stream) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+type LocalAddr struct{}
+
+var _ net.Addr = LocalAddr{}
+
+func (l LocalAddr) Network() string { return "port-forwarding" }
+func (l LocalAddr) String() string  { return "apiserver" }


### PR DESCRIPTION
With port forwarding through the API server we no longer need a
running container with socat inside it. For the metrics test it makes
no big difference, but the new code might be useful also for other
tests.