### PR TITLE
test: nil pointer in metrics test

### DIFF
--- a/test/e2e/metrics/metrics.go
+++ b/test/e2e/metrics/metrics.go
@@ -78,6 +78,7 @@ var _ = deploy.Describe("direct-testing", "direct-testing-metrics", "", func(d *
 								pod.Namespace, pod.Name, port.ContainerPort)
 							resp, err := client.Get(url)
 							framework.ExpectNoError(err, "GET failed")
+							Expect(resp.Body).NotTo(BeNil(), "have response body")
 							data, err := ioutil.ReadAll(resp.Body)
 							framework.ExpectNoError(err, "read GET response")
 							name := pod.Name + "/" + container.Name


### PR DESCRIPTION
Apparently resp.Body can be nil even when there was no error code:

```
/mnt/workspace/pmem-csi_devel/test/e2e/metrics/metrics.go:50
Test Panicked
/go/src/runtime/panic.go:212
Panic: runtime error: invalid memory address or nil pointer dereference
Full stack:
github.com/intel/pmem-csi/test/e2e/metrics.glob..func1.2.1()
	/mnt/workspace/pmem-csi_devel/test/e2e/metrics/metrics.go:81
        +0x7f0
```

That's the line with `ioutil.ReadAll(resp.Body)`.

An assertion failure gets caught, a panic isn't, therefore Expect()
deals with this problem.

Fixes: #971 