### PR TITLE
pmem-csi-driver: structured, contextual logging

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -722,48 +722,15 @@ pmem-csi    pmem-csi-intel-com-node-jkbgz   3/3     Running   0          75s   1
 pmem-csi    pmem-csi-intel-com-node-th56d   3/3     Running   0          75s   192.168.220.67    pmem-csi-pmem-govm-worker2   <none>           <none>
 
 $ kubectl logs -n pmem-csi pmem-csi-intel-com-node-jkbgz pmem-driver
-I0526 14:40:15.350646       1 main.go:69] Version: v0.9.0-88-g602e0f88c
-I0526 14:40:15.351472       1 pmd-lvm.go:326] Create fsdax-namespaces in region0, allowed 50 %, real align 1073741824:
-total       :      68719476736
-avail       :      68719476736
-can use     :      34359738368
-I0526 14:40:15.351968       1 pmd-lvm.go:341] Calculated canUse:34359738368, available by Region info:68719476736
-I0526 14:40:15.352034       1 pmd-lvm.go:358] Create 34359738368-bytes fsdax-namespace
-I0526 14:40:15.355296       1 region.go:244] setting namespace sector size: 0
-I0526 14:40:15.357631       1 region.go:254] setting pfn
-I0526 14:40:15.793975       1 region.go:265] enabling namespace
-I0526 14:40:15.794737       1 exec.go:32] Executing: /sbin/pvs --noheadings -o vg_name /dev/pmem0
-I0526 14:40:15.806291       1 exec.go:69] /sbin/pvs: stderr:   Failed to find physical volume "/dev/pmem0".
-I0526 14:40:15.814110       1 exec.go:50] /sbin/pvs terminated, with 0 bytes of stdout, 47 of combined output and error exit status 5
-I0526 14:40:15.814277       1 exec.go:32] Executing: /sbin/vgdisplay ndbus0region0fsdax
-I0526 14:40:15.821343       1 exec.go:69] /sbin/vgdisplay: stderr:   Volume group "ndbus0region0fsdax" not found
-I0526 14:40:15.821477       1 exec.go:69] /sbin/vgdisplay: stderr:   Cannot process volume group ndbus0region0fsdax
-I0526 14:40:15.831688       1 exec.go:50] /sbin/vgdisplay terminated, with 0 bytes of stdout, 95 of combined output and error exit status 5
-I0526 14:40:15.831841       1 pmd-lvm.go:418] No volume group with name ndbus0region0fsdax, mark for creation
-I0526 14:40:15.831998       1 exec.go:32] Executing: /sbin/vgcreate --force ndbus0region0fsdax /dev/pmem0
-I0526 14:40:15.851768       1 exec.go:69] /sbin/vgcreate: stdout:   Physical volume "/dev/pmem0" successfully created.
-I0526 14:40:15.852864       1 exec.go:69] /sbin/vgcreate: stderr:   WARNING: This metadata update is NOT backed up.
-I0526 14:40:15.852905       1 exec.go:69] /sbin/vgcreate: stdout:   Volume group "ndbus0region0fsdax" successfully created
-I0526 14:40:15.861623       1 exec.go:50] /sbin/vgcreate terminated, with 110 bytes of stdout, 160 of combined output and error <nil>
-I0526 14:40:15.861746       1 exec.go:32] Executing: /sbin/vgs ndbus0region0fsdax
-I0526 14:40:15.870096       1 exec.go:69] /sbin/vgs: stdout:   VG                 #PV #LV #SN Attr   VSize   VFree  
-I0526 14:40:15.870237       1 exec.go:69] /sbin/vgs: stdout:   ndbus0region0fsdax   1   0   0 wz--n- <31.00g <31.00g
-I0526 14:40:15.880273       1 exec.go:50] /sbin/vgs terminated, with 112 bytes of stdout, 112 of combined output and error <nil>
-I0526 14:40:15.880373       1 exec.go:32] Executing: /sbin/lvs --noheadings --nosuffix -o lv_name,lv_path,lv_size --units B ndbus0region0fsdax
-I0526 14:40:15.899066       1 exec.go:50] /sbin/lvs terminated, with 0 bytes of stdout, 0 of combined output and error <nil>
-I0526 14:40:15.899553       1 mount_linux.go:163] Detected OS without systemd
-I0526 14:40:15.900187       1 exec.go:32] Executing: /sbin/vgs --noheadings --nosuffix -o vg_name,vg_size,vg_free --units B ndbus0region0fsdax
-I0526 14:40:15.900189       1 server.go:52] Listening for connections on address: /csi/csi.sock
-I0526 14:40:15.912667       1 exec.go:69] /sbin/vgs: stdout:   ndbus0region0fsdax 33281802240 33281802240
-I0526 14:40:15.925819       1 exec.go:50] /sbin/vgs terminated, with 45 bytes of stdout, 45 of combined output and error <nil>
-I0526 14:40:15.926627       1 exec.go:32] Executing: /sbin/vgs --noheadings --nosuffix -o vg_name,vg_size,vg_free --units B ndbus0region0fsdax
-I0526 14:40:15.941874       1 exec.go:69] /sbin/vgs: stdout:   ndbus0region0fsdax 33281802240 33281802240
-I0526 14:40:15.954167       1 exec.go:50] /sbin/vgs terminated, with 45 bytes of stdout, 45 of combined output and error <nil>
-I0526 14:40:15.954661       1 pmem-csi-driver.go:304] PMEM-CSI ready. Capacity: 31740Mi maximum volume size, 31740Mi available, 31740Mi managed, 64Gi total
-I0526 14:40:15.955139       1 pmem-csi-driver.go:336] Prometheus endpoint started at http://[::]:10010/metrics
+I0623 07:15:18.710690       1 main.go:73] "PMEM-CSI started." version="v0.9.0-188-gd451ec6f3-dirty"
+I0623 07:15:18.711645       1 pmd-lvm.go:328] "LVM-New/setupNS: Checking region for fsdax namespaces" region="region0" percentage=50 size="64Gi" available="64Gi" max-available-extent="64Gi" may-use="32Gi"
+I0623 07:15:18.712251       1 pmd-lvm.go:361] "LVM-New/setupNS: Create fsdax namespace" size="32Gi"
+I0623 07:15:19.041186       1 region.go:282] "LVM-New/setupNS/CreateNamespace: Namespace created" region="region0" namespace="namespace0.1" usable-size="32254Mi" raw-size="32Gi" uuid="c3e6fe52-d3f2-11eb-b33e-c2b1549139a7"
+I0623 07:15:19.079791       1 pmd-lvm.go:422] "LVM-New/setupVG/setupVGForNamespace: Creating new volume group" vg="ndbus0region0fsdax"
+I0623 07:15:19.130041       1 mount_linux.go:163] Detected OS without systemd
+I0623 07:15:19.130661       1 server.go:54] "GRPC Server: Listening for connections" endpoint="unix:///csi/csi.sock"
+I0623 07:15:19.180760       1 pmem-csi-driver.go:305] "PMEM-CSI ready." capacity="32252Mi maximum volume size, 32252Mi available, 32252Mi managed, 64Gi total"
 ```
-
-Depending on the log level, only the `PMEM-CSI ready` line might be printed.
 
 In a production environment, the [metrics support](#metrics-support)
 could be used to monitor available PMEM per node.
@@ -798,21 +765,21 @@ conversion.
 
 The output of a successful conversion will look like this:
 ```
-I0407 16:24:43.453802       1 main.go:69] Version: v0.9.0-29-g043b4e9c0-dirty
-I0407 16:24:43.456707       1 convert.go:78] "raw-namespace-conversion: checking for namespaces"
-I0407 16:24:43.457705       1 convert.go:80] "raw-namespace-conversion: checking" bus="{\"dev\":\"ndbus0\",\"dimms\":[{}],\"provider\":\"ACPI.NFIT\",\"regions\":[{}]}"
-I0407 16:24:43.458144       1 convert.go:82] "raw-namespace-conversion: checking" region="{\"available_size\":0,\"dev\":\"region0\",\"mappings\":[{}],\"max_available_extent\":0,\"namespaces\":[{}],\"size\":68719476736,\"type\":\"pmem\"}"
-I0407 16:24:43.458264       1 convert.go:89] "raw-namespace-conversion: checking" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":true,\"id\":0,\"mode\":\"raw\",\"name\":\"\",\"size\":68719476736,\"uuid\":\"40b5697c-9453-457d-b4b3-789718ac54ab\"}"
-I0407 16:24:43.458337       1 convert.go:98] "raw-namespace-conversion: converting raw namespace" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":true,\"id\":0,\"mode\":\"raw\",\"name\":\"\",\"size\":68719476736,\"uuid\":\"40b5697c-9453-457d-b4b3-789718ac54ab\"}"
-I0407 16:24:44.077114       1 convert.go:126] "raw-namespace-conversion: setting up volume group" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":false,\"id\":0,\"mode\":\"fsdax\",\"name\":\"\",\"size\":18446744073709551615,\"uuid\":\"00000000-0000-0000-0000-000000000000\"}" VG="ndbus0region0fsdax"
-I0407 16:24:44.111153       1 pmd-lvm.go:408] /dev/pmem0: already part of volume group ndbus0region0fsdax
-I0407 16:24:44.111352       1 pmd-lvm.go:412] no unused namespace found to add to this group: ndbus0region0fsdax
-I0407 16:24:44.111541       1 convert.go:132] "raw-namespace-conversion: converted to fsdax namespace" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":false,\"id\":0,\"mode\":\"fsdax\",\"name\":\"\",\"size\":18446744073709551615,\"uuid\":\"00000000-0000-0000-0000-000000000000\"}" VG="ndbus0region0fsdax"
-I0407 16:24:44.111573       1 convert.go:74] "raw-namespace-conversion: successful" converted=1
-I0407 16:24:44.127330       1 convert.go:171] "check-pmem: volume group will be used by PMEM-CSI in LVM mode" VG="ndbus0region0fsdax"
-I0407 16:24:44.150347       1 convert.go:200] "relabel: change node labels" node="pmem-csi-pmem-govm-master" patch="{\"metadata\":{\"labels\":{\"pmem-csi.intel.com/convert-raw-namespaces\": null, \"feature.node.kubernetes.io/memory-nv.dax\": \"true\"}}}"
-I0407 16:24:44.150370       1 pmem-csi-driver.go:325] raw namespace conversion is done, waiting for termination signal
-I0407 16:24:45.614284       1 pmem-csi-driver.go:343] Caught signal terminated, terminating.
+I0623 07:32:52.773207       1 main.go:73] "PMEM-CSI started." version="v0.9.0-188-gd451ec6f3-dirty"
+I0623 07:32:52.774386       1 convert.go:79] "ForceConvertRawNamespaces/convert: checking for namespaces"
+I0623 07:32:52.774871       1 convert.go:81] "ForceConvertRawNamespaces/convert: checking" bus="{\"dev\":\"ndbus0\",\"dimms\":[{}],\"provider\":\"ACPI.NFIT\",\"regions\":[{}]}"
+I0623 07:32:52.775316       1 convert.go:83] "ForceConvertRawNamespaces/convert: checking" region="{\"available_size\":0,\"dev\":\"region0\",\"mappings\":[{}],\"max_available_extent\":0,\"namespaces\":[{}],\"size\":68719476736,\"type\":\"pmem\"}"
+I0623 07:32:52.775444       1 convert.go:90] "ForceConvertRawNamespaces/convert: checking" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":true,\"id\":0,\"mode\":\"raw\",\"name\":\"\",\"size\":68719476736,\"uuid\":\"1711a2a0-358d-4b14-a43c-8efa1a9f7154\"}"
+I0623 07:32:52.775550       1 convert.go:99] "ForceConvertRawNamespaces/convert: converting raw namespace" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":true,\"id\":0,\"mode\":\"raw\",\"name\":\"\",\"size\":68719476736,\"uuid\":\"1711a2a0-358d-4b14-a43c-8efa1a9f7154\"}"
+I0623 07:32:53.397897       1 convert.go:127] "ForceConvertRawNamespaces/convert: setting up volume group" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":false,\"id\":0,\"mode\":\"fsdax\",\"name\":\"\",\"size\":18446744073709551615,\"uuid\":\"00000000-0000-0000-0000-000000000000\"}" vg="ndbus0region0fsdax"
+I0623 07:32:53.434094       1 pmd-lvm.go:422] "ForceConvertRawNamespaces/convert/setupVGForNamespace: Creating new volume group" vg="ndbus0region0fsdax"
+I0623 07:32:53.457108       1 convert.go:133] "ForceConvertRawNamespaces/convert: converted to fsdax namespace" namespace="{\"blockdev\":\"pmem0\",\"dev\":\"namespace0.0\",\"enabled\":false,\"id\":0,\"mode\":\"fsdax\",\"name\":\"\",\"size\":18446744073709551615,\"uuid\":\"00000000-0000-0000-0000-000000000000\"}" vg="ndbus0region0fsdax"
+I0623 07:32:53.457148       1 convert.go:75] "ForceConvertRawNamespaces/convert: successful" converted=1
+I0623 07:32:53.479512       1 convert.go:172] "ForceConvertRawNamespaces/havePMEM: Volume group will be used by PMEM-CSI in LVM mode" vg="ndbus0region0fsdax"
+I0623 07:32:53.523412       1 convert.go:200] "ForceConvertRawNamespaces/relabel: Change node labels" node="pmem-csi-pmem-govm-master" patch="{\"metadata\":{\"labels\":{\"pmem-csi.intel.com/convert-raw-namespaces\": null, \"feature.node.kubernetes.io/memory-nv.dax\": \"true\"}}}"
+I0623 07:32:53.523605       1 pmem-csi-driver.go:326] "Raw namespace conversion is done, waiting for termination signal."
+I0623 07:33:03.954098       1 pmem-csi-driver.go:344] "Caught signal, terminating." signal="terminated"
+I0623 07:33:05.016426       1 main.go:93] "PMEM-CSI stopped."
 ```
 
 It terminates once Kubernetes notices that the pod is no longer

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -7,16 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package exec
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/klog/v2"
+	pmemlog "github.com/intel/pmem-csi/pkg/logger"
+	"github.com/intel/pmem-csi/pkg/logger/testinglogger"
 )
-
-func init() {
-	klog.InitFlags(nil)
-}
 
 var testcases = map[string]struct {
 	cmd []string
@@ -106,7 +104,8 @@ hello world
 func TestRun(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			output, err := RunCommand(tc.cmd[0], tc.cmd[1:]...)
+			ctx := pmemlog.Set(context.Background(), testinglogger.New(t))
+			output, err := RunCommand(ctx, tc.cmd[0], tc.cmd[1:]...)
 			assert.Equal(t, tc.expectedOutput, output, "output")
 			errStr := ""
 			if err != nil {

--- a/pkg/grpc-server/server.go
+++ b/pkg/grpc-server/server.go
@@ -7,14 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package pmemcsidriver
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"sync"
 
+	pmemlog "github.com/intel/pmem-csi/pkg/logger"
 	pmemgrpc "github.com/intel/pmem-csi/pkg/pmem-grpc"
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	"google.golang.org/grpc"
-	"k8s.io/klog/v2"
 )
 
 type Service interface {
@@ -33,7 +34,7 @@ func NewNonBlockingGRPCServer() *NonBlockingGRPCServer {
 	return &NonBlockingGRPCServer{}
 }
 
-func (s *NonBlockingGRPCServer) Start(endpoint, errorPrefix string, tlsConfig *tls.Config, csiMetricsManager metrics.CSIMetricsManager, services ...Service) error {
+func (s *NonBlockingGRPCServer) Start(ctx context.Context, endpoint, errorPrefix string, tlsConfig *tls.Config, csiMetricsManager metrics.CSIMetricsManager, services ...Service) error {
 	if endpoint == "" {
 		return fmt.Errorf("endpoint cannot be empty")
 	}
@@ -46,14 +47,15 @@ func (s *NonBlockingGRPCServer) Start(endpoint, errorPrefix string, tlsConfig *t
 	}
 	s.servers = append(s.servers, rpcServer)
 
+	logger := pmemlog.Get(ctx).WithName("GRPC-server").WithValues("endpoint", endpoint)
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		klog.V(3).Infof("Listening for connections on address: %v", l.Addr())
+		logger.V(3).Info("Listening for connections")
 		if err := rpcServer.Serve(l); err != nil {
-			klog.Errorf("Server Listen failure: %s", err.Error())
+			logger.Error(err, "Listen failure")
 		}
-		klog.V(3).Infof("Server on '%s' stopped", endpoint)
+		logger.V(3).Info("Stopped")
 	}()
 
 	return nil

--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 )
 
 // NewClient connects to an API server either through KUBECONFIG (if set) or
@@ -53,8 +52,6 @@ func GetKubernetesVersion(cfg *rest.Config) (*version.Version, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	klog.Infof("Kubernetes version read from server: %v.%v", ver.Major, ver.Minor)
 
 	// Suppress all non digits, version might contain special charcters like, <number>+
 	reg, _ := regexp.Compile("[^0-9]+")

--- a/pkg/logger/kubernetes.go
+++ b/pkg/logger/kubernetes.go
@@ -12,6 +12,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var (
+	KObj = klog.KObj
+	KRef = klog.KRef
+)
+
 // ObjectRef references a kubernetes object
 type ObjectRefWithType struct {
 	klog.ObjectRef

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -38,3 +38,10 @@ func Get(ctx context.Context) logr.Logger {
 	}
 	return klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog))
 }
+
+// WithName updates the logger in the context and returns the new logger and context.
+func WithName(ctx context.Context, name string) (context.Context, logr.Logger) {
+	logger := Get(ctx).WithName(name)
+	ctx = Set(ctx, logger)
+	return ctx, logger
+}

--- a/pkg/ndctl/fake/region.go
+++ b/pkg/ndctl/fake/region.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package fake
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -110,7 +111,7 @@ func (r *Region) GetAlign() uint64 {
 	return r.RegionAlign_
 }
 
-func (r *Region) CreateNamespace(opts ndctl.CreateNamespaceOpts) (ndctl.Namespace, error) {
+func (r *Region) CreateNamespace(ctx context.Context, opts ndctl.CreateNamespaceOpts) (ndctl.Namespace, error) {
 	var err error
 	/* Set defaults */
 	if opts.Type == "" {
@@ -204,10 +205,6 @@ func (r *Region) DestroyNamespace(ns ndctl.Namespace, force bool) error {
 	}
 
 	return fmt.Errorf("namespace %v not", ns)
-}
-
-func (r *Region) AdaptAlign(align uint64) (uint64, error) {
-	return align, nil
 }
 
 func (r *Region) FsdaxAlignment() uint64 {

--- a/pkg/pmem-csi-driver/main.go
+++ b/pkg/pmem-csi-driver/main.go
@@ -8,14 +8,14 @@ SPDX-License-Identifier: Apache-2.0
 package pmemcsidriver
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
 
-	"k8s.io/klog/v2"
-
 	api "github.com/intel/pmem-csi/pkg/apis/pmemcsi/v1beta1"
 	"github.com/intel/pmem-csi/pkg/logger"
+	pmemlog "github.com/intel/pmem-csi/pkg/logger"
 	pmemcommon "github.com/intel/pmem-csi/pkg/pmem-common"
 )
 
@@ -66,7 +66,12 @@ func Main() int {
 		return 0
 	}
 
-	klog.V(3).Info("Version: ", version)
+	ctx := context.Background()
+	logger := pmemlog.Get(ctx)
+	ctx = pmemlog.Set(ctx, logger)
+
+	logger.Info("PMEM-CSI started.", "version", version)
+	defer logger.Info("PMEM-CSI stopped.")
 
 	if config.schedulerListen != "" && config.Mode != Webhooks {
 		pmemcommon.ExitError("scheduler listening", errors.New("only supported in the controller"))
@@ -80,7 +85,7 @@ func Main() int {
 		return 1
 	}
 
-	if err = driver.Run(); err != nil {
+	if err = driver.Run(ctx); err != nil {
 		pmemcommon.ExitError("failed to run driver", err)
 		return 1
 	}

--- a/pkg/pmem-csi-driver/rescheduler.go
+++ b/pkg/pmem-csi-driver/rescheduler.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/intel/pmem-csi/pkg/logger"
+	pmemlog "github.com/intel/pmem-csi/pkg/logger"
 	"github.com/intel/pmem-csi/pkg/types"
 
 	v1 "k8s.io/api/core/v1"
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
 )
 
@@ -79,7 +78,7 @@ type pmemCSIProvisioner struct {
 // into a problem, either during the startup phase (blocking) or later
 // at runtime (in a go routine).
 func (pcp *pmemCSIProvisioner) startRescheduler(ctx context.Context, cancel func()) {
-	l := logger.Get(ctx).WithName("rescheduler")
+	l := pmemlog.Get(ctx).WithName("rescheduler")
 
 	l.Info("starting")
 	go func() {
@@ -93,7 +92,7 @@ func (pcp *pmemCSIProvisioner) startRescheduler(ctx context.Context, cancel func
 // starts working on the PVC. We only deal with those which need to be
 // rescheduled.
 func (pcp *pmemCSIProvisioner) ShouldProvision(ctx context.Context, pvc *v1.PersistentVolumeClaim) bool {
-	l := logger.Get(ctx)
+	l := pmemlog.Get(ctx)
 
 	reschedule, err := pcp.shouldReschedule(ctx, pvc, nil)
 	if err != nil {
@@ -137,9 +136,9 @@ func (pcp *pmemCSIProvisioner) Delete(context.Context, *v1.PersistentVolume) err
 }
 
 func (pcp *pmemCSIProvisioner) shouldReschedule(ctx context.Context, pvc *v1.PersistentVolumeClaim, node *v1.Node) (bool, error) {
-	l := logger.Get(ctx).WithName("ShouldReschedulePVC").WithValues("pvc", klog.KObj(pvc))
+	l := pmemlog.Get(ctx).WithName("ShouldReschedulePVC").WithValues("pvc", pmemlog.KObj(pvc))
 	if node != nil {
-		l = l.WithValues("node", klog.KObj(node))
+		l = l.WithValues("node", pmemlog.KObj(node))
 	}
 
 	// "node" might be nil. Check the label directly.

--- a/pkg/pmem-csi-operator/controller/deployment/deployment_controller.go
+++ b/pkg/pmem-csi-operator/controller/deployment/deployment_controller.go
@@ -216,7 +216,7 @@ func NewReconcileDeployment(ctx context.Context, client client.Client, opts pmem
 	ctx = logger.Set(ctx, l)
 
 	if opts.Namespace == "" {
-		opts.Namespace = k8sutil.GetNamespace()
+		opts.Namespace = k8sutil.GetNamespace(ctx)
 	}
 
 	if opts.DriverImage == "" {

--- a/pkg/pmem-csi-operator/main.go
+++ b/pkg/pmem-csi-operator/main.go
@@ -66,7 +66,7 @@ func Main() int {
 	ctx := context.Background()
 
 	// Retrieve namespace to watch for new deployments and to create sub-resources
-	namespace := k8sutil.GetNamespace()
+	namespace := k8sutil.GetNamespace(ctx)
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{

--- a/pkg/pmem-device-manager/convert.go
+++ b/pkg/pmem-device-manager/convert.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/intel/pmem-csi/pkg/exec"
-	"github.com/intel/pmem-csi/pkg/logger"
+	pmemlog "github.com/intel/pmem-csi/pkg/logger"
 	"github.com/intel/pmem-csi/pkg/ndctl"
 	pmemcommon "github.com/intel/pmem-csi/pkg/pmem-common"
 	"github.com/intel/pmem-csi/pkg/types"
@@ -33,6 +33,7 @@ const (
 // node labels such that the normal driver runs instead of this
 // special one-time operation.
 func ForceConvertRawNamespaces(ctx context.Context, client kubernetes.Interface, driverName string, nodeSelector types.NodeSelector, nodeName string) (finalErr error) {
+	ctx, _ = pmemlog.WithName(ctx, "ForceConvertRawNamespaces")
 	defer func() {
 		if finalErr == nil {
 			return
@@ -66,42 +67,42 @@ func ForceConvertRawNamespaces(ctx context.Context, client kubernetes.Interface,
 }
 
 func convert(ctx context.Context, ndctx ndctl.Context) (numConverted int, finalErr error) {
-	l := logger.Get(ctx).WithName("raw-namespace-conversion")
+	ctx, logger := pmemlog.WithName(ctx, "convert")
 	defer func() {
 		if finalErr != nil {
-			l.Error(finalErr, "failed", "converted", numConverted)
+			logger.Error(finalErr, "failed", "converted", numConverted)
 		} else {
-			l.V(3).Info("successful", "converted", numConverted)
+			logger.V(3).Info("successful", "converted", numConverted)
 		}
 	}()
 
-	l.V(3).Info("checking for namespaces")
+	logger.V(3).Info("checking for namespaces")
 	for _, bus := range ndctx.GetBuses() {
-		l.V(3).Info("checking", "bus", bus)
+		logger.V(3).Info("checking", "bus", bus)
 		for _, region := range bus.ActiveRegions() {
-			l.V(3).Info("checking", "region", region)
+			logger.V(3).Info("checking", "region", region)
 			if region.Readonly() {
-				l.V(3).Info("skipped because read-only")
+				logger.V(3).Info("skipped because read-only")
 				continue
 			}
 			vgName := pmemcommon.VgName(bus, region)
 			for _, namespace := range region.AllNamespaces() {
-				l.V(3).Info("checking", "namespace", namespace)
+				logger.V(3).Info("checking", "namespace", namespace)
 				size := namespace.Size()
 				if size <= 0 {
-					l.V(3).Info("skipped because size is zero")
+					logger.V(3).Info("skipped because size is zero")
 					continue
 				}
 
 				switch namespace.Mode() {
 				case ndctl.RawMode:
-					l.V(2).Info("converting raw namespace", "namespace", namespace)
+					logger.V(2).Info("converting raw namespace", "namespace", namespace)
 					// We don't even try to set the special namespace alt name here.
 					// This code is supposed to be used for legacy PMEM where the
 					// name would be silently ignored by ndctl. By not even trying
 					// set it, we avoid a special case and can test this also
 					// with PMEM were the name would be set.
-					_, err := exec.RunCommand("ndctl", "create-namespace",
+					_, err := exec.RunCommand(ctx, "ndctl", "create-namespace",
 						"--force", "--mode", "fsdax",
 						"--bus", bus.DeviceName(),
 						"--region", region.DeviceName(),
@@ -123,16 +124,16 @@ func convert(ctx context.Context, ndctx ndctl.Context) (numConverted int, finalE
 					}
 					// Otherwise we must have the right volume group for it.
 					// If we don't, try to create it.
-					l.V(2).Info("setting up volume group", "namespace", namespace, "VG", vgName)
+					logger.V(2).Info("setting up volume group", "namespace", namespace, "vg", vgName)
 					devName := "/dev/" + namespace.BlockDeviceName()
-					if err := setupVGForNamespaces(vgName, devName); err != nil {
+					if err := setupVGForNamespaces(ctx, vgName, devName); err != nil {
 						finalErr = err
 						return
 					}
-					l.V(2).Info("converted to fsdax namespace", "namespace", namespace, "VG", vgName)
+					logger.V(2).Info("converted to fsdax namespace", "namespace", namespace, "vg", vgName)
 					numConverted++
 				default:
-					l.V(3).Info("ignoring namespace because of mode", "mode", namespace.Mode())
+					logger.V(3).Info("ignoring namespace because of mode", "mode", namespace.Mode())
 				}
 			}
 		}
@@ -142,33 +143,33 @@ func convert(ctx context.Context, ndctx ndctl.Context) (numConverted int, finalE
 }
 
 func havePMEM(ctx context.Context, ndctx ndctl.Context) error {
-	l := logger.Get(ctx).WithName("check-pmem")
+	ctx, logger := pmemlog.WithName(ctx, "havePMEM")
 
 	haveFsdaxWithName := 0
 	haveVG := 0
 	for _, bus := range ndctx.GetBuses() {
-		l.V(5).Info("checking", "bus", bus)
+		logger.V(5).Info("Checking bus", "bus", bus)
 		for _, region := range bus.ActiveRegions() {
-			l.V(5).Info("checking", "region", region)
+			logger.V(5).Info("Checking region", "region", region)
 			if region.Readonly() {
-				l.V(3).Info("skipped because read-only")
+				logger.V(3).Info("Skipped because read-only")
 				continue
 			}
 			vgName := pmemcommon.VgName(bus, region)
 			for _, namespace := range region.AllNamespaces() {
-				l.V(5).Info("checking", "namespace", namespace)
+				logger.V(5).Info("Checking namespace", "namespace", namespace)
 				size := namespace.Size()
 				if size > 0 &&
 					namespace.Mode() == ndctl.FsdaxMode &&
 					namespace.Name() == pmemCSINamespaceName {
-					l.V(3).Info("namespace will be used by PMEM-CSI in LVM mode because of name", "namespace", namespace)
+					logger.V(3).Info("Namespace will be used by PMEM-CSI in LVM mode because of name", "namespace", namespace)
 					haveFsdaxWithName++
 				}
 			}
-			if _, err := exec.RunCommand("vgdisplay", vgName); err != nil {
-				l.V(5).Info("volume group does not exist", "VG", vgName)
+			if _, err := exec.RunCommand(ctx, "vgdisplay", vgName); err != nil {
+				logger.V(5).Info("Volume group does not exist", "vg", vgName)
 			} else {
-				l.V(3).Info("volume group will be used by PMEM-CSI in LVM mode", "VG", vgName)
+				logger.V(3).Info("Volume group will be used by PMEM-CSI in LVM mode", "vg", vgName)
 				haveVG++
 			}
 		}
@@ -180,8 +181,7 @@ func havePMEM(ctx context.Context, ndctx ndctl.Context) error {
 }
 
 func relabel(ctx context.Context, client kubernetes.Interface, driverName string, nodeSelector types.NodeSelector, nodeName string) error {
-	l := logger.Get(ctx).WithName("relabel")
-
+	ctx, logger := pmemlog.WithName(ctx, "relabel")
 	labels := []string{}
 
 	// Remove "force" label.
@@ -193,10 +193,10 @@ func relabel(ctx context.Context, client kubernetes.Interface, driverName string
 
 	// Apply patch.
 	patch := fmt.Sprintf(`{"metadata":{"labels":{%s}}}`, strings.Join(labels, ", "))
-	l.V(5).Info("node", "patch", patch)
+	logger.V(5).Info("Node", "patch", patch)
 	if _, err := client.CoreV1().Nodes().Patch(ctx, nodeName, k8stypes.MergePatchType, []byte(patch), metav1.PatchOptions{}, ""); err != nil {
 		return fmt.Errorf("failed to patch node: %v", err)
 	}
-	l.V(3).Info("change node labels", "node", nodeName, "patch", patch)
+	logger.V(3).Info("Change node labels", "node", nodeName, "patch", patch)
 	return nil
 }

--- a/pkg/pmem-device-manager/metrics.go
+++ b/pkg/pmem-device-manager/metrics.go
@@ -7,6 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package pmdmanager
 
 import (
+	"context"
+
+	pmemlog "github.com/intel/pmem-csi/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -59,7 +62,11 @@ func (cc CapacityCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements prometheus.Collector.Collect.
 func (cc CapacityCollector) Collect(ch chan<- prometheus.Metric) {
-	capacity, err := cc.GetCapacity()
+	ctx := context.TODO() // would be nicer to get it from caller
+	logger := pmemlog.Get(ctx).WithName("Prometheus Collect")
+	pmemlog.Set(ctx, logger)
+
+	capacity, err := cc.GetCapacity(ctx)
 	if err != nil {
 		return
 	}

--- a/pkg/pmem-device-manager/pmd-fake.go
+++ b/pkg/pmem-device-manager/pmd-fake.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package pmdmanager
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -45,7 +46,7 @@ func (dm *fakeDM) GetMode() api.DeviceMode {
 	return api.DeviceModeFake
 }
 
-func (dm *fakeDM) GetCapacity() (capacity Capacity, err error) {
+func (dm *fakeDM) GetCapacity(ctx context.Context) (capacity Capacity, err error) {
 	dm.mutex.Lock()
 	defer dm.mutex.Unlock()
 
@@ -65,7 +66,7 @@ func (dm *fakeDM) getCapacity() Capacity {
 	}
 }
 
-func (dm *fakeDM) CreateDevice(volumeId string, size uint64) (uint64, error) {
+func (dm *fakeDM) CreateDevice(ctx context.Context, volumeId string, size uint64) (uint64, error) {
 	dm.mutex.Lock()
 	defer dm.mutex.Unlock()
 
@@ -86,7 +87,7 @@ func (dm *fakeDM) CreateDevice(volumeId string, size uint64) (uint64, error) {
 	return size, nil
 }
 
-func (dm *fakeDM) DeleteDevice(volumeId string, flush bool) error {
+func (dm *fakeDM) DeleteDevice(ctx context.Context, volumeId string, flush bool) error {
 	dm.mutex.Lock()
 	defer dm.mutex.Unlock()
 
@@ -96,7 +97,7 @@ func (dm *fakeDM) DeleteDevice(volumeId string, flush bool) error {
 	return nil
 }
 
-func (dm *fakeDM) ListDevices() ([]*PmemDeviceInfo, error) {
+func (dm *fakeDM) ListDevices(ctx context.Context) ([]*PmemDeviceInfo, error) {
 	dm.mutex.Lock()
 	defer dm.mutex.Unlock()
 
@@ -108,7 +109,7 @@ func (dm *fakeDM) ListDevices() ([]*PmemDeviceInfo, error) {
 	return devices, nil
 }
 
-func (dm *fakeDM) GetDevice(volumeId string) (*PmemDeviceInfo, error) {
+func (dm *fakeDM) GetDevice(ctx context.Context, volumeId string) (*PmemDeviceInfo, error) {
 	dm.mutex.Lock()
 	defer dm.mutex.Unlock()
 

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -1,6 +1,7 @@
 package pmdmanager
 
 import (
+	"context"
 	"fmt"
 
 	api "github.com/intel/pmem-csi/pkg/apis/pmemcsi/v1beta1"
@@ -42,7 +43,7 @@ type Capacity struct {
 	Total uint64
 }
 
-func (c Capacity) GetCapacity() (Capacity, error) {
+func (c Capacity) GetCapacity(ctx context.Context) (Capacity, error) {
 	return c, nil
 }
 
@@ -65,7 +66,7 @@ var _ PmemDeviceCapacity = Capacity{}
 // PmemDeviceCapacity interface just returns capacity information.
 type PmemDeviceCapacity interface {
 	// GetCapacity returns information about local capacity.
-	GetCapacity() (Capacity, error)
+	GetCapacity(ctx context.Context) (Capacity, error)
 }
 
 //PmemDeviceManager interface to manage the PMEM block devices
@@ -78,30 +79,30 @@ type PmemDeviceManager interface {
 	// CreateDevice creates a new block device with give name, size and namespace mode.
 	// It returns the actual volume size which will always be at least as large as requested.
 	// Possible errors: ErrNotEnoughSpace, ErrDeviceExists
-	CreateDevice(name string, size uint64) (uint64, error)
+	CreateDevice(ctx context.Context, name string, size uint64) (uint64, error)
 
 	// GetDevice returns the block device information for given name
 	// Possible errors: ErrDeviceNotFound
-	GetDevice(name string) (*PmemDeviceInfo, error)
+	GetDevice(ctx context.Context, name string) (*PmemDeviceInfo, error)
 
 	// DeleteDevice deletes an existing block device with give name.
 	// If 'flush' is 'true', then the device data is zeroed before deleting the device
 	// Possible errors: ErrDeviceInUse
-	DeleteDevice(name string, flush bool) error
+	DeleteDevice(ctx context.Context, name string, flush bool) error
 
 	// ListDevices returns all the block devices information that was created by this device manager
-	ListDevices() ([]*PmemDeviceInfo, error)
+	ListDevices(ctx context.Context) ([]*PmemDeviceInfo, error)
 }
 
 // New creates a new device manager for the given mode and percentage.
-func New(mode api.DeviceMode, pmemPercentage uint) (PmemDeviceManager, error) {
+func New(ctx context.Context, mode api.DeviceMode, pmemPercentage uint) (PmemDeviceManager, error) {
 	switch mode {
 	case api.DeviceModeFake:
 		return newFake(pmemPercentage)
 	case api.DeviceModeLVM:
-		return newPmemDeviceManagerLVM(pmemPercentage)
+		return newPmemDeviceManagerLVM(ctx, pmemPercentage)
 	case api.DeviceModeDirect:
-		return newPmemDeviceManagerNdctl(pmemPercentage)
+		return newPmemDeviceManagerNdctl(ctx, pmemPercentage)
 	default:
 		return nil, fmt.Errorf("unsupported device mode %q", mode)
 	}

--- a/pkg/pmem-device-manager/pmd-util.go
+++ b/pkg/pmem-device-manager/pmd-util.go
@@ -1,6 +1,7 @@
 package pmdmanager
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -8,16 +9,19 @@ import (
 
 	pmemerr "github.com/intel/pmem-csi/pkg/errors"
 	pmemexec "github.com/intel/pmem-csi/pkg/exec"
+	pmemlog "github.com/intel/pmem-csi/pkg/logger"
 	"golang.org/x/sys/unix"
-	"k8s.io/klog/v2"
 )
 
 const (
 	retryStatTimeout time.Duration = 100 * time.Millisecond
 )
 
-func clearDevice(dev *PmemDeviceInfo, flush bool) error {
-	klog.V(4).Infof("ClearDevice: path: %v flush:%v", dev.Path, flush)
+func clearDevice(ctx context.Context, dev *PmemDeviceInfo, flush bool) error {
+	logger := pmemlog.Get(ctx).WithName("clearDevice").WithValues("device", dev.Path)
+	ctx = pmemlog.Set(ctx, logger)
+	logger.V(4).Info("Starting", "flush", flush)
+
 	// by default, clear 4 kbytes to avoid recognizing file system by next volume seeing data area
 	var blocks uint64 = 4
 	if flush {
@@ -31,13 +35,11 @@ func clearDevice(dev *PmemDeviceInfo, flush bool) error {
 	// Before action, check that dev.Path exists and is device
 	fileinfo, err := os.Stat(dev.Path)
 	if err != nil {
-		klog.Errorf("clearDevice: %s does not exist", dev.Path)
-		return err
+		return fmt.Errorf("clear device: %v", err)
 	}
 
 	// Check if device
 	if (fileinfo.Mode() & os.ModeDevice) == 0 {
-		klog.Errorf("clearDevice: %s is not device", dev.Path)
 		return fmt.Errorf("%s is not device", dev.Path)
 	}
 
@@ -49,37 +51,40 @@ func clearDevice(dev *PmemDeviceInfo, flush bool) error {
 	}
 
 	if blocks == 0 {
-		klog.V(5).Infof("Wiping entire device: %s", dev.Path)
+		logger.V(5).Info("Wiping entire device")
 		// shred would write n times using random data, followed by optional write of zeroes.
 		// For faster operation, and because we consider zeroing enough for
 		// reasonable clearing in case of a memory device, we force zero iterations
 		// with random data, followed by one pass writing zeroes.
-		if _, err := pmemexec.RunCommand("shred", "-n", "0", "-z", dev.Path); err != nil {
+		if _, err := pmemexec.RunCommand(ctx, "shred", "-n", "0", "-z", dev.Path); err != nil {
 			return fmt.Errorf("device shred failure: %v", err.Error())
 		}
 	} else {
-		klog.V(5).Infof("Zeroing %d 1k blocks at start of device: %s Size %v", blocks, dev.Path, dev.Size)
+		logger.V(5).Info("Zeroing blocks at start of device", "blocks", blocks, "dev-size", dev.Size)
 		of := "of=" + dev.Path
 		// guard against writing more than volume size
 		if blocks*1024 > dev.Size {
 			blocks = dev.Size / 1024
 		}
 		count := "count=" + strconv.FormatUint(blocks, 10)
-		if _, err := pmemexec.RunCommand("dd", "if=/dev/zero", of, "bs=1024", count); err != nil {
+		if _, err := pmemexec.RunCommand(ctx, "dd", "if=/dev/zero", of, "bs=1024", count); err != nil {
 			return fmt.Errorf("device zeroing failure: %v", err.Error())
 		}
 	}
 	return nil
 }
 
-func waitDeviceAppears(dev *PmemDeviceInfo) error {
+func waitDeviceAppears(ctx context.Context, dev *PmemDeviceInfo) error {
+	logger := pmemlog.Get(ctx).WithName("waitDeviceAppears").WithValues("device", dev.Path)
 	for i := 0; i < 10; i++ {
 		if _, err := os.Stat(dev.Path); err == nil {
 			return nil
 		}
 
-		klog.Warningf("waitDeviceAppears[%d]: %s does not exist, sleep %v and retry",
-			i, dev.Path, retryStatTimeout)
+		logger.V(2).Info("Device does not exist, sleep and retry",
+			"attempt", i,
+			"timeout", retryStatTimeout,
+		)
 		time.Sleep(retryStatTimeout)
 	}
 	return fmt.Errorf("%s: device not ready", dev.Path)

--- a/pkg/pmem-state/pmem-state.go
+++ b/pkg/pmem-state/pmem-state.go
@@ -13,8 +13,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-
-	"k8s.io/klog/v2"
 )
 
 // StateManager manages the driver persistent state, i.e, volumes information
@@ -73,10 +71,8 @@ func (fs *fileState) Create(id string, data interface{}) error {
 
 	if err := json.NewEncoder(fp).Encode(data); err != nil {
 		// cleanup file entry before returning error
-		fp.Close() //nolint: errcheck, gosec
-		if e := os.Remove(file); e != nil {
-			klog.Warningf("file-state: failed to remove state file: %v", e)
-		}
+		fp.Close()      //nolint: errcheck, gosec
+		os.Remove(file) //nolint: errcheck, gosec
 		return fmt.Errorf("failed to encode metadata: %w", err)
 	}
 

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -265,7 +265,7 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 
 			// Run in-cluster kubectl from master node
 			ssh := os.Getenv("REPO_ROOT") + "/_work/" + os.Getenv("CLUSTER") + "/ssh.0"
-			out, err := exec.RunCommand(ssh, "kubectl", "get", "pmemcsideployments.pmem-csi.intel.com", "--no-headers")
+			out, err := exec.RunCommand(ctx, ssh, "kubectl", "get", "pmemcsideployments.pmem-csi.intel.com", "--no-headers")
 			Expect(err).ShouldNot(HaveOccurred(), "kubectl get: %v", out)
 			Expect(out).Should(MatchRegexp(`%s\s+%s\s+.*"?%s"?:"?%s"?.*\s+%s\s+%s\s+[0-9]+(s|m)`,
 				d.Name, d.Spec.DeviceMode, lblKey, lblValue, d.Spec.Image, d.Status.Phase), "fields mismatch")
@@ -315,9 +315,9 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 					framework.ExpectNoError(err, "get pod logs for running controller-0")
 
 					if format == api.LogFormatJSON {
-						Expect(output).To(MatchRegexp(`\{"ts":\d+.\d+,"msg":"Version:`), "PMEM-CSI driver output in JSON")
+						Expect(output).To(MatchRegexp(`\{"ts":\d+.\d+,"msg":.*"version":`), "PMEM-CSI driver output in JSON")
 					} else {
-						Expect(output).To(MatchRegexp(`I.*main.go:.*Version: `), "PMEM-CSI driver output in glog format")
+						Expect(output).To(MatchRegexp(`I.*main.go:.*version="`), "PMEM-CSI driver output in glog format")
 					}
 					framework.Logf("got pod log: %s", output)
 				})

--- a/test/e2e/storage/conversion.go
+++ b/test/e2e/storage/conversion.go
@@ -173,9 +173,9 @@ func testRawNamespaceConversion(f *framework.Framework, driverName, namespace st
 		if err != nil {
 			return fmt.Errorf("get pmem-driver output on master node: %v", err)
 		}
-		parts := regexp.MustCompile(`PMEM-CSI ready. Capacity:[^\n]*(\d+)\s*\S+ available[^\n]*`).FindStringSubmatch(output)
+		parts := regexp.MustCompile(`"PMEM-CSI ready." capacity="[^\n]*(\d+)\s*\S+ available[^\n]*`).FindStringSubmatch(output)
 		if len(parts) != 2 {
-			return fmt.Errorf("pod %s has not printed the expected `PMEM-CSI ready. Capacity: ...` log message yet", pod.Name)
+			return fmt.Errorf("pod %s has not printed the expected `PMEM-CSI ready.` log message yet", pod.Name)
 		}
 		if parts[1] == "0" {
 			return fmt.Errorf("pod %s is ready, but without any capacity: %s", pod.Name, parts[0])

--- a/test/e2e/storage/conversion.go
+++ b/test/e2e/storage/conversion.go
@@ -79,10 +79,23 @@ func testRawNamespaceConversion(f *framework.Framework, driverName, namespace st
 	// labels which might have cause the PMEM-CSI driver to run
 	// on the master node. None of the other tests expect that.
 	defer func() {
+		By("destroying volume groups again")
+		vgs := exec.Command(sshcmd, "sudo vgs --noheadings --options name")
+		out, err := vgs.Output() // ignore stderr, it may contain warnings
+		if err != nil {
+			framework.Logf("listing volume groups with %+v failed: %s", vgs, string(out))
+		}
+		for _, vg := range strings.Split(string(out), "\n") {
+			vgremove := exec.Command(sshcmd, "sudo vgremove "+vg)
+			out, err := vgremove.CombinedOutput()
+			if err != nil {
+				framework.Logf("removing volume group with %+v failed: %s", vgremove, string(out))
+			}
+		}
+
 		By("destroying namespace again")
 		cmd := exec.Command(sshcmd, "sudo ndctl destroy-namespace --force all")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
+		if out, err := cmd.CombinedOutput(); err != nil {
 			framework.Logf("erasing namespaces with %+v failed: %s", cmd, string(out))
 		}
 

--- a/test/e2e/versionskew/operator.go
+++ b/test/e2e/versionskew/operator.go
@@ -39,6 +39,7 @@ var _ = deploy.DescribeForSome("versionskew", func(d *deploy.Deployment) bool {
 
 	f := framework.NewDefaultFramework("skew")
 	f.SkipNamespaceCreation = true
+	ctx := context.Background()
 
 	BeforeEach(func() {
 		var err error
@@ -78,7 +79,7 @@ var _ = deploy.DescribeForSome("versionskew", func(d *deploy.Deployment) bool {
 			semver := current + ".0"
 			defer func() {
 				// Remove generated bundle
-				_, err := pmemexec.RunCommand("rm", "-rf", root+"/deploy/olm-bundle/"+semver)
+				_, err := pmemexec.RunCommand(ctx, "rm", "-rf", root+"/deploy/olm-bundle/"+semver)
 				framework.ExpectNoError(err, "remove generated bundle: %v", err)
 			}()
 			// (Re)Generate olm-bundle with future release version number
@@ -86,7 +87,7 @@ var _ = deploy.DescribeForSome("versionskew", func(d *deploy.Deployment) bool {
 			make := exec.Command("make", "operator-generate-bundle", "VERSION=v"+semver)
 			make.Dir = root
 			make.Env = os.Environ()
-			_, err := pmemexec.Run(make)
+			_, err := pmemexec.Run(ctx, make)
 			framework.ExpectNoError(err, "%s: generate bundle for operator version %s", d.Name(), d.Version)
 		}
 


### PR DESCRIPTION
All log messages from PMEM-CSI itself are produced with log message
plus key/value pairs. Loggers accumulate a prefix and additional
key/value pairs as they are passed down the call chain.

All gRPC calls have the method name as prefix and incrementing request
counter, to distinguish between different requests for the same
operation.

Fixes: #825 