### PR TITLE
deploy/operator: remove newly added app label from selector list

### DIFF
--- a/deploy/kustomize/operator/operator.yaml
+++ b/deploy/kustomize/operator/operator.yaml
@@ -119,7 +119,6 @@ metadata:
 spec:
   selector:
     name: pmem-csi-operator
-    app: pmem-csi-operator
   ports:
   - port: 8080
     targetPort: 8080
@@ -134,7 +133,6 @@ spec:
   selector:
     matchLabels:
       name: pmem-csi-operator
-      app: pmem-csi-operator
   template:
     metadata:
       labels:

--- a/deploy/operator/pmem-csi-operator.yaml
+++ b/deploy/operator/pmem-csi-operator.yaml
@@ -150,7 +150,6 @@ spec:
   - port: 8080
     targetPort: 8080
   selector:
-    app: pmem-csi-operator
     name: pmem-csi-operator
 ---
 apiVersion: apps/v1
@@ -162,7 +161,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: pmem-csi-operator
       name: pmem-csi-operator
   template:
     metadata:


### PR DESCRIPTION
Adding this label breaks operator upgrades using OLM, as the previous
(v0.9.x) versions do not have this label that results in mismatched
label selector.