### PR TITLE
test/e2e: Fix operator deployment update tests.

### DIFF
--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -718,9 +718,10 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 		for _, testcase := range testcases.UpdateTests() {
 			testcase := testcase
 			Context(testcase.Name, func() {
-				testIt := func(restart bool) {
+				testIt := func(name string, restart bool) {
 					deployment := *testcase.Deployment.DeepCopyObject().(*api.PmemCSIDeployment)
 
+					deployment.Name = deployment.Name + "-" + name
 					// Use fake images to prevent pods from actually starting.
 					deployment.Spec.Image = dummyImage
 					deployment.Spec.NodeRegistrarImage = dummyImage
@@ -770,11 +771,11 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 				}
 
 				It("while running", func() {
-					testIt(false)
+					testIt("while-running", false)
 				})
 
 				It("while stopped", func() {
-					testIt(true)
+					testIt("while-stopped", true)
 				})
 			})
 		}


### PR DESCRIPTION
Using the same deployment name for both update 'while running' and
'while stopped' makes it hard depending on reconcile metric count. The
'while running' test could fail when it is run after a 'while stopped'
test as it reset the counter to zero.

FIXES #988