### PR TITLE
avoid Delete call in controller

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -142,7 +142,7 @@ $ make operator-generate-bundle VERSION=<X.Y.Z> REPLACES=<X.Y.Z> # semantic vers
 ```
 Running the above command generates the OLM package bundle files under `deploy/olm-bundle/<X.Y.Z>`
 
-* Clone `operator-framework/community-operators` repository
+* Clone `k8s-operatorhub/community-operators` repository
 ``` console
 $ git clone https://github.com/k8s-operatorhub/community-operators.git
 ```

--- a/pkg/pmem-csi-driver/rescheduler.go
+++ b/pkg/pmem-csi-driver/rescheduler.go
@@ -75,6 +75,7 @@ type pmemCSIProvisioner struct {
 
 var _ controller.Qualifier = &pmemCSIProvisioner{}
 var _ controller.DeletionGuard = &pmemCSIProvisioner{}
+var _ controller.BlockProvisioner = &pmemCSIProvisioner{}
 
 // startRescheduler logs errors and cancels the context when it runs
 // into a problem, either during the startup phase (blocking) or later
@@ -141,6 +142,10 @@ func (pcp *pmemCSIProvisioner) Delete(context.Context, *v1.PersistentVolume) err
 	return &controller.IgnoredError{
 		Reason: "deletion must be done on the node",
 	}
+}
+
+func (pcp *pmemCSIProvisioner) SupportsBlock(context.Context) bool {
+	return true
 }
 
 func (pcp *pmemCSIProvisioner) shouldReschedule(ctx context.Context, pvc *v1.PersistentVolumeClaim, node *v1.Node) (bool, error) {


### PR DESCRIPTION
Main reason for the PR is an observation that some tests because the controller container restarted directly after doing some useless Delete (see commit message).

Also contains some other, minor enhancements.
