### PR TITLE
volume handling cleanup and fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.35.37 // indirect
-	github.com/container-storage-interface/spec v1.3.0
+	github.com/container-storage-interface/spec v1.5.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.5
@@ -24,6 +24,7 @@ require (
 	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40
 	google.golang.org/genproto v0.0.0-20210207032614-bba0dbe2a9ea // indirect
 	google.golang.org/grpc v1.35.0
+	google.golang.org/protobuf v1.26.0
 	gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,9 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/container-storage-interface/spec v1.2.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
-github.com/container-storage-interface/spec v1.3.0 h1:wMH4UIoWnK/TXYw8mbcIHgZmB6kHOeIsYsiaTJwa6bc=
 github.com/container-storage-interface/spec v1.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.5.0 h1:lvKxe3uLgqQeVQcrnL2CPQKISoKjTJxojEs9cBk+HXo=
+github.com/container-storage-interface/spec v1.5.0/go.mod h1:8K96oQNkJ7pFcC2R9Z1ynGGBB1I93kcS6PGg3SsOk8s=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=

--- a/pkg/logger/capacity.go
+++ b/pkg/logger/capacity.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2020 Intel Coporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logger
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// CapacityRef returns an object that pretty-prints the given number of bytes.
+func CapacityRef(size int64) *resource.Quantity {
+	return resource.NewQuantity(size, resource.BinarySI)
+}

--- a/pkg/ndctl/fake/namespace.go
+++ b/pkg/ndctl/fake/namespace.go
@@ -17,6 +17,7 @@ type Namespace struct {
 	DeviceName_      string
 	BlockDeviceName_ string
 	Size_            uint64
+	Overhead_        uint64
 	Mode_            ndctl.NamespaceMode
 	Type_            ndctl.NamespaceType
 	Enabled_         bool
@@ -47,6 +48,10 @@ func (ns *Namespace) BlockDeviceName() string {
 
 func (ns *Namespace) Size() uint64 {
 	return ns.Size_
+}
+
+func (ns *Namespace) RawSize() uint64 {
+	return ns.Size_ + ns.Overhead_
 }
 
 func (ns *Namespace) Mode() ndctl.NamespaceMode {

--- a/pkg/ndctl/namespace.go
+++ b/pkg/ndctl/namespace.go
@@ -85,8 +85,11 @@ type Namespace interface {
 	DeviceName() string
 	// BlockDeviceName returns the block device name of the namespace.
 	BlockDeviceName() string
-	// Size returns the size of the namespace.
+	// Size returns the size of the device provided by the namespace.
 	Size() uint64
+	// RawSize returns the amount of PMEM used by the namespace
+	// in the underlying region, which is more than Size().
+	RawSize() uint64
 	// Mode returns the namespace mode.
 	Mode() NamespaceMode
 	// Type returns the namespace type.
@@ -183,6 +186,15 @@ func (ns *namespace) Size() uint64 {
 	}
 
 	return uint64(size)
+}
+
+func (ns *namespace) RawSize() uint64 {
+	switch ns.Mode() {
+	case FsdaxMode:
+		return uint64(C.ndctl_namespace_get_size(ns))
+	default:
+		return ns.Size()
+	}
 }
 
 func (ns *namespace) Mode() NamespaceMode {

--- a/pkg/pmem-device-manager/pmd-fake.go
+++ b/pkg/pmem-device-manager/pmd-fake.go
@@ -65,17 +65,17 @@ func (dm *fakeDM) getCapacity() Capacity {
 	}
 }
 
-func (dm *fakeDM) CreateDevice(volumeId string, size uint64) error {
+func (dm *fakeDM) CreateDevice(volumeId string, size uint64) (uint64, error) {
 	dm.mutex.Lock()
 	defer dm.mutex.Unlock()
 
 	_, ok := dm.devices[volumeId]
 	if ok {
-		return pmemerr.DeviceExists
+		return 0, pmemerr.DeviceExists
 	}
 
 	if size > dm.getCapacity().MaxVolumeSize {
-		return pmemerr.NotEnoughSpace
+		return 0, pmemerr.NotEnoughSpace
 	}
 
 	dm.devices[volumeId] = &PmemDeviceInfo{
@@ -83,7 +83,7 @@ func (dm *fakeDM) CreateDevice(volumeId string, size uint64) error {
 		Size:     size,
 		Path:     FakeDevicePathPrefix + volumeId,
 	}
-	return nil
+	return size, nil
 }
 
 func (dm *fakeDM) DeleteDevice(volumeId string, flush bool) error {

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -75,9 +75,10 @@ type PmemDeviceManager interface {
 	// GetName returns current device manager's operation mode
 	GetMode() api.DeviceMode
 
-	// CreateDevice creates a new block device with give name, size and namespace mode
+	// CreateDevice creates a new block device with give name, size and namespace mode.
+	// It returns the actual volume size which will always be at least as large as requested.
 	// Possible errors: ErrNotEnoughSpace, ErrDeviceExists
-	CreateDevice(name string, size uint64) error
+	CreateDevice(name string, size uint64) (uint64, error)
 
 	// GetDevice returns the block device information for given name
 	// Possible errors: ErrDeviceNotFound

--- a/pkg/pmem-device-manager/pmd-manager_test.go
+++ b/pkg/pmem-device-manager/pmd-manager_test.go
@@ -88,8 +88,9 @@ func runTests(mode string) {
 	It("Should create a new device", func() {
 		name := "test-dev-new"
 		size := uint64(2) * 1024 * 1024 // 2Mb
-		err := dm.CreateDevice(name, size)
+		actual, err := dm.CreateDevice(name, size)
 		Expect(err).Should(BeNil(), "Failed to create new device")
+		Expect(actual).Should(BeNumerically(">=", size), "device at least as large as requested")
 
 		cleanupList[name] = true
 
@@ -103,8 +104,9 @@ func runTests(mode string) {
 	It("Should support recreating a device", func() {
 		name := "test-dev"
 		size := uint64(2) * 1024 * 1024 // 2Mb
-		err := dm.CreateDevice(name, size)
+		actual, err := dm.CreateDevice(name, size)
 		Expect(err).Should(BeNil(), "Failed to create new device")
+		Expect(actual).Should(BeNumerically(">=", size), "device at least as large as requested")
 
 		cleanupList[name] = true
 
@@ -118,8 +120,9 @@ func runTests(mode string) {
 		Expect(err).Should(BeNil(), "Failed to delete device")
 		cleanupList[name] = false
 
-		err = dm.CreateDevice(name, size)
+		actual, err = dm.CreateDevice(name, size)
 		Expect(err).Should(BeNil(), "Failed to recreate the same device")
+		Expect(actual).Should(BeNumerically(">=", size), "device at least as large as requested")
 		cleanupList[name] = true
 	})
 
@@ -146,8 +149,9 @@ func runTests(mode string) {
 		for i := 1; i <= max_devices; i++ {
 			name := fmt.Sprintf("list-dev-%d", i)
 			sizes[name] = uint64(rand.Intn(15)+1) * 1024 * 1024
-			err := dm.CreateDevice(name, sizes[name])
+			actual, err := dm.CreateDevice(name, sizes[name])
 			Expect(err).Should(BeNil(), "Failed to create new device")
+			Expect(actual).Should(BeNumerically(">=", sizes[name]), "device at least as large as requested")
 			cleanupList[name] = true
 		}
 		list, err = dm.ListDevices()
@@ -189,8 +193,9 @@ func runTests(mode string) {
 	It("Should delete devices", func() {
 		name := "delete-dev"
 		size := uint64(2) * 1024 * 1024 // 2Mb
-		err := dm.CreateDevice(name, size)
+		actual, err := dm.CreateDevice(name, size)
 		Expect(err).Should(BeNil(), "Failed to create new device")
+		Expect(actual).Should(BeNumerically(">=", size), "device at least as large as requested")
 		cleanupList[name] = true
 
 		dev, err := dm.GetDevice(name)

--- a/runtime-deps.csv
+++ b/runtime-deps.csv
@@ -1,6 +1,7 @@
 Go,https://golang.org/,11382
 client_golang,https://github.com/prometheus/client_golang,
 github.com/operator-framework/operator-lib
+golang-protobuf,https://github.com/golang/protobuf/types/known/wrapperspb,
 google uuid,https://github.com/google/uuid,
 grpc-go,https://github.com/grpc/grpc-go,
 kubernetes,https://github.com/kubernetes/kubernetes,12141

--- a/test/e2e/storage/sanity.go
+++ b/test/e2e/storage/sanity.go
@@ -511,6 +511,19 @@ fi
 			v.create(1024*1024*1024*1024*1024, nodeID, codes.ResourceExhausted)
 		})
 
+		It("NodeUnstageVolume for unknown volume", func() {
+			_, err := v.nc.NodeUnstageVolume(v.ctx, &csi.NodeUnstageVolumeRequest{
+				VolumeId: "no-such-volume",
+				StagingTargetPath: "/foo/bar",
+			})
+			Expect(err).ShouldNot(BeNil(), "NodeUnstageVolume should have failed")
+			s, ok := status.FromError(err)
+			if !ok {
+				framework.Failf("Expected a status error, got %T: %v", err, err)
+			}
+			Expect(s.Code()).Should(BeEquivalentTo(codes.NotFound), "Expected volume not found")
+		})
+
 		It("stress test", func() {
 			// The load here consists of n workers which
 			// create and test volumes in parallel until

--- a/test/test.make
+++ b/test/test.make
@@ -94,7 +94,7 @@ RUNTIME_DEPS += sed \
 	-e 's;\(github.com/go-openapi/swag\);go-openapi/swag,https://\1;' \
 	-e 's;\(github.com/gogo/protobuf\);gogo protobuf,https://\1;' \
 	-e 's;\(github.com/golang/groupcache\);golang-groupcache,https://\1;' \
-	-e 's;\(github.com/golang/protobuf\);golang-protobuf,https://\1;' \
+	-e 's;\(github.com/golang/protobuf\|google.golang.org/protobuf\);golang-protobuf,https://github.com/golang/protobuf;' \
 	-e 's;\(github.com/google/go-cmp\);go-cmp,https://\1;' \
 	-e 's;\(github.com/google/gofuzz\);Google gofuzz,https://\1;' \
 	-e 's;\(github.com/google/uuid\);google uuid,https://\1;' \


### PR DESCRIPTION
NodeUnstageVolume did not return the correct error code anymore when the volume didn't exist. This was found while working on a new test where volumes get deleted before running the normal cleanup code.

The actual goal was to have a test for space fragmentation and checking that the maximum volume size is handled correctly. While working on that, I ended up addressing various todos.
