### PR TITLE
pmem-csi: avoid false negative liveness probe

### DIFF
--- a/deploy/kubernetes-1.19/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/direct/pmem-csi.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/direct/testing/pmem-csi.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.19/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/lvm/pmem-csi.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.19/lvm/testing/pmem-csi.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-direct-testing.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.19/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-direct.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-lvm-testing.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.19/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.19/pmem-csi-lvm.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/direct/pmem-csi.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/direct/testing/pmem-csi.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/lvm/pmem-csi.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.20/lvm/testing/pmem-csi.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-direct-testing.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-direct.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-lvm-testing.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.20/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.20/pmem-csi-lvm.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/direct/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/direct/pmem-csi.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/direct/testing/pmem-csi.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/lvm/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/lvm/pmem-csi.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
+++ b/deploy/kubernetes-1.21/lvm/testing/pmem-csi.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-direct-testing.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/pmem-csi-direct.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-direct.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-lvm-testing.yaml
@@ -383,7 +383,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -402,7 +402,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -482,7 +482,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -502,7 +502,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kubernetes-1.21/pmem-csi-lvm.yaml
+++ b/deploy/kubernetes-1.21/pmem-csi-lvm.yaml
@@ -382,7 +382,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -401,7 +401,7 @@ spec:
         startupProbe:
           failureThreshold: 60
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1
@@ -480,7 +480,7 @@ spec:
         livenessProbe:
           failureThreshold: 6
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 10
@@ -500,7 +500,7 @@ spec:
         startupProbe:
           failureThreshold: 300
           httpGet:
-            path: /metrics
+            path: /metrics/simple
             port: metrics
             scheme: HTTP
           periodSeconds: 1

--- a/deploy/kustomize/patches/metrics-controller.yaml
+++ b/deploy/kustomize/patches/metrics-controller.yaml
@@ -21,7 +21,7 @@
     # then it is alive.
     httpGet:
       scheme: HTTP
-      path: /metrics
+      path: /metrics/simple
       port: metrics
     # Allow it to for a total duration of one minute.
     # This is conservative because the probe is new.
@@ -34,7 +34,7 @@
   value:
     httpGet:
       scheme: HTTP
-      path: /metrics
+      path: /metrics/simple
       port: metrics
     # Check more frequently while the container starts up
     # to get it into a ready state quickly.

--- a/deploy/kustomize/patches/metrics-node.yaml
+++ b/deploy/kustomize/patches/metrics-node.yaml
@@ -18,11 +18,16 @@
   path: /spec/template/spec/containers/0/livenessProbe
   value:
     # If the PMEM-CSI driver is able to serve metrics,
-    # then it is alive. In particular this covers capacity
-    # checking.
+    # then it is alive, for some definition of "alive".
+    #
+    # In particular this does *not covers capacity
+    # checking, because that needs to take a lock
+    # which can take an unpredictable amount of time
+    # when there is an operation in progress like
+    # scrubbing a volume.
     httpGet:
       scheme: HTTP
-      path: /metrics
+      path: /metrics/simple
       port: metrics
     # Allow it to for a total duration of one minute.
     # This is conservative because the probe is new.
@@ -35,7 +40,7 @@
   value:
     httpGet:
       scheme: HTTP
-      path: /metrics
+      path: /metrics/simple
       port: metrics
     # Startup may be slower when LVM needs to be set up first.
     # Check more frequently to get it into a ready state quickly.

--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -83,10 +83,13 @@ var (
 		},
 		[]string{"version"},
 	)
+
+	simpleMetrics = prometheus.NewPedanticRegistry()
 )
 
 func init() {
 	prometheus.MustRegister(buildInfo)
+	simpleMetrics.MustRegister(buildInfo)
 }
 
 //Config type for driver configuration
@@ -384,6 +387,7 @@ func (csid *csiDriver) startMetrics(ctx context.Context, cancel func()) (string,
 			promhttp.HandlerFor(csid.gatherers, promhttp.HandlerOpts{}),
 		),
 	)
+	mux.Handle(csid.cfg.metricsPath+"/simple", promhttp.HandlerFor(simpleMetrics, promhttp.HandlerOpts{}))
 	return csid.startHTTPSServer(ctx, cancel, csid.cfg.metricsListen, mux, false /* no TLS */)
 }
 

--- a/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
+++ b/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
@@ -1427,8 +1427,8 @@ func (d *pmemCSIDeployment) getControllerContainer() corev1.Container {
 		SecurityContext: &corev1.SecurityContext{
 			ReadOnlyRootFilesystem: &true,
 		},
-		LivenessProbe: getMetricsProbe(6, 10),
-		StartupProbe:  getMetricsProbe(60, 1),
+		LivenessProbe: getMetricsProbe(6, 10, "/simple"),
+		StartupProbe:  getMetricsProbe(60, 1, "/simple"),
 	}
 
 	if d.Spec.ControllerTLSSecret != "" {
@@ -1512,8 +1512,8 @@ func (d *pmemCSIDeployment) getNodeDriverContainer() corev1.Container {
 		},
 		TerminationMessagePath:   "/tmp/termination-log",
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		LivenessProbe:            getMetricsProbe(6, 10),
-		StartupProbe:             getMetricsProbe(300, 1),
+		LivenessProbe:            getMetricsProbe(6, 10, "/simple"),
+		StartupProbe:             getMetricsProbe(300, 1, "/simple"),
 	}
 
 	return c
@@ -1562,8 +1562,8 @@ func (d *pmemCSIDeployment) getProvisionerContainer() corev1.Container {
 		},
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		LivenessProbe:            getMetricsProbe(6, 10),
-		StartupProbe:             getMetricsProbe(300, 1),
+		LivenessProbe:            getMetricsProbe(6, 10, ""),
+		StartupProbe:             getMetricsProbe(300, 1, ""),
 	}
 
 	if d.withStorageCapacity() {
@@ -1799,12 +1799,12 @@ func (d *pmemCSIDeployment) getObjectMeta(name string, isClusterResource bool) m
 	return meta
 }
 
-func getMetricsProbe(failureThreshold int32, periodSeconds int32) *corev1.Probe {
+func getMetricsProbe(failureThreshold int32, periodSeconds int32, pathSuffix string) *corev1.Probe {
 	return &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Scheme: "HTTP",
-				Path:   "/metrics",
+				Path:   "/metrics" + pathSuffix,
 				Port:   intstr.FromString("metrics"),
 			},
 		},


### PR DESCRIPTION
During a long-running DeleteVolume for a 200GB volume the LVM lock is held and
the liveness probe for metrics data timed out after a minute, killing the
container, because metrics retrieval must take the LVM lock.

As operation duration is non-deterministic, the solution is to probe only
metrics data which can be served immediately when the process is up and
running. This is less precise (= doesn't really check any functionality), but
that's an inherent problem of liveness probes: they simply cannot cover the
full functionality.

Fixes: #1046 