### PR TITLE
Jenkinsfile: check for skipping 1.18 before spawning agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,10 @@ pipeline {
                     }
                 }
                 stage('1.18') {
-                    when { not { changeRequest() } }
+                    when {
+		        beforeAgent true
+		        not { changeRequest() }
+                    }
                     options {
                         timeout(time: 12, unit: "HOURS")
                     }


### PR DESCRIPTION
This causes creating 2 workers instead of 3 in PR CI jobs.