### PR TITLE
Operator metrics

### DIFF
--- a/deploy/bindata_generated.go
+++ b/deploy/bindata_generated.go
@@ -101,7 +101,7 @@ func deployKubernetes118DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 16675, mode: os.FileMode(420), modTime: time.Unix(1619451292, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/direct/pmem-csi.yaml", size: 16675, mode: os.FileMode(436), modTime: time.Unix(1620586606, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -121,7 +121,7 @@ func deployKubernetes118LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 16591, mode: os.FileMode(420), modTime: time.Unix(1619451294, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.18/lvm/pmem-csi.yaml", size: 16591, mode: os.FileMode(436), modTime: time.Unix(1620586609, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -141,7 +141,7 @@ func deployKubernetes119AlphaDirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/direct/pmem-csi.yaml", size: 16989, mode: os.FileMode(420), modTime: time.Unix(1619451307, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/direct/pmem-csi.yaml", size: 16989, mode: os.FileMode(436), modTime: time.Unix(1620586634, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func deployKubernetes119AlphaLvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/lvm/pmem-csi.yaml", size: 16905, mode: os.FileMode(420), modTime: time.Unix(1619451308, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19-alpha/lvm/pmem-csi.yaml", size: 16905, mode: os.FileMode(436), modTime: time.Unix(1620586637, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -181,7 +181,7 @@ func deployKubernetes119DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19/direct/pmem-csi.yaml", size: 16675, mode: os.FileMode(420), modTime: time.Unix(1619451297, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19/direct/pmem-csi.yaml", size: 16675, mode: os.FileMode(436), modTime: time.Unix(1620586616, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -201,7 +201,7 @@ func deployKubernetes119LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.19/lvm/pmem-csi.yaml", size: 16591, mode: os.FileMode(420), modTime: time.Unix(1619451298, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.19/lvm/pmem-csi.yaml", size: 16591, mode: os.FileMode(436), modTime: time.Unix(1620586618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -221,7 +221,7 @@ func deployKubernetes120DirectPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.20/direct/pmem-csi.yaml", size: 16675, mode: os.FileMode(420), modTime: time.Unix(1619451302, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.20/direct/pmem-csi.yaml", size: 16675, mode: os.FileMode(436), modTime: time.Unix(1620586625, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -241,7 +241,7 @@ func deployKubernetes120LvmPmemCsiYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kubernetes-1.20/lvm/pmem-csi.yaml", size: 16591, mode: os.FileMode(420), modTime: time.Unix(1619451303, 0)}
+	info := bindataFileInfo{name: "deploy/kubernetes-1.20/lvm/pmem-csi.yaml", size: 16591, mode: os.FileMode(436), modTime: time.Unix(1620586627, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -261,7 +261,7 @@ func deployKustomizeWebhookWebhookYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kustomize/webhook/webhook.yaml", size: 1196, mode: os.FileMode(420), modTime: time.Unix(1615969377, 0)}
+	info := bindataFileInfo{name: "deploy/kustomize/webhook/webhook.yaml", size: 1196, mode: os.FileMode(436), modTime: time.Unix(1620026661, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -281,7 +281,7 @@ func deployKustomizeSchedulerSchedulerServiceYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "deploy/kustomize/scheduler/scheduler-service.yaml", size: 277, mode: os.FileMode(420), modTime: time.Unix(1615969377, 0)}
+	info := bindataFileInfo{name: "deploy/kustomize/scheduler/scheduler-service.yaml", size: 277, mode: os.FileMode(436), modTime: time.Unix(1620026661, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/deploy/kustomize/operator/operator.yaml
+++ b/deploy/kustomize/operator/operator.yaml
@@ -111,6 +111,19 @@ roleRef:
   kind: ClusterRole
   name: pmem-csi-operator
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pmem-csi-operator-metrics
+  namespace: default
+spec:
+  selector:
+    name: pmem-csi-operator
+    app: pmem-csi-operator
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -121,6 +134,7 @@ spec:
   selector:
     matchLabels:
       name: pmem-csi-operator
+      app: pmem-csi-operator
   template:
     metadata:
       labels:
@@ -135,9 +149,13 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
           - /usr/local/bin/pmem-csi-operator
+          - -metrics-addr=:8080
           - -v=3
           securityContext:
             readOnlyRootFilesystem: true
+          ports:
+          - containerPort: 8080
+            name: metrics
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/operator/pmem-csi-operator.yaml
+++ b/deploy/operator/pmem-csi-operator.yaml
@@ -140,6 +140,19 @@ subjects:
   name: pmem-csi-operator
   namespace: pmem-csi
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pmem-csi-operator-metrics
+  namespace: pmem-csi
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    app: pmem-csi-operator
+    name: pmem-csi-operator
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -149,6 +162,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app: pmem-csi-operator
       name: pmem-csi-operator
   template:
     metadata:
@@ -160,6 +174,7 @@ spec:
       containers:
       - command:
         - /usr/local/bin/pmem-csi-operator
+        - -metrics-addr=:8080
         - -v=3
         env:
         - name: WATCH_NAMESPACE
@@ -177,6 +192,9 @@ spec:
         image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-csi-operator
+        ports:
+        - containerPort: 8080
+          name: metrics
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:

--- a/docs/install.md
+++ b/docs/install.md
@@ -1485,6 +1485,18 @@ deployment is in the `Failed` state, then one can look into the event(s) using
 > driver could run can be configured by using `nodeSelector` property of
 > [`DeploymentSpec`](#deployment-crd-api).
 
+#### Operator metrics data
+
+PMEM-CSI operator exposes below metrics data about active PmemCSIDeployment
+custom resources and it's sub-object in addition to the
+[metrics data provided by the controller-runtime](https://book-v1.book.kubebuilder.io/beyond_basics/controller_metrics.html):
+
+Name | Type | Explanation
+-----|------|------------
+`pmem_csi_deployment_reconcile` | counter | Counter that gets incremented on each time a PmemCSIDeployment CR gone through a reconcile loop, labeled with the deployment name and uid.
+`pmem_csi_deployment_sub_resource_created_at` | gauge | Timestamp at which a sub resource of the PmemCSIDeployment CR was created  by the operator. Labeled by resource details ("name, "namespace", "group", "version", "kind", "uid", "ownedBy").
+`pmem_csi_deployment_sub_resource_updated_at` | gauge | Timestamp at which a sub resource of the PmemCSIDeployment CR was updated by the operator. Labeled by resource details ("name, "namespace", "group", "version", "kind", "uid", "ownedBy").
+
 
 ## Filing issues and contributing
 

--- a/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
+++ b/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
@@ -13,6 +13,7 @@ import (
 
 	api "github.com/intel/pmem-csi/pkg/apis/pmemcsi/v1beta1"
 	"github.com/intel/pmem-csi/pkg/logger"
+	"github.com/intel/pmem-csi/pkg/pmem-csi-operator/metrics"
 	"github.com/intel/pmem-csi/pkg/types"
 	"github.com/intel/pmem-csi/pkg/version"
 
@@ -282,6 +283,9 @@ func (d *pmemCSIDeployment) redeploy(ctx context.Context, r *ReconcileDeployment
 			if err := r.client.Patch(ctx, copy, patch); err != nil {
 				return nil, fmt.Errorf("patch object: %v", err)
 			}
+			if err := metrics.SetSubResourceUpdateMetric(o); err != nil {
+				l.V(3).Error(err, "failed to set sub-resource metrics", "object", o)
+			}
 		}
 	} else {
 		// For unknown reason client.Create() clearing off the
@@ -292,6 +296,9 @@ func (d *pmemCSIDeployment) redeploy(ctx context.Context, r *ReconcileDeployment
 			return nil, fmt.Errorf("create object: %v", err)
 		}
 		o.GetObjectKind().SetGroupVersionKind(gvk)
+		if err := metrics.SetSubResourceCreateMetric(o); err != nil {
+			l.V(3).Error(err, "failed to set sub-resource metrics", "object", o)
+		}
 	}
 
 	// Final per-object changes, like emitting events or setting status.

--- a/pkg/pmem-csi-operator/controller/deployment/deployment_controller_test.go
+++ b/pkg/pmem-csi-operator/controller/deployment/deployment_controller_test.go
@@ -351,12 +351,7 @@ func TestDeploymentController(t *testing.T) {
 				dep.Spec.Image = testDriverImage
 			}
 
-			// If the CR was not updated, then objects should still be the same as they were initially.
-			rv := tc.resourceVersions
-			if wasUpdated {
-				rv = nil
-			}
-			_, err := validate.DriverDeployment(tc.ctx, tc.c, testK8sVersion, testNamespace, *dep, rv)
+			err := validate.DriverDeployment(tc.ctx, tc.c, testK8sVersion, testNamespace, *dep)
 			require.NoError(tc.t, err, "validate deployment")
 			validateEvents(tc, dep, expectedEvents)
 		}

--- a/pkg/pmem-csi-operator/main.go
+++ b/pkg/pmem-csi-operator/main.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	// import deployment to ensure that the deployment reconciler get initialized.
 	_ "github.com/intel/pmem-csi/pkg/pmem-csi-operator/controller/deployment"
@@ -39,7 +40,8 @@ var (
 	driverImage    = flag.String("image", "", "docker container image used for deploying the operator.")
 	leaderElection = flag.Bool("leader-election", false, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
-	logFormat = logger.NewFlag()
+	metricsAddr = flag.String("metrics-addr", metrics.DefaultBindAddress, "The address the metric endpoint binds to. Use \"0\" to disable metrics.")
+	logFormat   = logger.NewFlag()
 )
 
 func init() {
@@ -72,6 +74,7 @@ func Main() int {
 		LeaderElection:          *leaderElection,
 		LeaderElectionNamespace: namespace,
 		LeaderElectionID:        "pmem-csi-operator-lock",
+		MetricsBindAddress:      *metricsAddr,
 	})
 	if err != nil {
 		pmemcommon.ExitError("Failed to create controller manager: ", err)

--- a/pkg/pmem-csi-operator/metrics/metrics.go
+++ b/pkg/pmem-csi-operator/metrics/metrics.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package metrics
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	// PmemCSIDeploymentSubsystemKey represents the key used for
+	// PMEM-CSI deployment metrics sub-system.
+	PmemCSIDeploymentSubsystemKey = "pmem_csi_deployment"
+)
+
+var (
+	// Reconcile creates new prometheus metrics counter
+	// that gets incremented on each reconcile loop
+	// of a PmemCSIDeployment CR, with information: {"name", "uid"}.
+	Reconcile = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: PmemCSIDeploymentSubsystemKey,
+		Name:      "reconcile",
+		Help:      "Number of reconcile loops gone through by a PmemCSIDeployment CR.",
+	}, []string{"name", "uid"})
+
+	// SubResourceCreatedAt creates new prometheus metrics for
+	// a sub resource deployed for a PmemCSIDeployment,
+	// with information: {"name", "namespace", "group", "version", "kind", "uid", "ownedBy"}
+	SubResourceCreatedAt = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: PmemCSIDeploymentSubsystemKey,
+		Name:      "sub_resource_created_at",
+		Help:      "Timestamp at which a sub resource was created.",
+	}, []string{"name", "namespace", "group", "version", "kind", "uid", "ownedBy"})
+
+	// SubResourceUpdatedAt creates new prometheus metrics for
+	// a sub resource redeployed for a PmemCSIDeployment,
+	// with information: {"name", "namespace", "group", "version", "kind", "uid", "ownedBy"}
+	SubResourceUpdatedAt = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: PmemCSIDeploymentSubsystemKey,
+		Name:      "sub_resource_updated_at",
+		Help:      "Timestamp at which a sub resource was update.",
+	}, []string{"name", "namespace", "group", "version", "kind", "uid", "ownedBy"})
+)
+
+func RegisterMetrics() {
+	metrics.Registry.MustRegister(
+		Reconcile,
+		SubResourceCreatedAt,
+		SubResourceUpdatedAt,
+	)
+}
+
+func SetSubResourceCreateMetric(obj client.Object) error {
+	if obj == nil {
+		return nil
+	}
+	return setGauge(SubResourceCreatedAt, GetSubResourceLabels(obj))
+}
+
+func SetSubResourceUpdateMetric(obj client.Object) error {
+	if obj == nil {
+		return nil
+	}
+	return setGauge(SubResourceUpdatedAt, GetSubResourceLabels(obj))
+}
+
+func SetReconcileMetrics(name, uid string) error {
+	return setCounter(Reconcile, map[string]string{
+		"name": name,
+		"uid":  uid,
+	})
+}
+
+func GetSubResourceLabels(obj client.Object) map[string]string {
+	owners := []string{}
+	for _, ref := range obj.GetOwnerReferences() {
+		owners = append(owners, string(ref.UID))
+	}
+	return map[string]string{
+		"name":      obj.GetName(),
+		"namespace": obj.GetNamespace(),
+		"group":     obj.GetObjectKind().GroupVersionKind().Group,
+		"version":   obj.GetObjectKind().GroupVersionKind().Version,
+		"kind":      obj.GetObjectKind().GroupVersionKind().Kind,
+		"uid":       string(obj.GetUID()),
+		"ownedBy":   strings.Join(owners, ","),
+	}
+}
+
+func setGauge(gauge *prometheus.GaugeVec, labels map[string]string) error {
+	m, err := gauge.GetMetricWith(labels)
+	if err != nil {
+		return err
+	}
+	m.SetToCurrentTime()
+	return nil
+}
+
+func setCounter(counter *prometheus.CounterVec, labels map[string]string) error {
+	m, err := counter.GetMetricWith(labels)
+	if err != nil {
+		return err
+	}
+
+	m.Inc()
+	return nil
+}

--- a/test/e2e/deploy/cluster.go
+++ b/test/e2e/deploy/cluster.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 
 	. "github.com/onsi/gomega"
@@ -27,12 +28,14 @@ type Cluster struct {
 	nodeIPs []string
 	cs      kubernetes.Interface
 	dc      dynamic.Interface
+	cfg     *rest.Config
 }
 
-func NewCluster(cs kubernetes.Interface, dc dynamic.Interface) (*Cluster, error) {
+func NewCluster(cs kubernetes.Interface, dc dynamic.Interface, cfg *rest.Config) (*Cluster, error) {
 	cluster := &Cluster{
-		cs: cs,
-		dc: dc,
+		cs:  cs,
+		dc:  dc,
+		cfg: cfg,
 	}
 
 	hosts, err := e2essh.NodeSSHHosts(cs)

--- a/test/e2e/deploy/operator.go
+++ b/test/e2e/deploy/operator.go
@@ -12,12 +12,14 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/intel/pmem-csi/pkg/apis"
 	api "github.com/intel/pmem-csi/pkg/apis/pmemcsi/v1beta1"
+	cm "github.com/prometheus/client_model/go"
 
 	"github.com/onsi/gomega"
 )
@@ -170,4 +172,19 @@ func LogError(err error, format string, args ...interface{}) {
 	if err != nil {
 		framework.Logf(format, args...)
 	}
+}
+
+func GetOperatorMetricsURL(ctx context.Context, cluster *Cluster, d *Deployment) (string, error) {
+	return GetMetricsURL(ctx, cluster, d.Namespace, labels.Set{
+		"pmem-csi.intel.com/deployment": d.Label(),
+		"app":                           "pmem-csi-operator",
+	})
+}
+
+func GetOperatorMetrics(ctx context.Context, cluster *Cluster, d *Deployment) (map[string]*cm.MetricFamily, error) {
+	url, err := GetOperatorMetricsURL(ctx, cluster, d)
+	if err != nil {
+		return nil, err
+	}
+	return GetMetrics(ctx, cluster, url)
 }

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -292,12 +292,12 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 			cases := map[string]api.LogFormat{
 				"default": "",
 				"text":    api.LogFormatText,
-				"JSON":    api.LogFormatJSON,
+				"json":    api.LogFormatJSON,
 			}
 			for name, format := range cases {
 				format := format
 				It(name, func() {
-					deployment := getDeployment("test-deployment-driver-image")
+					deployment := getDeployment("test-logging-format-" + name)
 					deployment.Spec.Image = ""
 					deployment.Spec.PMEMPercentage = 50
 					deployment.Spec.LogFormat = format

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -894,7 +894,8 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 					obj := getter(&dep)
 					delete(obj)
 					ensureObjectRecovered(obj)
-					validateDriver(deployment, nil, "restore deleted registry secret")
+					err := validate.DriverDeployment(ctx, client, k8sver, d.Namespace, deployment)
+					Expect(err).ShouldNot(HaveOccurred(), "validate driver after object recover")
 				})
 			}
 		})
@@ -984,7 +985,9 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 						return err
 					}, "2m", "1s").ShouldNot(HaveOccurred(), "update: %s", name)
 
-					validateDriver(deployment, []runtime.Object{obj}, fmt.Sprintf("recovered %s", name))
+					Eventually(func() error {
+						return validate.DriverDeployment(ctx, client, k8sver, d.Namespace, deployment)
+					}, "2m", "1s").ShouldNot(HaveOccurred(), fmt.Sprintf("recovered %s", name))
 				})
 			}
 		})

--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -99,7 +99,7 @@ var _ = deploy.DescribeForSome("sanity", func(d *deploy.Deployment) bool {
 		cs := f.ClientSet
 
 		var err error
-		cluster, err = deploy.NewCluster(cs, f.DynamicClient)
+		cluster, err = deploy.NewCluster(cs, f.DynamicClient, f.ClientConfig())
 		framework.ExpectNoError(err, "query cluster")
 
 		config.Address, config.ControllerAddress, err = deploy.LookupCSIAddresses(cluster, d.Namespace)

--- a/test/e2e/versionskew/versionskew.go
+++ b/test/e2e/versionskew/versionskew.go
@@ -262,7 +262,7 @@ func (p *skewTestSuite) DefineTests(driver testsuites.TestDriver, pattern testpa
 	// of the skew won't matter.
 	It("controller [Slow]", func() {
 		withKataContainers := false
-		c, err := deploy.NewCluster(f.ClientSet, f.DynamicClient)
+		c, err := deploy.NewCluster(f.ClientSet, f.DynamicClient, f.ClientConfig())
 		framework.ExpectNoError(err, "new cluster")
 		// Get the current controller image.
 		//


### PR DESCRIPTION
Added support for operator metrics, by default at port 8080, which could be configured using `--metrics-addr` command-line argument.

Changed the validation logic in e2e tests to make use of these metrics to know when a deployment CR went through the reconciliation loop and, to detect if any unexpected object updates initiated by the operator.