### PR TITLE
OpenShift permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,7 +181,3 @@ RUN sed -i \
         /etc/lvm/lvm.conf
 
 ENV LD_LIBRARY_PATH=/usr/lib
-# By default container runs with non-root user
-# Choose root user explicitly only where needed, like - node driver
-RUN useradd --uid 1000 --user-group --shell /bin/bash pmem-csi
-USER 1000

--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,12 @@ KUSTOMIZE :=
 
 # For each supported Kubernetes version, we provide four different flavors.
 # The "testing" flavor of the generated files contains both
-# the loglevel changes and enables coverage data collection.
+# the loglevel changes but does not enable coverage data collection.
 KUSTOMIZE_KUBERNETES_OUTPUT = \
     deploy/kubernetes-X.XX/pmem-csi-direct.yaml=deploy/kustomize/kubernetes-base-direct \
     deploy/kubernetes-X.XX/pmem-csi-lvm.yaml=deploy/kustomize/kubernetes-base-lvm \
-    deploy/kubernetes-X.XX/pmem-csi-direct-testing.yaml=deploy/kustomize/kubernetes-base-direct-coverage \
-    deploy/kubernetes-X.XX/pmem-csi-lvm-testing.yaml=deploy/kustomize/kubernetes-base-lvm-coverage \
+    deploy/kubernetes-X.XX/pmem-csi-direct-testing.yaml=deploy/kustomize/kubernetes-base-direct-testing \
+    deploy/kubernetes-X.XX/pmem-csi-lvm-testing.yaml=deploy/kustomize/kubernetes-base-lvm-testing \
 
 # Kubernetes versions derived from kubernetes-base.
 #

--- a/deploy/common/pmem-app-ephemeral.yaml
+++ b/deploy/common/pmem-app-ephemeral.yaml
@@ -5,12 +5,6 @@ apiVersion: v1
 metadata:
   name: my-csi-app-inline-volume
 spec:
-  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
-  # This security context causes permissions of volume mounts
-  # to be adapted accordingly, see
-  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext:
-    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-app-generic-ephemeral.yaml
+++ b/deploy/common/pmem-app-generic-ephemeral.yaml
@@ -6,12 +6,6 @@ apiVersion: v1
 metadata:
   name: my-csi-app-inline-volume
 spec:
-  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
-  # This security context causes permissions of volume mounts
-  # to be adapted accordingly, see
-  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext:
-    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-app-late-binding.yaml
+++ b/deploy/common/pmem-app-late-binding.yaml
@@ -3,12 +3,6 @@ apiVersion: v1
 metadata:
   name: my-csi-app
 spec:
-  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
-  # This security context causes permissions of volume mounts
-  # to be adapted accordingly, see
-  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext:
-    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-app.yaml
+++ b/deploy/common/pmem-app.yaml
@@ -3,12 +3,6 @@ apiVersion: v1
 metadata:
   name: my-csi-app-1
 spec:
-  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
-  # This security context causes permissions of volume mounts
-  # to be adapted accordingly, see
-  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext:
-    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary
@@ -26,12 +20,6 @@ apiVersion: v1
 metadata:
   name: my-csi-app-2
 spec:
-  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
-  # This security context causes permissions of volume mounts
-  # to be adapted accordingly, see
-  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext:
-    fsGroup: 1000
   containers:
     - name: my-frontend
       image: intel/pmem-csi-driver-test:canary

--- a/deploy/common/pmem-kata-app-ephemeral.yaml
+++ b/deploy/common/pmem-kata-app-ephemeral.yaml
@@ -5,12 +5,6 @@ metadata:
   labels:
     io.katacontainers.config.hypervisor.memory_offset: "2147483648" # 2Gi, must be at least as large as the PMEM volume
 spec:
-  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
-  # This security context causes permissions of volume mounts
-  # to be adapted accordingly, see
-  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext:
-    fsGroup: 1000
   # see https://github.com/kata-containers/packaging/tree/1.11.0-rc0/kata-deploy#run-a-sample-workload
   runtimeClassName: kata-qemu
   nodeSelector:

--- a/deploy/common/pmem-kata-app.yaml
+++ b/deploy/common/pmem-kata-app.yaml
@@ -5,12 +5,6 @@ metadata:
   labels:
     io.katacontainers.config.hypervisor.memory_offset: "2147483648" # 2Gi, must be at least as large as the PMEM volume
 spec:
-  # The 'pmem-csi-driver-test' container runs apps as user/group 1000/1000.
-  # This security context causes permissions of volume mounts
-  # to be adapted accordingly, see
-  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  securityContext:
-    fsGroup: 1000
   # see https://github.com/kata-containers/packaging/tree/1.11.0-rc0/kata-deploy#run-a-sample-workload
   runtimeClassName: kata-qemu
   nodeSelector:

--- a/deploy/kubernetes-1.19/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/direct/pmem-csi.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.19/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/direct/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.19/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/lvm/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/lvm/pmem-csi.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.19/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-direct.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.19/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-direct.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.19/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-lvm.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.19/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-lvm.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/direct/pmem-csi.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/direct/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.20/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/lvm/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/lvm/pmem-csi.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.20/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-direct.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-direct.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -666,10 +656,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -718,7 +704,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.20/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-lvm.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.20/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-lvm.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/direct/pmem-csi.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/direct/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -675,10 +665,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -727,7 +713,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.21/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/lvm/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/lvm/pmem-csi.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -675,10 +665,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -727,7 +713,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -675,10 +665,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -727,7 +713,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.21/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-direct.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-direct.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: direct-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: direct-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
@@ -416,24 +416,7 @@ spec:
           name: webhook-cert
         - mountPath: /var/lib/pmem-csi-coverage
           name: coverage-dir
-      initContainers:
-      - command:
-        - chown
-        - -R
-        - pmem-csi:pmem-csi
-        - /var/lib/pmem-csi-coverage
-        image: intel/pmem-csi-driver-test:canary
-        imagePullPolicy: Always
-        name: coverage-init
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
@@ -386,7 +386,6 @@ spec:
         - -schedulerListen=:8000
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-controller-*.out
         env:
         - name: TERMINATION_LOG_PATH
           value: /dev/termination-log
@@ -396,7 +395,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -430,8 +429,6 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: webhook-cert
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       priorityClassName: system-cluster-critical
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
@@ -443,10 +440,6 @@ spec:
       - name: webhook-cert
         secret:
           secretName: pmem-csi-intel-com-controller-secret
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -491,7 +484,6 @@ spec:
         - -pmemPercentage=100
         - -metricsListen=:10010
         - -v=5
-        - -coverprofile=/var/lib/pmem-csi-coverage/pmem-csi-driver-node-*.out
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -502,7 +494,7 @@ spec:
           value: pmem-csi.intel.com
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 6
@@ -552,8 +544,6 @@ spec:
         - mountPath: /var/lib/pmem-csi.intel.com
           mountPropagation: Bidirectional
           name: pmem-state-dir
-        - mountPath: /var/lib/pmem-csi-coverage
-          name: coverage-dir
       - args:
         - -v=3
         - --kubelet-registration-path=/var/lib/kubelet/plugins/$(PMEM_CSI_DRIVER_NAME)/csi.sock
@@ -675,10 +665,6 @@ spec:
           path: /sys
           type: DirectoryOrCreate
         name: sys-dir
-      - hostPath:
-          path: /var/lib/pmem-csi-coverage
-          type: DirectoryOrCreate
-        name: coverage-dir
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -727,7 +713,7 @@ spec:
               fieldPath: spec.nodeName
         - name: TERMINATION_LOG_PATH
           value: /tmp/termination-log
-        image: intel/pmem-csi-driver-test:canary
+        image: intel/pmem-csi-driver:canary
         imagePullPolicy: IfNotPresent
         name: pmem-driver
         securityContext:

--- a/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-testing
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-lvm.yaml
@@ -253,6 +253,22 @@ kind: RoleBinding
 metadata:
   labels:
     pmem-csi.intel.com/deployment: lvm-production
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: pmem-csi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: pmem-csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    pmem-csi.intel.com/deployment: lvm-production
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: pmem-csi
 roleRef:

--- a/deploy/kubernetes-1.21/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-lvm.yaml
@@ -413,9 +413,6 @@ spec:
         - mountPath: /certs
           name: webhook-cert
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       tolerations:
       - effect: NoSchedule

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -147,10 +147,6 @@ spec:
         app.kubernetes.io/instance: pmem-csi.intel.com
         pmem-csi.intel.com/webhook: ignore
     spec:
-      securityContext:
-        runAsNonRoot: true
-        # UID 1000 is defined in Dockerfile
-        runAsUser: 1000
       serviceAccountName: pmem-csi-intel-com-webhooks
       # Allow this pod to run on all nodes and
       # prevent eviction (https://github.com/kubernetes-csi/csi-driver-host-path/issues/47#issuecomment-538469081).

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -4,6 +4,26 @@ metadata:
   name: pmem-csi-intel-com-controller
   namespace: default
 ---
+# This role binding corresponds to what the following command creates:
+# oc adm policy add-scc-to-user privileged -z pmem-csi-intel-com-controller
+#
+# One difference is that we don't use the name system:openshift:scc:privileged
+# for the object. That object is managed by oc and the admin, whereas this
+# one here is under control of PMEM-CSI (YAML or operator).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pmem-csi-intel-com-node-openshift-cfg
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: pmem-csi-intel-com-controller
+  namespace: default
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/kustomize/driver/pmem-csi.yaml
+++ b/deploy/kustomize/driver/pmem-csi.yaml
@@ -7,16 +7,12 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  labels:
-    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-cfg
   namespace: default
 rules:
@@ -32,8 +28,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-runner
 rules:
 - apiGroups:
@@ -79,8 +73,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role-cfg
   namespace: default
 roleRef:
@@ -95,8 +87,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    pmem-csi.intel.com/deployment: lvm-testing
   name: pmem-csi-intel-com-webhooks-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/kustomize/kubernetes-1.21-direct-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.21-direct-testing/kustomization.yaml
@@ -8,6 +8,6 @@ patchesJson6902:
 - target:
     group: apps
     version: v1
-    kind: StatefulSet
-    name: pmem-csi-intel-com-controller
+    kind: DaemonSet
+    name: pmem-csi-intel-com-node
   path: ../patches/external-provisioner-storage-capacity-patch.yaml

--- a/deploy/kustomize/kubernetes-1.21-lvm-testing/kustomization.yaml
+++ b/deploy/kustomize/kubernetes-1.21-lvm-testing/kustomization.yaml
@@ -8,6 +8,6 @@ patchesJson6902:
 - target:
     group: apps
     version: v1
-    kind: StatefulSet
-    name: pmem-csi-intel-com-controller
+    kind: DaemonSet
+    name: pmem-csi-intel-com-node
   path: ../patches/external-provisioner-storage-capacity-patch.yaml

--- a/deploy/kustomize/testing/controller-coverage-patch.yaml
+++ b/deploy/kustomize/testing/controller-coverage-patch.yaml
@@ -14,23 +14,3 @@
     hostPath:
       path: /var/lib/pmem-csi-coverage
       type: DirectoryOrCreate
-# driver in controller mode runs as non-root user
-# which cannot have enough permissions to access
-# coverage-dir(/var/lib/pmem-csi-coverage)
-# Change the ownership of this folder to "pmem-csi:pmem-csi"
-# so that driver could write coverage reports.
-- op: add
-  path: /spec/template/spec/initContainers
-  value:
-  - name: coverage-init
-    imagePullPolicy: Always
-    image: intel/pmem-csi-driver:canary
-    command: ["chown", "-R", "pmem-csi:pmem-csi", "/var/lib/pmem-csi-coverage"]
-    securityContext:
-      privileged: true
-      runAsUser: 0
-    volumeMounts:
-    - mountPath: /var/lib/pmem-csi-coverage
-      name: coverage-dir
-- op: remove
-  path: /spec/template/spec/securityContext/runAsNonRoot

--- a/docs/design.md
+++ b/docs/design.md
@@ -226,6 +226,16 @@ A production deployment can improve upon that by using some other key
 delivery mechanism, like for example
 [Vault](https://www.vaultproject.io/).
 
+The PMEM-CSI controller runs with the default security context. On
+upstream Kubernetes, this means that it runs as root. The expectation
+is that actual production deployments of PMEM-CSI will avoid that, for
+example with the help of [OpenShift's dynamid UID
+assignment](https://www.openshift.com/blog/a-guide-to-openshift-and-uids).
+
+The PMEM-CSI node driver must run as root because it has to access the
+node's `/dev` and `/sys` and needs to execute privileged operations
+like mounting.
+
 ## Volume Persistency
 
 In a typical CSI deployment, volumes are provided by a storage backend

--- a/pkg/apis/pmemcsi/v1beta1/deployment_types.go
+++ b/pkg/apis/pmemcsi/v1beta1/deployment_types.go
@@ -546,6 +546,12 @@ func (d *PmemCSIDeployment) ProvisionerServiceAccountName() string {
 	return d.GetHyphenedName() + "-controller"
 }
 
+// ProvisionerRoleBindingName returns the name of the node driver's
+// RoleBinding object name for OpenShift
+func (d *PmemCSIDeployment) NodeOpenShiftRoleBindingName() string {
+	return d.GetHyphenedName() + "-node-openshift-cfg"
+}
+
 // ProvisionerRoleName returns the name of the provisioner's
 // RBAC Role object name used by the deployment
 func (d *PmemCSIDeployment) ProvisionerRoleName() string {

--- a/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
+++ b/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
@@ -1042,8 +1042,6 @@ func (d *pmemCSIDeployment) getControllerProvisionerClusterRoleBinding(crb *rbac
 
 func (d *pmemCSIDeployment) getControllerStatefulSet(ss *appsv1.StatefulSet) {
 	replicas := int32(1)
-	true := true
-	pmemcsiUser := int64(1000)
 
 	// To make sure that the default values set by the API server
 	// are not unset by the operator we choose to update only specific
@@ -1083,11 +1081,6 @@ func (d *pmemCSIDeployment) getControllerStatefulSet(ss *appsv1.StatefulSet) {
 		})
 	ss.Spec.Template.ObjectMeta.Annotations = map[string]string{
 		"pmem-csi.intel.com/scrape": "containers",
-	}
-	ss.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-		// Controller pod must run as non-root user
-		RunAsNonRoot: &true,
-		RunAsUser:    &pmemcsiUser,
 	}
 	ss.Spec.Template.Spec.PriorityClassName = "system-cluster-critical"
 	ss.Spec.Template.Spec.ServiceAccountName = d.GetHyphenedName() + "-webhooks"

--- a/test/e2e/storage/dax/dax.go
+++ b/test/e2e/storage/dax/dax.go
@@ -165,21 +165,12 @@ func CreatePod(
 	)
 	privileged := volumeMode == v1.PersistentVolumeBlock
 	root := int64(0)
-	pmemUID := int64(1000) // Set explicitly in the PMEM-CSI Dockerfile.
-	pmemGID := int64(1000) // Set indirectly.
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: f.Namespace.Name,
 		},
 		Spec: v1.PodSpec{
-			// Use non-root security context to trigger filesystem
-			// ownership change of the PMEM volume.
-			SecurityContext: &v1.PodSecurityContext{
-				RunAsUser:  &pmemUID,
-				RunAsGroup: &pmemGID,
-				FSGroup:    &pmemGID,
-			},
 			Containers: []v1.Container{
 				{
 					Name:    containerName,


### PR DESCRIPTION
This consists of two changes:
- running the controller without a fixed UID to allow OpenShift to assign a UID dynamically (see commit for a detailed discussion)
- adding one additional role binding for the node driver

Fixes: https://github.com/intel/pmem-csi/issues/935