### PR TITLE
test, docs: drop remaining use of admissionregistration.k8s.io/v1beta1

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1234,7 +1234,7 @@ bases:
 patchesJson6902:
   - target:
       group: admissionregistration.k8s.io
-      version: v1beta1
+      version: v1
       kind: MutatingWebhookConfiguration
       name: pmem-csi-intel-com-hook
     path: webhook-patch.yaml

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -571,10 +571,10 @@ func RemoveObjects(c *Cluster, deployment *Deployment) error {
 			}
 		}
 
-		if list, err := c.cs.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.Background(), filter); !failure(err) {
+		if list, err := c.cs.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), filter); !failure(err) {
 			for _, object := range list.Items {
 				del(object.ObjectMeta, object, func() error {
-					return c.cs.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.Background(), object.Name, metav1.DeleteOptions{})
+					return c.cs.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.Background(), object.Name, metav1.DeleteOptions{})
 				})
 			}
 		}


### PR DESCRIPTION
This was missed in 3e896ef.

Fixes: https://github.com/intel/pmem-csi/issues/973