### PR TITLE
build: bump to Go 1.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG LINUX_BASE=debian:buster-slim
 FROM ${LINUX_BASE} AS build
 ARG APT_GET="env DEBIAN_FRONTEND=noninteractive apt-get"
 
-ARG GO_VERSION="1.17.6"
+ARG GO_VERSION="1.18.1"
 
 # CACHEBUST is set by the CI when building releases to ensure that apt-get really gets
 # run instead of just using some older, cached result.


### PR DESCRIPTION
It is the latest supported release at this time.