### PR TITLE
test: workaround operator-sdk image pinning

### DIFF
--- a/test/start-operator.sh
+++ b/test/start-operator.sh
@@ -91,7 +91,9 @@ function deploy_using_olm() {
   fi
 
   # Deploy the operator
+  # Pinning the image is a workaround for https://github.com/operator-framework/operator-registry/issues/984.
   ${BINDIR}/operator-sdk run bundle${upgrade} ${NAMESPACE} --timeout 5m ${TEST_LOCAL_REGISTRY}/pmem-csi-bundle:v${BUNDLE_VERSION} \
+           --index-image=quay.io/operator-framework/opm:v1.23.0 \
            $(if ${TEST_LOCAL_REGISTRY_SKIP_TLS}; then echo '--skip-tls'; fi)
 }
 


### PR DESCRIPTION
"operator-sdk run" pulls the latest version of certain images, which started to
break after an quay.io/operator-framework/opm update. Pinning to a known
version in our invocation is a workaround for that
bug (https://github.com/operator-framework/operator-registry/issues/984).