### PR TITLE
operator hub: explicitly list "Intel" as keyword

### DIFF
--- a/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
+++ b/deploy/kustomize/olm-catalog/bases/pmem-csi-operator.clusterserviceversion.yaml
@@ -34,6 +34,7 @@ spec:
   - PMEM-CSI operator
   - Persistent Memory
   - PMEM
+  - Intel
   maintainers:
   - email: olev.kartau@intel.com
     name: Olev Kartau


### PR DESCRIPTION
https://operatorhub.io/?keyword=intel finds the "Intel Device Plugins
Operator", probably because the word appears in the title. We don't have that
for PMEM-CSI, so list the keyword explicitly.