### PR TITLE
docs: fix indention of "Volume parameters"

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -544,7 +544,7 @@ pmem-csi-intel-com-controller-0   2/2     Running   0          3m15s
 pmem-csi-intel-com-node-fbmpg     2/2     Running   0          3m15s
 ```
 
-#### Volume parameters
+### Volume parameters
 
 A Kubernetes cluster administrators must define some volume parameters
 like the filesystem type in [storage


### PR DESCRIPTION
This was meant to be at the same level as "Install PMEM-CSI driver"
and "Creating volumes".