### PR TITLE
test: Fedora 34 + WeaveNet

### DIFF
--- a/test/setup-kubernetes.sh
+++ b/test/setup-kubernetes.sh
@@ -49,27 +49,6 @@ esac
 
 k8sversion=$(kubeadm version -o short)
 distro=`egrep "^ID=" /etc/os-release |awk -F= '{print $2}'`
-case $distro in
-    clear-linux-os)
-	# From https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network
-	# However, the commit currently listed there for 1.16 is broken. Current master fixes some issues
-	# and works.
-	podnetworkingurl=https://raw.githubusercontent.com/coreos/flannel/v0.12.0/Documentation/kube-flannel.yml
-	# Needed for flannel (https://clearlinux.org/latest/tutorials/kubernetes.html).
-	kubeadm_config_cluster="$kubeadm_config_cluster
-networking:
-  podSubnet: \"10.244.0.0/16\""
-	;;
-    fedora)
-	# Use Calico on Fedora as it is the only CNI plugin that is tested by kubeadm.
-	# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network
-	podnetworkingurl=https://docs.projectcalico.org/manifests/calico.yaml
-	;;
-    *)
-	echo "ERROR: unsupported distro=$distro"
-	exit 1
-	;;
-esac
 
 list_gates () (
     IFS=","
@@ -295,7 +274,7 @@ kubectl get pods --all-namespaces
 
 ${TEST_CONFIGURE_POST_MASTER}
 
-kubectl apply -f $podnetworkingurl
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
 
 # Install addon storage CRDs, needed if certain feature gates are enabled.
 # Only applicable to Kubernetes 1.13 and older. 1.14 will have them as builtin APIs.

--- a/test/start-kubernetes.sh
+++ b/test/start-kubernetes.sh
@@ -65,7 +65,7 @@ case ${TEST_DISTRO} in
     fedora)
         CLOUD_USER=${CLOUD_USER:-fedora}
         EFI=${EFI:-false}
-        TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-33}
+        TEST_DISTRO_VERSION=${TEST_DISTRO_VERSION:-34}
         FEDORA_CLOUDIMG_REL=${FEDORA_CLOUDIMG_REL:-1.2}
         IMAGE_URL=${IMAGE_URL:-https://download.fedoraproject.org/pub/fedora/linux/releases/${TEST_DISTRO_VERSION}/Cloud/x86_64/images}
         CLOUD_IMAGE=${CLOUD_IMAGE:-Fedora-Cloud-Base-${TEST_DISTRO_VERSION}-${FEDORA_CLOUDIMG_REL}.x86_64.raw.xz}
@@ -365,7 +365,7 @@ function init_kubernetes_cluster() (
     pids=""
     IPS=$(print_ips)
     # in Fedora-3[123] case, add a flag to kernel cmdline and reboot to disable cgroups v2
-    if [[ "$TEST_DISTRO" = "fedora" && "$TEST_DISTRO_VERSION" =~ 3[1-3] ]]; then
+    if [[ "$TEST_DISTRO" = "fedora" && "$TEST_DISTRO_VERSION" =~ 3[1-4] ]]; then
         SYSTEMD_UNIFIED_CGROUP_HIERARCHY=systemd.unified_cgroup_hierarchy
         for ip in ${IPS}; do
             GRUB_BFS=$(ssh $SSH_ARGS ${CLOUD_USER}@${ip} "grep ^GRUB_ENABLE_BLSCFG /etc/default/grub | sed -e \"s;\(GRUB_ENABLE_BLSCFG=\)\(.*\);\2;g\"")


### PR DESCRIPTION
The Fedora 33 kernel runs into panics during the raw conversion
test. We need to replace 33 with 34 anyway.

Testing showed that Calico had problems with the newer Fedora while
WeaveNet worked, so that is used again.

Fixes: https://github.com/intel/pmem-csi/issues/1008