### PR TITLE
operator: Bump operator-sdk version to v1.13.1

### DIFF
--- a/operator/operator.make
+++ b/operator/operator.make
@@ -3,13 +3,7 @@ OPERATOR_SDK_VERSION=1.6.1
 # download operator-sdk binary
 _work/bin/operator-sdk-$(OPERATOR_SDK_VERSION):
 	mkdir -p _work/bin/ 2> /dev/null
-	# Building operator-sdk from sources as that needs fixes for:
-	# https://github.com/operator-framework/operator-sdk/pull/4816
-	tmpdir=`mktemp -d` && \
-	trap 'set -x; rm -rf $$tmpdir' EXIT && \
-	git clone --branch $(OPERATOR_SDK_VERSION)+fixes https://github.com/avalluri/operator-sdk.git $$tmpdir && \
-	cd $$tmpdir && $(MAKE) build/operator-sdk && \
-	cp $$tmpdir/build/operator-sdk $(abspath $@) && \
+	curl -L https://github.com/operator-framework/operator-sdk/releases/download/v$(OPERATOR_SDK_VERSION)/operator-sdk_linux_amd64 -o $(abspath $@)
 	chmod a+x $(abspath $@)
 	cd $(dir $@); ln -sf operator-sdk-$(OPERATOR_SDK_VERSION) operator-sdk
 

--- a/operator/operator.make
+++ b/operator/operator.make
@@ -1,4 +1,4 @@
-OPERATOR_SDK_VERSION=1.6.1
+OPERATOR_SDK_VERSION=1.14.0
 
 # download operator-sdk binary
 _work/bin/operator-sdk-$(OPERATOR_SDK_VERSION):

--- a/test/start-stop-olm.sh
+++ b/test/start-stop-olm.sh
@@ -67,6 +67,7 @@ if [ $cmd == install ]; then
         if ! ${BIN_DIR}/operator-sdk olm status 2>&1 ; then
             echo "OLM installation failed!!!"
             ${KUBECTL} get all -n olm
+            ${KUBECTL} get crd
             exit 1
         fi
     fi

--- a/test/start-stop-olm.sh
+++ b/test/start-stop-olm.sh
@@ -61,8 +61,9 @@ if [ $cmd == install ]; then
     # So, we depend on `olm status` instead to check if the installation
     # was successfull
     set +e
-    echo "Installing OLM..."
-    if ! ${BIN_DIR}/operator-sdk olm install --verbose --timeout=5m 2>&1 ; then
+    OLM_VERSION=0.18.3
+    echo "Installing OLM ($OLM_VERSION)..."
+    if ! ${BIN_DIR}/operator-sdk olm install --verbose --version=$OLM_VERSION --timeout=5m 2>&1 ; then
         if ! ${BIN_DIR}/operator-sdk olm status 2>&1 ; then
             echo "OLM installation failed!!!"
             ${KUBECTL} get all -n olm


### PR DESCRIPTION
The most recent operator-sdk version is 1.14.0 which requires k8s 1.22. We can upgrade to 1.14 as part of adding 1.22 support to the driver.