### PR TITLE
test: nil pointer in metrics test, II

### DIFF
--- a/test/e2e/metrics/metrics.go
+++ b/test/e2e/metrics/metrics.go
@@ -78,7 +78,13 @@ var _ = deploy.Describe("direct-testing", "direct-testing-metrics", "", func(d *
 								pod.Namespace, pod.Name, port.ContainerPort)
 							resp, err := client.Get(url)
 							framework.ExpectNoError(err, "GET failed")
-							Expect(resp.Body).NotTo(BeNil(), "have response body")
+							// When wrapped with InterceptGomegaFailures, err == nil doesn't
+							// cause the function to abort. We have to do that ourselves before
+							// using resp to avoid a panic.
+							// https://github.com/onsi/gomega/issues/198#issuecomment-856630787
+							if err != nil {
+								return
+							}
 							data, err := ioutil.ReadAll(resp.Body)
 							framework.ExpectNoError(err, "read GET response")
 							name := pod.Name + "/" + container.Name


### PR DESCRIPTION
Apparently resp (?!) can be nil even when there was no error code.

Panic: runtime error: invalid memory address or nil pointer dereference
Full stack:
github.com/intel/pmem-csi/test/e2e/metrics.glob..func1.2.1()
	/mnt/workspace/pmem-csi_PR-977/test/e2e/metrics/metrics.go:81 +0x7f0
github.com/onsi/gomega.InterceptGomegaFailures(0xc0052d4ab0, 0xc0014b2660, 0x0, 0xc002627800)
	/mnt/workspace/gopath/pkg/mod/github.com/onsi/gomega@v1.10.5/gomega_dsl.go:107
        +0xbb

metrics.go:81 now had:

     Expect(resp.Body).NotTo(BeNil(), "have response body")

Fixes: https://github.com/intel/pmem-csi/issues/971