### PR TITLE
pmem-csi-driver: revert to mounting with "-o dax"

### DIFF
--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -45,6 +45,13 @@ const (
 
 	// Mount point inside the target directory for the original volume.
 	kataContainersMount = "kata-containers-host-volume"
+
+	// "-o dax" is said to be deprecated (https://www.kernel.org/doc/Documentation/filesystems/dax.txt)
+	// but in practice works across a wider range of kernel versions whereas
+	// "-o dax=always", the recommended alternative, fails on old kernels.
+	// Given that "-o dax" is part of the kernel API, it's unlikely that
+	// support for it really gets removed, therefore we continue to use it.
+	daxMountFlag = "dax"
 )
 
 type volumeInfo struct {
@@ -183,7 +190,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return nil, err
 		}
 		srcPath = device.Path
-		mountFlags = append(mountFlags, "dax=always")
+		mountFlags = append(mountFlags, daxMountFlag)
 	} else {
 		// Validate parameters.
 		v, err := parameters.Parse(parameters.PersistentVolumeOrigin, req.GetVolumeContext())
@@ -563,7 +570,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	mountOptions = append(mountOptions, "dax=always")
+	mountOptions = append(mountOptions, daxMountFlag)
 
 	if err = ns.mount(ctx, device.Path, stagingtargetPath, mountOptions, false /* raw block */); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
"dax=always" gets passed verbatim to the kernel by the mount
command. Older kernels like 5.4 then fail with "wrong fs type, bad
option, bad superblock on /dev/pmem1.1, missing codepage or helper
program, or other error."

Although "-o dax" is said to be a legacy option that may get removed,
in practice the risk of that happening is low, so we can revert to
using it without any fallbacks. It's functionally the same.