### PR TITLE
e2e: fix OLM version skew testing

### DIFF
--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -1246,7 +1246,7 @@ func EnsureDeploymentNow(f *framework.Framework, deployment *Deployment) {
 		// generated oln-bundles under /deploy in the source tree.
 		if deployment.HasOLM {
 			make := exec.Command("make", "operator-generate-bundle", "VERSION="+tag, "REPO_ROOT="+workRoot)
-			make.Dir = root
+			make.Dir = workRoot
 			make.Env = env
 			_, err := pmemexec.Run(ctx, make)
 			framework.ExpectNoError(err, "%s: generate bundle for operator version %s", deployment.Name(), deployment.Version)


### PR DESCRIPTION
https://github.com/intel/pmem-csi/pull/1052 simplified the make rules
for the OLM bundle. However, that had the effect that those rules now
no longer can build the OLM bundle for the previous release, 1.0.1, which
caused version skew testing to fail.

The solution is to run make in the 1.0.1 source directory and thus use
the make rules from that release. This is cleaner, too.