### PR TITLE
test: remove ginkgo.skip default

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -50,8 +50,6 @@ func TestMain(m *testing.M) {
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
-	// Skip slow or distruptive tests by default.
-	flag.Set("ginkgo.skip", `\[Slow|Disruptive\]`)
 	flag.Parse()
 
 	// Register framework flags, then handle flags.


### PR DESCRIPTION
Ginkgo recently changed the semantic of -ginkgo.skip so that it
accumulates skip strings instead of setting
them (https://github.com/onsi/ginkgo/pull/736/files#r669576114). In
our case that had the effect that slow tests (like version skew) were
always skipped, regardless of the -ginkgo.skip string passed to the
e2e.test binary.