### PR TITLE
fix various linter warnings

### DIFF
--- a/cmd/pmem-csi-driver/main.go
+++ b/cmd/pmem-csi-driver/main.go
@@ -10,7 +10,7 @@ package main
 import (
 	"os"
 
-	"github.com/intel/pmem-csi/pkg/pmem-csi-driver"
+	pmemcsidriver "github.com/intel/pmem-csi/pkg/pmem-csi-driver"
 )
 
 func main() {

--- a/cmd/pmem-csi-driver/main_test.go
+++ b/cmd/pmem-csi-driver/main_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/intel/pmem-csi/pkg/coverage"
-	"github.com/intel/pmem-csi/pkg/pmem-csi-driver"
+	pmemcsidriver "github.com/intel/pmem-csi/pkg/pmem-csi-driver"
 )
 
 func TestMain(t *testing.T) {

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -53,11 +53,11 @@ func Run(ctx context.Context, cmd *exec.Cmd) (string, error) {
 
 	switch {
 	case err != nil && both.Len() > 0:
-		err = fmt.Errorf("%q: command failed: %v\nCombined stderr/stdout output: %s", cmd, err, string(both.Bytes()))
+		err = fmt.Errorf("%q: command failed: %v\nCombined stderr/stdout output: %s", cmd, err, both.String())
 	case err != nil:
 		err = fmt.Errorf("%q: command failed with no output: %v", cmd, err)
 	}
-	return string(stdout.Bytes()), err
+	return stdout.String(), err
 }
 
 func dumpOutput(ctx context.Context, wg *sync.WaitGroup, in io.Reader, out []io.Writer) {
@@ -66,8 +66,8 @@ func dumpOutput(ctx context.Context, wg *sync.WaitGroup, in io.Reader, out []io.
 	scanner := bufio.NewScanner(in)
 	for scanner.Scan() {
 		for _, o := range out {
-			o.Write(scanner.Bytes())
-			o.Write([]byte("\n"))
+			_, _ = o.Write(scanner.Bytes())
+			_, _ = o.Write([]byte("\n"))
 		}
 		logger.V(5).Info(scanner.Text())
 	}

--- a/pkg/imagefile/imagefile.go
+++ b/pkg/imagefile/imagefile.go
@@ -165,12 +165,14 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"golang.org/x/sys/unix"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/intel/pmem-csi/third-party/go-fibmap"
 )
@@ -300,7 +302,7 @@ func Create(filename string, size Bytes, fs FsType) error {
 	if err := dd(mbr1, filename, true, 0); err != nil {
 		return err
 	}
-	if _, err := file.Seek(int64(daxHeaderOffset), os.SEEK_SET); err != nil {
+	if _, err := file.Seek(int64(daxHeaderOffset), io.SeekStart); err != nil {
 		return err
 	}
 	if _, err := file.Write(nsdax(uint(HeaderSize), uint(DaxAlignment))); err != nil {
@@ -477,10 +479,10 @@ const ioChunkSize = 256 * 1024 * 1024
 func copyRange(from, to *os.File, skip, seek, size int64) error {
 	buffer := make([]byte, ioChunkSize)
 
-	if _, err := from.Seek(skip, os.SEEK_SET); err != nil {
+	if _, err := from.Seek(skip, io.SeekStart); err != nil {
 		return err
 	}
-	if _, err := to.Seek(seek, os.SEEK_SET); err != nil {
+	if _, err := to.Seek(seek, io.SeekStart); err != nil {
 		return err
 	}
 	remaining := size

--- a/pkg/imagefile/imagefile_test.go
+++ b/pkg/imagefile/imagefile_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -109,7 +110,7 @@ func TestExtents(t *testing.T) {
 	const numExtents = initialExtentSize
 	offset := int64(0)
 	for count := 1; count <= numExtents; count++ {
-		if _, err := file.Seek(offset, os.SEEK_SET); err != nil {
+		if _, err := file.Seek(offset, io.SeekStart); err != nil {
 			t.Fatalf("seek to %d: %v", offset, err)
 		}
 		if _, err := file.Write(make([]byte, count)); err != nil {

--- a/pkg/ndctl/region.go
+++ b/pkg/ndctl/region.go
@@ -273,7 +273,7 @@ func (r *region) CreateNamespace(ctx gocontext.Context, opts CreateNamespaceOpts
 
 	if err != nil {
 		// reset seed on failure
-		ns.SetEnforceMode(RawMode)
+		_ = ns.SetEnforceMode(RawMode)
 		C.ndctl_namespace_delete(ndns)
 		return nil, err
 	}

--- a/pkg/pmem-csi-driver/controllerserver-node.go
+++ b/pkg/pmem-csi-driver/controllerserver-node.go
@@ -165,7 +165,9 @@ func (cs *nodeControllerServer) CreateVolume(ctx context.Context, req *csi.Creat
 	}
 
 	nodeVolumeMutex.LockKey(req.Name)
-	defer nodeVolumeMutex.UnlockKey(req.Name)
+	defer func() {
+		_ = nodeVolumeMutex.UnlockKey(req.Name)
+	}()
 
 	volumeID, size, err := cs.createVolumeInternal(ctx,
 		p,

--- a/pkg/pmem-csi-driver/main.go
+++ b/pkg/pmem-csi-driver/main.go
@@ -56,7 +56,7 @@ func init() {
 	flag.StringVar(&config.StateBasePath, "statePath", "", "node: directory path where to persist the state of the driver, defaults to /var/lib/<drivername>")
 	flag.UintVar(&config.PmemPercentage, "pmemPercentage", 100, "node: percentage of space to be used by the driver in each PMEM region")
 
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("logtostderr", "true")
 }
 
 func Main() int {

--- a/pkg/pmem-csi-driver/nodeserver.go
+++ b/pkg/pmem-csi-driver/nodeserver.go
@@ -125,7 +125,9 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	// Serialize by VolumeId
 	volumeMutex.LockKey(volumeID)
-	defer volumeMutex.UnlockKey(volumeID)
+	defer func() {
+		_ = volumeMutex.UnlockKey(volumeID)
+	}()
 
 	var ephemeral bool
 	var device *pmdmanager.PmemDeviceInfo
@@ -372,7 +374,9 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 
 	// Serialize by VolumeId
 	volumeMutex.LockKey(volumeID)
-	defer volumeMutex.UnlockKey(volumeID)
+	defer func() {
+		_ = volumeMutex.UnlockKey(volumeID)
+	}()
 
 	var vol *nodeVolume
 	if vol = ns.cs.getVolumeByID(volumeID); vol == nil {
@@ -525,7 +529,9 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 
 	// Serialize by VolumeId
 	volumeMutex.LockKey(req.GetVolumeId())
-	defer volumeMutex.UnlockKey(req.GetVolumeId())
+	defer func() {
+		_ = volumeMutex.UnlockKey(req.GetVolumeId())
+	}()
 
 	mountOptions := req.GetVolumeCapability().GetMount().GetMountFlags()
 	logger.V(3).Info("Staging volume",
@@ -600,7 +606,9 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 
 	// Serialize by VolumeId
 	volumeMutex.LockKey(volumeID)
-	defer volumeMutex.UnlockKey(volumeID)
+	defer func() {
+		_ = volumeMutex.UnlockKey(volumeID)
+	}()
 
 	logger.V(3).Info("Unstage volume")
 	dm, err := ns.getDeviceManagerForVolume(ctx, volumeID)

--- a/pkg/pmem-csi-driver/pmem-csi-driver_test.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver_test.go
@@ -85,15 +85,13 @@ func checkResponse(t *testing.T, expected, actual *http.Response, err error, wha
 		defer actual.Body.Close()
 
 		assert.Equal(t, expected.StatusCode, actual.StatusCode, what)
-		body, err := ioutil.ReadAll(actual.Body)
+		actualBody, err := ioutil.ReadAll(actual.Body)
 		if assert.NoError(t, err, "read actual body") &&
 			expected.Body != nil {
-			body, err = ioutil.ReadAll(expected.Body)
+			expectedBody, err := ioutil.ReadAll(expected.Body)
 			if assert.NoError(t, err, "read expected body") {
-				expectedBody := string(body)
-				actualBody := string(body)
 				// Substring search because the full body contains a lot of additional metrics data.
-				assert.Contains(t, actualBody, expectedBody, "body")
+				assert.Contains(t, string(actualBody), string(expectedBody), "body")
 			}
 		}
 	}

--- a/pkg/pmem-csi-driver/rescheduler.go
+++ b/pkg/pmem-csi-driver/rescheduler.go
@@ -175,7 +175,7 @@ func (pcp *pmemCSIProvisioner) shouldReschedule(ctx context.Context, pvc *v1.Per
 	// Only when the extensions are off, then Provision() may get
 	// called more often. Such a cluster setup should better be
 	// avoided.
-	driverIsRunning := true
+	driverIsRunning := false
 	csiNode, err := pcp.csiNodeLister.Get(selectedNode)
 	switch {
 	case err == nil:

--- a/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
+++ b/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
@@ -373,7 +373,7 @@ var subObjectHandlers = map[string]redeployObject{
 			ds := o.(*appsv1.DaemonSet)
 			// Update node driver status is status object
 			status := "NotReady"
-			reason := "Unknown"
+			reason := ""
 			if ds.Status.NumberAvailable == 0 {
 				reason = "Node daemon set has not started yet."
 			} else if ds.Status.NumberReady == ds.Status.NumberAvailable {
@@ -402,7 +402,7 @@ var subObjectHandlers = map[string]redeployObject{
 			ss := o.(*appsv1.Deployment)
 			// Update controller status is status object
 			status := "NotReady"
-			reason := "Unknown"
+			reason := ""
 			if ss.Status.Replicas == 0 {
 				reason = "Controller deployment has not started yet."
 			} else if ss.Status.ReadyReplicas == ss.Status.Replicas {

--- a/pkg/pmem-csi-operator/controller/deployment/deployment_controller_test.go
+++ b/pkg/pmem-csi-operator/controller/deployment/deployment_controller_test.go
@@ -665,7 +665,9 @@ func TestDeploymentController(t *testing.T) {
 					validateDriver(tc, dep, []string{api.EventReasonNew, api.EventReasonRunning}, false)
 				}()
 
-				tc.rc.Reconcile(tc.ctx, req)
+				if _, err := tc.rc.Reconcile(tc.ctx, req); err != nil {
+					t.Fatalf("unexpected error from Reconcile: %v", err)
+				}
 			}
 		})
 	}
@@ -691,7 +693,7 @@ type testClient struct {
 }
 
 func newTestClient(initObjs ...runtime.Object) client.Client {
-	return &testClient{Client: fake.NewFakeClient(initObjs...)}
+	return &testClient{Client: fake.NewClientBuilder().WithRuntimeObjects(initObjs...).Build()}
 }
 
 func (t *testClient) InjectPanicOn(gvk *schema.GroupVersionKind) {

--- a/pkg/pmem-csi-operator/main.go
+++ b/pkg/pmem-csi-operator/main.go
@@ -47,7 +47,7 @@ var (
 func init() {
 	// klog gets initialized by k8s.io/component-base/logs.
 
-	flag.Set("logtostderr", "true")
+	_ = flag.Set("logtostderr", "true")
 }
 
 func Main() int {

--- a/pkg/pmem-device-manager/pmd-manager_test.go
+++ b/pkg/pmem-device-manager/pmd-manager_test.go
@@ -79,7 +79,7 @@ func runTests(mode string) {
 				continue
 			}
 			By("Cleaning up device: " + devName)
-			dm.DeleteDevice(ctx, devName, false)
+			_ = dm.DeleteDevice(ctx, devName, false)
 		}
 		if mode == ModeLVM {
 			err := vg.Clean()
@@ -209,7 +209,9 @@ func runTests(mode string) {
 		mountPath, err := mountDevice(dev)
 		Expect(err).Should(BeNil(), "Failed to create mount path: %s", mountPath)
 
-		defer unmount(mountPath)
+		defer func() {
+			_ = unmount(mountPath)
+		}()
 
 		// Delete should fail as the device is in use
 		err = dm.DeleteDevice(ctx, name, true)
@@ -318,7 +320,7 @@ func createTestVGS(vgname string, size uint64) (*testVGS, error) {
 	defer func() {
 		if err != nil {
 			By("Removing volume group due to failure")
-			pmemexec.RunCommand(ctx, "vgremove", "--force", vgname)
+			_, _ = pmemexec.RunCommand(ctx, "vgremove", "--force", vgname)
 		}
 	}()
 

--- a/pkg/scheduler/capacity_test.go
+++ b/pkg/scheduler/capacity_test.go
@@ -179,7 +179,9 @@ func TestCapacityFromMetrics(t *testing.T) {
 				server := http.Server{
 					Handler: mux,
 				}
-				go server.Serve(listener)
+				go func() {
+					_ = server.Serve(listener)
+				}()
 				defer server.Close()
 
 				// Now fake a PMEM-CSI pod on that node.
@@ -189,7 +191,7 @@ func TestCapacityFromMetrics(t *testing.T) {
 				require.NoError(t, err, "parse listen port")
 				pod := node.createPMEMPod(port)
 				if pod != nil {
-					podIndexer.Add(pod)
+					_ = podIndexer.Add(pod)
 				}
 			}
 			podLister := corelistersv1.NewPodLister(podIndexer)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -124,7 +124,9 @@ func NewScheduler(
 	}
 	s.decoder = decoder
 	webhook := webhook.Admission{Handler: s}
-	webhook.InjectLogger(s.log.WithName("webhook"))
+	if err := webhook.InjectLogger(s.log.WithName("webhook")); err != nil {
+		return nil, fmt.Errorf("inject logger: %v", err)
+	}
 
 	s.instrumentedFilter = wrapHTTPHandler("filter", s.filter)
 	s.instrumentedStatus = wrapHTTPHandler("status", s.status)
@@ -159,7 +161,7 @@ func (s *scheduler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *scheduler) status(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok"))
+	_, _ = w.Write([]byte("ok"))
 }
 
 // filter handles the JSON decoding+encoding.
@@ -184,7 +186,7 @@ func (s *scheduler) filter(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(response)
+		_, _ = w.Write(response)
 	}
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -171,7 +171,7 @@ func newTestEnv(t *testing.T, capacity Capacity, stopCh <-chan struct{}) *testEn
 
 func (env *testEnv) initClaims(pvcs []*v1.PersistentVolumeClaim) {
 	for _, pvc := range pvcs {
-		env.pvcInformer.Informer().GetIndexer().Add(pvc)
+		_ = env.pvcInformer.Informer().GetIndexer().Add(pvc)
 	}
 }
 

--- a/test/cmd/pmem-dax-check/main.go
+++ b/test/cmd/pmem-dax-check/main.go
@@ -95,7 +95,7 @@ func run(filename string, size int, wait bool) (int, error) {
 
 	if wait {
 		fmt.Printf("map(MAP_SYNC) succeeded. Continue with CTRL-C.\n")
-		exitSignal := make(chan os.Signal)
+		exitSignal := make(chan os.Signal, 2)
 		signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
 		<-exitSignal
 	}

--- a/test/cmd/watch-pvs/watch-pvs.go
+++ b/test/cmd/watch-pvs/watch-pvs.go
@@ -81,6 +81,5 @@ func main() {
 	volumeInformer.AddEventHandlerWithResyncPeriod(volumeHandler, time.Hour)
 
 	factory.Start(ctx.Done())
-	for {
-	}
+	<-ctx.Done()
 }

--- a/test/e2e/deploy/operator.go
+++ b/test/e2e/deploy/operator.go
@@ -142,6 +142,9 @@ func UpdateDeploymentCR(f *framework.Framework, dep api.PmemCSIDeployment) api.P
 	gomega.Eventually(func() error {
 		var err error
 		in, err := f.DynamicClient.Resource(DeploymentResource).Get(context.Background(), dep.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 		d := DeploymentFromUnstructured(in)
 		d.Spec = dep.Spec
 		in = DeploymentToUnstructured(d)

--- a/test/e2e/deploy/volumeleaks.go
+++ b/test/e2e/deploy/volumeleaks.go
@@ -98,7 +98,6 @@ func listVolumes(sshcmd, prefix, cmd string) []string {
 			return lines
 		}
 	}
-	return nil
 }
 
 // CheckForLeftovers lists volumes again after test, diff means leftovers.

--- a/test/e2e/driver/driver.go
+++ b/test/e2e/driver/driver.go
@@ -127,6 +127,7 @@ func (m *manifestDriver) GetDynamicProvisionStorageClass(config *storageframewor
 	err = utils.PatchItems(f, f.Namespace, items...)
 	Expect(err).NotTo(HaveOccurred())
 	err = utils.PatchCSIDeployment(f, m.finalPatchOptions(f), items[0])
+	Expect(err).NotTo(HaveOccurred())
 
 	sc, ok := items[0].(*storagev1.StorageClass)
 	Expect(ok).To(BeTrue(), "storage class from %s", scManifest)

--- a/test/e2e/operator/deployment_api.go
+++ b/test/e2e/operator/deployment_api.go
@@ -434,6 +434,7 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 		})
 
 		It("driver deployment shall be running even after operator exit", func() {
+			var err error
 			deployment := getDeployment("test-deployment-operator-exit")
 
 			deployment = deploy.CreateDeploymentCR(f, deployment)
@@ -445,7 +446,9 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 			})
 
 			// Stop the operator
-			stopOperator(c, d)
+			err = stopOperator(c, d)
+			Expect(err).ShouldNot(HaveOccurred(), "stop operator")
+
 			// restore the deployment so that next test should  not effect
 			defer func() {
 				startOperator(c, d)
@@ -455,7 +458,7 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 			}()
 
 			// Ensure that the driver is running consistently
-			err := validate.DriverDeployment(ctx, client, k8sver, d.Namespace, deployment)
+			err = validate.DriverDeployment(ctx, client, k8sver, d.Namespace, deployment)
 			Expect(err).ShouldNot(HaveOccurred(), "after operator restart")
 		})
 
@@ -751,7 +754,8 @@ var _ = deploy.DescribeForSome("API", func(d *deploy.Deployment) bool {
 					}
 					restored := false
 					if restart {
-						stopOperator(c, d)
+						err := stopOperator(c, d)
+						Expect(err).ShouldNot(HaveOccurred(), "stop operator")
 						defer func() {
 							if !restored {
 								startOperator(c, d)

--- a/test/e2e/operator/validate/validate.go
+++ b/test/e2e/operator/validate/validate.go
@@ -215,7 +215,9 @@ func DriverDeployment(ctx context.Context, c client.Client, k8sver version.Versi
 	// The operator currently always uses the production image. We
 	// can only find that indirectly.
 	driverImage := strings.Replace(os.Getenv("PMEM_CSI_IMAGE"), "-test", "", 1)
-	(&deployment).EnsureDefaults(driverImage)
+	if err := (&deployment).EnsureDefaults(driverImage); err != nil {
+		return err
+	}
 
 	// Validate sub-objects. A sub-object is anything that has the deployment object as owner.
 	objects, err := listAllDeployedObjects(ctx, c, deployment, namespace)

--- a/test/e2e/storage/conversion.go
+++ b/test/e2e/storage/conversion.go
@@ -80,7 +80,8 @@ func testRawNamespaceConversion(f *framework.Framework, driverName, namespace st
 	// on the master node. None of the other tests expect that.
 	defer func() {
 		By("destroying volume groups and namespaces again")
-		deploy.ResetPMEM(ctx, "0")
+		err := deploy.ResetPMEM(ctx, "0")
+		framework.ExpectNoError(err, "reset PMEM")
 
 		By("reverting labels")
 		labels := []string{

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -188,8 +188,8 @@ func DefineLateBindingTests(d *deploy.Deployment, f *framework.Framework) {
 				StatusWriter: GinkgoWriter,
 				LogWriter:    GinkgoWriter,
 			}
-			podlogs.CopyAllLogs(ctx, f.ClientSet, f.Namespace.Name, to)
-			podlogs.WatchPods(ctx, f.ClientSet, f.Namespace.Name, GinkgoWriter)
+			framework.ExpectNoError(podlogs.CopyAllLogs(ctx, f.ClientSet, f.Namespace.Name, to))
+			framework.ExpectNoError(podlogs.WatchPods(ctx, f.ClientSet, f.Namespace.Name, GinkgoWriter))
 
 			wg := sync.WaitGroup{}
 			volumes := int64(0)

--- a/test/e2e/storage/dax/dax.go
+++ b/test/e2e/storage/dax/dax.go
@@ -113,7 +113,7 @@ func (p *daxTestSuite) DefineTests(driver storageframework.TestDriver, pattern s
 
 	cleanup := func() {
 		if l.resource != nil {
-			l.resource.CleanupResource()
+			_ = l.resource.CleanupResource()
 			l.resource = nil
 		}
 

--- a/test/e2e/storage/scheduler/scheduler.go
+++ b/test/e2e/storage/scheduler/scheduler.go
@@ -103,7 +103,7 @@ func (p *schedulerTestSuite) DefineTests(driver storageframework.TestDriver, pat
 
 	cleanup := func() {
 		if l.resource != nil {
-			l.resource.CleanupResource()
+			_ = l.resource.CleanupResource()
 			l.resource = nil
 		}
 

--- a/third-party/go-fibmap/fibmap.go
+++ b/third-party/go-fibmap/fibmap.go
@@ -6,6 +6,7 @@
 package fibmap
 
 import (
+	"io"
 	"os"
 	"syscall"
 	"unsafe"
@@ -134,7 +135,7 @@ func (f FibmapFile) FibmapExtents() ([]Extent, syscall.Errno) {
 			e.Length = uint64(length) * uint64(bsz)
 			result = append(result, e)
 		}
-		
+
 		// new extent
 		e = Extent{}
 		e.Logical = uint64(i) * uint64(bsz)
@@ -197,7 +198,8 @@ func (f FibmapFile) SeekDataHole() []int64 {
 		break
 	}
 
-	f.Seek(old, os.SEEK_SET)
+	// Not expected to fail...
+	_, _ = f.Seek(old, io.SeekStart)
 
 	return datahole
 }


### PR DESCRIPTION
Mostly they are around inefficient initialization, missing error checking, deprecated APIs, and
some unreachable code.

In several cases, error handling is intentionally omitted, either because the
error cannot occur or cannot be handled. This can be expressed by assigning the
error to _.