### PR TITLE
docs: remove obsolete TODO

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1432,8 +1432,6 @@ pmem_csi_node_operations_seconds_count{method_name="/csi.v1.Controller/CreateVol
 
 ## PMEM-CSI Deployment CRD
 
-TODO update operator
-
 `PmemCSIDeployment` is a cluster-scoped Kubernetes resource in the
 `pmem-csi.intel.com` API group. It describes how a PMEM-CSI driver
 instance is to be created.


### PR DESCRIPTION
This shouldn't have been merged in the first place (was already
addressed, PRs shouldn't add new TODOs).

This commit is also in PR #979 