### PR TITLE
test: bump up fictional future version number for OLM upgrade test

### DIFF
--- a/test/e2e/versionskew/operator.go
+++ b/test/e2e/versionskew/operator.go
@@ -78,7 +78,8 @@ var _ = deploy.DescribeForSome("versionskew", func(d *deploy.Deployment) bool {
 			newDeploymentName = d.Name() + "---" + version
 		} else if d.HasOLM {
 			root := os.Getenv("REPO_ROOT")
-			semver := current + ".0"
+			// A future version number. Must be higher than the current one.
+			semver := "100.0.0"
 			defer func() {
 				// Remove generated bundle
 				_, err := pmemexec.RunCommand(ctx, "rm", "-rf", root+"/deploy/olm-bundle/"+semver)

--- a/test/e2e/versionskew/versionskew.go
+++ b/test/e2e/versionskew/versionskew.go
@@ -38,10 +38,6 @@ import (
 const (
 	// base is the release branch used for version skew testing. Empty if none.
 	base = "0.9"
-	// Expected future release version.
-	// The version number used by the operator upgrade test for generating
-	// the OLM bundle for current devel code.
-	current = "1.0"
 )
 
 func baseSupportsKubernetes(ver version.Version) bool {


### PR DESCRIPTION
Since releasing 1.0.0, the "current = 1.0" version number was not high
enough anymore with the effect that the OLM upgrade test didn't
actually upgrade and after a test run removed the files under deploy
which were still needed.