### PR TITLE
pmem-csi-driver: alignment fixes for GetCapacity

### DIFF
--- a/pkg/math/math.go
+++ b/pkg/math/math.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 Intel Coporation.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package math contains some arithmetic helper functions.
+//
+// Origin of the GCD and LCM is the Google Playground,
+// with simplifications by Intel.
+package math
+
+// GCD returns the greatest common divisor, using the Euclidian algorithm.
+func GCD(a, b uint64) uint64 {
+	for b != 0 {
+		t := b
+		b = a % b
+		a = t
+	}
+	return a
+}
+
+// LCM returns the least common multiple.
+func LCM(a, b uint64) uint64 {
+	return a * b / GCD(a, b)
+}

--- a/pkg/ndctl/fake/region.go
+++ b/pkg/ndctl/fake/region.go
@@ -210,8 +210,8 @@ func (r *Region) AdaptAlign(align uint64) (uint64, error) {
 	return align, nil
 }
 
-func (r *Region) FsdaxAlignment() (uint64, error) {
-	return mib2, nil
+func (r *Region) FsdaxAlignment() uint64 {
+	return mib2
 }
 
 func (r *Region) namespaces(onlyActive bool) []ndctl.Namespace {

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -114,8 +114,7 @@ func (lvm *pmemLvm) GetCapacity() (capacity Capacity, err error) {
 
 	for _, vg := range vgs {
 		if vg.free > capacity.MaxVolumeSize {
-			// TODO: alignment?
-			capacity.MaxVolumeSize = vg.free
+			capacity.MaxVolumeSize = vg.free / lvmAlign * lvmAlign
 		}
 		capacity.Available += vg.free
 		capacity.Managed += vg.size


### PR DESCRIPTION
We must round down to the required alignment to ensure that volumes
that use a size smaller than the maximum volume size then can be
rounded up.

Fixes: https://github.com/intel/pmem-csi/issues/1002