### PR TITLE
deploy: set fsgroup for the pod in application example(s)

### DIFF
--- a/deploy/common/pmem-app-cache.yaml
+++ b/deploy/common/pmem-app-cache.yaml
@@ -12,6 +12,12 @@ spec:
       labels:
         app: my-csi-app
     spec:
+      # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+      # This security context causes permissions of volume mounts
+      # to be adapted accordingly, see
+      # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+      securityContext:
+        fsGroup: 1000
       # make sure that no two Pods run on same node
       affinity:
         podAntiAffinity:

--- a/deploy/common/pmem-app-ephemeral.yaml
+++ b/deploy/common/pmem-app-ephemeral.yaml
@@ -5,6 +5,12 @@ apiVersion: v1
 metadata:
   name: my-csi-app-inline-volume
 spec:
+  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+  # This security context causes permissions of volume mounts
+  # to be adapted accordingly, see
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-app-generic-ephemeral.yaml
+++ b/deploy/common/pmem-app-generic-ephemeral.yaml
@@ -6,6 +6,12 @@ apiVersion: v1
 metadata:
   name: my-csi-app-inline-volume
 spec:
+  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+  # This security context causes permissions of volume mounts
+  # to be adapted accordingly, see
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-app-late-binding.yaml
+++ b/deploy/common/pmem-app-late-binding.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 metadata:
   name: my-csi-app
 spec:
+  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+  # This security context causes permissions of volume mounts
+  # to be adapted accordingly, see
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-app.yaml
+++ b/deploy/common/pmem-app.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 metadata:
   name: my-csi-app-1
 spec:
+  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+  # This security context causes permissions of volume mounts
+  # to be adapted accordingly, see
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary
@@ -20,6 +26,12 @@ apiVersion: v1
 metadata:
   name: my-csi-app-2
 spec:
+  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+  # This security context causes permissions of volume mounts
+  # to be adapted accordingly, see
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-kata-app-ephemeral.yaml
+++ b/deploy/common/pmem-kata-app-ephemeral.yaml
@@ -5,6 +5,12 @@ metadata:
   labels:
     io.katacontainers.config.hypervisor.memory_offset: "2147483648" # 2Gi, must be at least as large as the PMEM volume
 spec:
+  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+  # This security context causes permissions of volume mounts
+  # to be adapted accordingly, see
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext:
+    fsGroup: 1000
   # see https://github.com/kata-containers/packaging/tree/1.11.0-rc0/kata-deploy#run-a-sample-workload
   runtimeClassName: kata-qemu
   nodeSelector:

--- a/deploy/common/pmem-kata-app.yaml
+++ b/deploy/common/pmem-kata-app.yaml
@@ -5,6 +5,12 @@ metadata:
   labels:
     io.katacontainers.config.hypervisor.memory_offset: "2147483648" # 2Gi, must be at least as large as the PMEM volume
 spec:
+  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
+  # This security context causes permissions of volume mounts
+  # to be adapted accordingly, see
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  securityContext:
+    fsGroup: 1000
   # see https://github.com/kata-containers/packaging/tree/1.11.0-rc0/kata-deploy#run-a-sample-workload
   runtimeClassName: kata-qemu
   nodeSelector:


### PR DESCRIPTION
The 'pmem-csi-driver-test' container runs with 'pmem-csi' user which
does not allow to access to mounted /data volume. Change the permissions
on the /data mount by using pod security context.

FIXES #926