### PR TITLE
build: check Go version during "make build-image"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,9 @@ push-image push-test-image: push%-image: $(PUSH_IMAGE_DEP)
 
 # This ensures that all sources are available in the "vendor" directory for use
 # inside "docker build".
-populate-vendor-dir:
-	go mod tidy
-	go mod vendor
+populate-vendor-dir: check-go-version-$(GO_BINARY)
+	$(GO_BINARY) mod tidy
+	$(GO_BINARY) mod vendor
 
 .PHONY: print-image-version
 print-image-version:


### PR DESCRIPTION
Populating the vendor dir was done before checking the Go version,
leading to a hard failure with older versions because we now depend on
"embed" from Go 1.16.

With this fix, a proper warning is shown:
```
$ make build-image

======================================================
                  WARNING

  This projects is tested with Go v1.16.
  Your current Go version is v1.13.
  This may or may not be close enough.

  In particular test_fmt and test_vendor
  are known to be sensitive to the version of
  Go.
======================================================

go mod tidy
warning: ignoring symlink /nvme/gopath/src/github.com/intel/pmem-csi/cmd/manager
github.com/intel/pmem-csi/deploy imports
	embed: malformed module path "embed": missing dot in first path element
make: *** [Makefile:118: populate-vendor-dir] Error 1
```