### PR TITLE
Fix Kata Containers support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,13 @@ COPY --from=build python3_100.0_all.deb /var/cache/python3_100.0_all.deb
 # xfsprogs, e2fsprogs - formating filesystems
 # lvm2 - volume management
 # ndctl - pulls in the necessary library, useful by itself
-# fio - only included in testing images
+# parted - for Kata Containers support
 RUN echo 'deb http://ftp.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/buster-backports.list
 RUN echo 'deb-src http://ftp.debian.org/debian buster-backports main' >> /etc/apt/sources.list.d/buster-backports.list
 RUN ${APT_GET} update && \
     mkdir -p /usr/local/share && \
     dpkg -i /var/cache/python3_100.0_all.deb && \
-    bash -c 'set -o pipefail; ${APT_GET} install -y --no-install-recommends file xfsprogs e2fsprogs lvm2 libndctl-dev/buster-backports ndctl/buster-backports \
+    bash -c 'set -o pipefail; ${APT_GET} install -y --no-install-recommends file xfsprogs e2fsprogs lvm2 libndctl-dev/buster-backports ndctl/buster-backports parted \
        | tee --append /usr/local/share/package-install.log' && \
     rm -rf /var/cache/*
 

--- a/deploy/common/pmem-kata-app.yaml
+++ b/deploy/common/pmem-kata-app.yaml
@@ -2,7 +2,7 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: my-csi-kata-app
-  labels:
+  annotations:
     io.katacontainers.config.hypervisor.memory_offset: "2147483648" # 2Gi, must be at least as large as the PMEM volume
 spec:
   # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.

--- a/docs/install.md
+++ b/docs/install.md
@@ -879,7 +879,7 @@ done globally by setting the `memory_offset` in the
 file](https://github.com/kata-containers/runtime/blob/ee985a608015d81772901c1d9999190495fc9a0a/cli/config/configuration-qemu.toml.in#L86-L91)
 or per-pod by setting the
 [`io.katacontainers.config.hypervisor.memory_offset`
-label](https://github.com/kata-containers/documentation/blob/master/how-to/how-to-set-sandbox-config-kata.md#hypervisor-options)
+annotation](https://github.com/kata-containers/documentation/blob/master/how-to/how-to-set-sandbox-config-kata.md#hypervisor-options)
 in the pod meta data. In both cases, the value has to be large enough
 for all PMEM volumes used by the pod, otherwise pod creation will fail
 with an error similar to this:
@@ -888,11 +888,23 @@ with an error similar to this:
 Error: container create failed: QMP command failed: not enough space, currently 0x8000000 in use of total space for memory devices 0x3c100000
 ```
 
+**Note**:
+* The offset is currently (= Kata Containers 2.1.0) limited to
+32 bit, which implies that volumes cannot be larger than 4GiB. An
+enhancement request for [Kata Containers is
+pending](https://github.com/kata-containers/kata-containers/issues/2006).
+* A newer version is also needed for a fix of [issue
+#2018](https://github.com/kata-containers/kata-containers/issues/2018).
+* kata-deploy, at least in Kata Containers 2.1.0, does [not enable the
+  `memory_offset` annotation](https://github.com/kata-containers/kata-containers/issues/2088), leading to
+  `failed to create containerd task: annotation io.katacontainers.config.hypervisor.memory_offset is not enabled`
+  errors.
+
 The examples for usage of Kata Containers [with
 ephemeral](/deploy/common/pmem-kata-app-ephemeral.yaml) and
 [persistent](/deploy/common/pmem-kata-app.yaml) volumes use the pod
 label. They assume that the `kata-qemu` runtime class [is
-installed](https://github.com/kata-containers/packaging/tree/1.11.0-rc0/kata-deploy#run-a-sample-workload).
+installed](https://github.com/kata-containers/kata-containers/tree/2.1.0/tools/packaging/kata-deploy#run-a-sample-workload).
 
 For the QEMU test cluster,
 [`setup-kata-containers.sh`](/test/setup-kata-containers.sh) can be

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -184,11 +184,16 @@ func (cs *nodeControllerServer) CreateVolume(ctx context.Context, req *csi.Creat
 		},
 	})
 
+	// Prepare the volume context. Including the name is useful for logging.
+	p.Name = &req.Name
+	volumeContext := p.ToContext()
+
 	resp = &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:           volumeID,
 			CapacityBytes:      size,
 			AccessibleTopology: topology,
+			VolumeContext:      volumeContext,
 		},
 	}
 

--- a/test/e2e/driver/driver.go
+++ b/test/e2e/driver/driver.go
@@ -17,12 +17,10 @@ limitations under the License.
 package driver
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
 	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -149,18 +147,6 @@ func (m *manifestDriver) GetDynamicProvisionStorageClass(config *storageframewor
 }
 
 func (m *manifestDriver) PrepareTest(f *framework.Framework) (*storageframework.PerTestConfig, func()) {
-	// If the driver depends on Kata Containers, first make sure
-	// that we have it on at least one node.
-	if strings.HasSuffix(m.driverInfo.Name, "-kata") {
-		nodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
-			LabelSelector: "katacontainers.io/kata-runtime=true",
-		})
-		framework.ExpectNoError(err, "list nodes")
-		if len(nodes.Items) == 0 {
-			skipper.Skipf("no nodes found with Kata Container runtime")
-		}
-	}
-
 	config := &storageframework.PerTestConfig{
 		Driver:    m,
 		Prefix:    "pmem",

--- a/test/e2e/storage/dax/dax.go
+++ b/test/e2e/storage/dax/dax.go
@@ -287,6 +287,15 @@ func CreatePod(
 	ns := f.Namespace.Name
 	podClient := f.PodClientNS(ns)
 	createdPod := podClient.Create(pod)
+	defer func() {
+		if r := recover(); r != nil {
+			// Delete pod before raising the panic again,
+			// because the caller will not do it when this
+			// function doesn't return normally.
+			DeletePod(f, createdPod)
+			panic(r)
+		}
+	}()
 	podErr := e2epod.WaitForPodRunningInNamespace(f.ClientSet, createdPod)
 	framework.ExpectNoError(podErr, "running pod")
 

--- a/test/e2e/storage/dax/dax.go
+++ b/test/e2e/storage/dax/dax.go
@@ -219,14 +219,14 @@ func getPod(
 		pod.Spec.NodeSelector = map[string]string{
 			"katacontainers.io/kata-runtime": "true",
 		}
-		if pod.Labels == nil {
-			pod.Labels = map[string]string{}
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
 		}
 
 		// The additional memory range must be large enough for all test volumes.
 		// https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-set-sandbox-config-kata.md#hypervisor-options
 		// Must be an uint32.
-		pod.Labels["io.katacontainers.config.hypervisor.memory_offset"] = "2147483648" // 2GiB
+		pod.Annotations["io.katacontainers.config.hypervisor.memory_offset"] = "2147483648" // 2GiB
 
 		// FSGroup not supported (?) by Kata Containers
 		// (https://github.com/intel/pmem-csi/issues/987#issuecomment-858350521),

--- a/test/e2e/storage/dax/dax.go
+++ b/test/e2e/storage/dax/dax.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dax
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -139,18 +140,33 @@ func testDaxInPod(
 	config *storageframework.PerTestConfig,
 	withKataContainers bool,
 ) {
+	expectDax := true
+	if withKataContainers {
+		nodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+			LabelSelector: "katacontainers.io/kata-runtime=true",
+		})
+		framework.ExpectNoError(err, "list nodes")
+		if len(nodes.Items) == 0 {
+			// This is a simplified version of the full test where we don't
+			// attempt to use Kata Containers.
+			framework.Logf("no nodes found with Kata Container runtime, skipping testing with it")
+			expectDax = false
+			withKataContainers = false
+		}
+	}
+
 	pod := CreatePod(f, "dax-volume-test", volumeMode, source, config, withKataContainers)
 	defer func() {
 		DeletePod(f, pod)
 	}()
-	checkWithNormalRuntime := testDax(f, pod, root, volumeMode, source, withKataContainers)
+	checkWithNormalRuntime := testDax(f, pod, root, volumeMode, source, withKataContainers, expectDax)
 	DeletePod(f, pod)
 	if checkWithNormalRuntime {
 		testDaxOutside(f, pod, root)
 	}
 }
 
-func CreatePod(
+func getPod(
 	f *framework.Framework,
 	name string,
 	volumeMode v1.PersistentVolumeMode,
@@ -282,6 +298,17 @@ func CreatePod(
 			RunAsGroup: &root,
 		}
 	}
+	return pod
+}
+
+func CreatePod(f *framework.Framework,
+	name string,
+	volumeMode v1.PersistentVolumeMode,
+	source *v1.VolumeSource,
+	config *storageframework.PerTestConfig,
+	withKataContainers bool,
+) *v1.Pod {
+	pod := getPod(f, name, volumeMode, source, config, withKataContainers)
 
 	By(fmt.Sprintf("Creating pod %s", pod.Name))
 	ns := f.Namespace.Name
@@ -309,6 +336,7 @@ func testDax(
 	volumeMode v1.PersistentVolumeMode,
 	source *v1.VolumeSource,
 	withKataContainers bool,
+	expectDax bool,
 ) bool {
 	ns := f.Namespace.Name
 	containerName := pod.Spec.Containers[0].Name
@@ -321,8 +349,13 @@ func testDax(
 	By("checking that missing DAX support is detected")
 	pmempod.RunInPod(f, root, []string{daxCheckBinary}, daxCheckBinary+" /tmp/no-dax; if [ $? -ne 1 ]; then echo should have reported missing DAX >&2; exit 1; fi", ns, pod.Name, containerName)
 
-	By("checking volume for DAX support")
-	pmempod.RunInPod(f, root, []string{daxCheckBinary}, "lsblk; mount | grep /mnt; "+daxCheckBinary+" /mnt/daxtest", ns, pod.Name, containerName)
+	if expectDax {
+		By("checking volume for DAX support")
+		pmempod.RunInPod(f, root, []string{daxCheckBinary}, "lsblk; mount | grep /mnt; "+daxCheckBinary+" /mnt/daxtest", ns, pod.Name, containerName)
+	} else {
+		By("checking volume for missing DAX support")
+		pmempod.RunInPod(f, root, []string{daxCheckBinary}, "lsblk; mount | grep /mnt; "+daxCheckBinary+" /mnt/daxtest; if [ $? -ne 1 ]; then echo should have reported missing DAX >&2; exit 1; fi", ns, pod.Name, containerName)
+	}
 
 	// Data written in a container running under Kata Containers
 	// should be visible also in a normal container, unless the

--- a/test/setup-kata-containers.sh
+++ b/test/setup-kata-containers.sh
@@ -25,6 +25,7 @@ while [ "$SECONDS" -lt "$TIMEOUT" ]; do
         ${KUBECTL} get nodes -l katacontainers.io/kata-runtime=true
         exit 0
     fi
+    sleep 1
 done
 
 echo "kata-deploy has not labelled nodes after $TIMEOUT seconds. Is the container runtime perhaps Docker? It is not supported."

--- a/test/setup-kata-containers.sh
+++ b/test/setup-kata-containers.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -o errexit
-set -o pipefail
 
 TEST_DIRECTORY=${TEST_DIRECTORY:-$(dirname $(readlink -f $0))}
 source ${TEST_CONFIG:-${TEST_DIRECTORY}/test-config.sh}
@@ -13,20 +12,9 @@ SSH="${CLUSTER_DIRECTORY}/ssh.0"
 KUBECTL="${SSH} kubectl" # Always use the kubectl installed in the cluster.
 VERSION="${TEST_KATA_CONTAINERS_VERSION:-2.1.0}"
 
-curl --location --fail --silent \
-     https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml |
-    ${KUBECTL} apply -f -
-
-# kata-deploy.yaml always installs the latest Kata Containers. We override that
-# here by locking the image to the specific version that we want.
-curl --location --fail --silent \
-     https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml |
-    sed -e "s;image: katadocker/kata-deploy.*;image: katadocker/kata-deploy:${VERSION};" |
-    ${KUBECTL} apply -f -
-
-curl --location --fail --silent \
-     https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml |
-    ${KUBECTL} apply -f -
+${KUBECTL} apply -f https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
+${KUBECTL} apply -f https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+${KUBECTL} apply -f https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
 
 echo "Waiting for kata-deploy to label nodes..."
 TIMEOUT=300

--- a/test/setup-kata-containers.sh
+++ b/test/setup-kata-containers.sh
@@ -11,21 +11,21 @@ REPO_DIRECTORY="${REPO_DIRECTORY:-$(dirname $(dirname $(readlink -f $0)))}"
 CLUSTER_DIRECTORY="${CLUSTER_DIRECTORY:-${REPO_DIRECTORY}/_work/${CLUSTER}}"
 SSH="${CLUSTER_DIRECTORY}/ssh.0"
 KUBECTL="${SSH} kubectl" # Always use the kubectl installed in the cluster.
-VERSION="${TEST_KATA_CONTAINERS_VERSION:-1.11.0}"
+VERSION="${TEST_KATA_CONTAINERS_VERSION:-2.1.0}"
 
 curl --location --fail --silent \
-     https://github.com/kata-containers/packaging/raw/${VERSION}/kata-deploy/kata-rbac/base/kata-rbac.yaml |
+     https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml |
     ${KUBECTL} apply -f -
 
 # kata-deploy.yaml always installs the latest Kata Containers. We override that
 # here by locking the image to the specific version that we want.
 curl --location --fail --silent \
-     https://github.com/kata-containers/packaging/raw/${VERSION}/kata-deploy/kata-deploy/base/kata-deploy.yaml |
+     https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml |
     sed -e "s;image: katadocker/kata-deploy.*;image: katadocker/kata-deploy:${VERSION};" |
     ${KUBECTL} apply -f -
 
 curl --location --fail --silent \
-     https://raw.githubusercontent.com/kata-containers/packaging/${VERSION}/kata-deploy/k8s-1.14/kata-qemu-runtimeClass.yaml |
+     https://github.com/kata-containers/kata-containers/raw/${VERSION}/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml |
     ${KUBECTL} apply -f -
 
 echo "Waiting for kata-deploy to label nodes..."


### PR DESCRIPTION
There were multiple issues, both in the driver and in the tests. Testing with LVM now at least brings up the Pod with working DAX volume, but then deleting the Pod hangs because of https://github.com/kata-containers/kata-containers/issues/2018

TODO:
- [x] set `enabled_annotations`

Fixes: https://github.com/intel/pmem-csi/issues/987
