### PR TITLE
Dockerfile: pull debian image from ECR registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Image builds are not reproducible because the base layer is changing over time.
-ARG LINUX_BASE=debian:buster-slim
+ARG LINUX_BASE=public.ecr.aws/debian/debian:buster-slim
 
 # Common base image for building PMEM-CSI and running CI tests.
 FROM ${LINUX_BASE} AS build


### PR DESCRIPTION
Don't pull debian image from Dockerhub to avoid reaching out Rate limit.

fixes #1036

Signed-off-by: Julio Montes <julio.montes@intel.com>

cc @pohly @GabyCT