### PR TITLE
fix "make vhtml"

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -345,7 +345,7 @@ When a pod requests a special [extended
 resource](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#extended-resources)
 , the Kubernetes scheduler calls
 a [scheduler
-extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md)
+extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md)
 provided by PMEM-CSI with a list of nodes that a pod might run
 on.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,7 @@ recommonmark == 0.7.1
 sphinx-markdown-tables == 0.0.15
 sphinx-copybutton == 0.2.11
 sphinx-md == 0.0.3
+markdown == 3.3.7
+
+# A working combination:
+# Jinja2-3.1.2 MarkupSafe-2.1.1 Pygments-2.12.0 alabaster-0.7.12 babel-2.10.1 beautifulsoup4-4.11.1 bs4-0.0.1 certifi-2022.5.18.1 charset-normalizer-2.0.12 commonmark-0.9.1 docutils-0.17.1 idna-3.3 imagesize-1.3.0 importlib-metadata-4.11.4 markdown-3.3.7 packaging-21.3 pyparsing-3.0.9 pytz-2022.1 recommonmark-0.7.1 requests-2.27.1 snowballstemmer-2.2.0 soupsieve-2.3.2.post1 sphinx-4.5.0 sphinx-copybutton-0.2.11 sphinx-markdown-tables-0.0.15 sphinx-md-0.0.3 sphinx-rtd-theme-1.0.0 sphinxcontrib-applehelp-1.0.2 sphinxcontrib-devhelp-1.0.2 sphinxcontrib-htmlhelp-2.0.0 sphinxcontrib-jsmath-1.0.1 sphinxcontrib-qthelp-1.0.3 sphinxcontrib-serializinghtml-1.1.5 typing-extensions-4.2.0 urllib3-1.26.9 zipp-3.8.0

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -1,7 +1,7 @@
 # Scheduler
 
 This directory contains the implementation of a [scheduler
-extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md).
+extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md).
 It is meant to be linked into the PMEM-CSI master controller because
 that is where we know about nodes and can get their current capacity.
 


### PR DESCRIPTION
The newer markdown 3.4.1 is not compatible with sphinx-markdown-tables.

The URL for the scheduler extender changed.