### PR TITLE
build: update to Go 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG LINUX_BASE=debian:buster-slim
 FROM ${LINUX_BASE} AS build
 ARG APT_GET="env DEBIAN_FRONTEND=noninteractive apt-get"
 
-ARG GO_VERSION="1.18.1"
+ARG GO_VERSION="1.19"
 
 # CACHEBUST is set by the CI when building releases to ensure that apt-get really gets
 # run instead of just using some older, cached result.

--- a/pkg/imagefile/imagefile.go
+++ b/pkg/imagefile/imagefile.go
@@ -23,30 +23,29 @@ Furthermore, this file is based on the following code published by Intel under A
 /*
 Package imagefile contains code to create a file with the following content:
 
-	.-----------.----------.---------------.
-	| 0 - 512 B | 4 - 8 Kb |  2M - ...     |
-	|-----------+----------+---------------+
-	|   MBR #1  |   DAX    |  FS           |
-	'-----------'----------'---------------'
-	      |         |      ^
-	      |         '-data-'
-	      |                |
-	      '--fs-partition--'
+		.-----------.----------.---------------.
+		| 0 - 512 B | 4 - 8 Kb |  2M - ...     |
+		|-----------+----------+---------------+
+		|   MBR #1  |   DAX    |  FS           |
+		'-----------'----------'---------------'
+		      |         |      ^
+		      |         '-data-'
+		      |                |
+		      '--fs-partition--'
 
-                    ^          ^
-          daxHeaderOffset      |
-                           HeaderSize
-
+	                    ^          ^
+	          daxHeaderOffset      |
+	                           HeaderSize
 
 MBR: Master boot record.
 DAX: Metadata required by the NVDIMM driver to enable DAX in the guest (struct nd_pfn_sb).
 FS: partition that contains a filesystem.
 
 The MBR is useful for working with the image file:
-- the `file` utility uses it to determine what the file contains
-- when binding the entire file to /dev/loop0, /dev/loop0p1 will be
-  the file system (beware that partprobe /dev/loop0 might be needed);
-  alternatively one could bind the file system directly by specifying an offset
+  - the `file` utility uses it to determine what the file contains
+  - when binding the entire file to /dev/loop0, /dev/loop0p1 will be
+    the file system (beware that partprobe /dev/loop0 might be needed);
+    alternatively one could bind the file system directly by specifying an offset
 
 When such a file is created on a dax-capable filesystem, then it can
 be used as backing store for a [QEMU nvdimm

--- a/pkg/ndctl/namespace.go
+++ b/pkg/ndctl/namespace.go
@@ -43,10 +43,10 @@ const (
 	NoneMap   MapLocation = "none"
 )
 
-//NamespaceType type to represent namespace type
+// NamespaceType type to represent namespace type
 type NamespaceType string
 
-//NamespaceMode represents mode of the namespace
+// NamespaceMode represents mode of the namespace
 type NamespaceMode string
 
 func (mode NamespaceMode) toCMode() C.enum_ndctl_namespace_mode {

--- a/pkg/ndctl/ndctl.go
+++ b/pkg/ndctl/ndctl.go
@@ -21,7 +21,7 @@ const (
 	mib2 uint64 = mib * 2
 )
 
-//CreateNamespaceOpts options to create a namespace
+// CreateNamespaceOpts options to create a namespace
 type CreateNamespaceOpts struct {
 	Name       string
 	Size       uint64

--- a/pkg/pmem-csi-driver/pmem-csi-driver.go
+++ b/pkg/pmem-csi-driver/pmem-csi-driver.go
@@ -93,7 +93,7 @@ func init() {
 	simpleMetrics.MustRegister(buildInfo)
 }
 
-//Config type for driver configuration
+// Config type for driver configuration
 type Config struct {
 	//DriverName name of the csi driver
 	DriverName string

--- a/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
+++ b/pkg/pmem-csi-operator/controller/deployment/controller_driver.go
@@ -240,12 +240,12 @@ type redeployObject struct {
 
 // redeploy creates or patches one sub-object so that it matches
 // the PmemCSIDeployment spec.
-//  1.
-//  2. Retrieve the latest data saved at APIServer for that object.
-//  3. Create an objectPatch for that object to record the changes from this point.
-//  4. Call ro.modify() to modify the object's data.
-//  5. Call objectPatch.Apply() to submit the chanages to the APIServer.
-//  6. If the update in step-5 was success, then call the ro.postUpdate() callback
+//
+//  1. Retrieve the latest data saved at APIServer for that object.
+//  2. Create an objectPatch for that object to record the changes from this point.
+//  3. Call ro.modify() to modify the object's data.
+//  4. Call objectPatch.Apply() to submit the chanages to the APIServer.
+//  5. If the update in step 4 was success, then call the ro.postUpdate() callback
 //     to run any post update steps.
 func (d *pmemCSIDeployment) redeploy(ctx context.Context, r *ReconcileDeployment, ro redeployObject) (finalObj client.Object, finalErr error) {
 	l := klog.FromContext(ctx).WithName("redeploy")

--- a/pkg/pmem-csi-operator/controller/deployment/deployment_controller.go
+++ b/pkg/pmem-csi-operator/controller/deployment/deployment_controller.go
@@ -368,7 +368,7 @@ func (r *ReconcileDeployment) RemoveHook(h ReconcileHook) {
 	delete(r.reconcileHooks, h)
 }
 
-//Get tries to retrives the Kubernetes objects
+// Get tries to retrives the Kubernetes objects
 func (r *ReconcileDeployment) Get(obj client.Object) error {
 	key := client.ObjectKeyFromObject(obj)
 	return r.client.Get(r.ctx, key, obj)

--- a/pkg/pmem-device-manager/pmd-lvm.go
+++ b/pkg/pmem-device-manager/pmd-lvm.go
@@ -279,7 +279,7 @@ func listDevices(ctx context.Context, volumeGroups ...string) (map[string]*PmemD
 	return parseLVSOutput(output)
 }
 
-//lvs options "lv_name,lv_path,lv_size,lv_free"
+// lvs options "lv_name,lv_path,lv_size,lv_free"
 func parseLVSOutput(output string) (map[string]*PmemDeviceInfo, error) {
 	devices := map[string]*PmemDeviceInfo{}
 	lines := strings.Split(output, "\n")

--- a/pkg/pmem-device-manager/pmd-manager.go
+++ b/pkg/pmem-device-manager/pmd-manager.go
@@ -71,7 +71,7 @@ type PmemDeviceCapacity interface {
 	GetCapacity(ctx context.Context) (Capacity, error)
 }
 
-//PmemDeviceManager interface to manage the PMEM block devices
+// PmemDeviceManager interface to manage the PMEM block devices
 type PmemDeviceManager interface {
 	PmemDeviceCapacity
 

--- a/pkg/pmem-device-manager/pmd-ndctl.go
+++ b/pkg/pmem-device-manager/pmd-ndctl.go
@@ -30,7 +30,7 @@ var _ PmemDeviceManager = &pmemNdctl{}
 // our locking strategy.
 var ndctlMutex = &sync.Mutex{}
 
-//NewPmemDeviceManagerNdctl Instantiates a new ndctl based pmem device manager
+// NewPmemDeviceManagerNdctl Instantiates a new ndctl based pmem device manager
 // FIXME(avalluri): consider pmemPercentage while calculating available space
 func newPmemDeviceManagerNdctl(ctx context.Context, pmemPercentage uint) (PmemDeviceManager, error) {
 	ctx, _ = pmemlog.WithName(ctx, "ndctl-New")

--- a/pkg/pmem-grpc/grpc.go
+++ b/pkg/pmem-grpc/grpc.go
@@ -34,7 +34,7 @@ func unixDialer(ctx context.Context, addr string) (net.Conn, error) {
 	return dialer.DialContext(ctx, "unix", addr)
 }
 
-//Connect is a helper function to initiate a grpc client connection to server running at endpoint using tlsConfig
+// Connect is a helper function to initiate a grpc client connection to server running at endpoint using tlsConfig
 func Connect(endpoint string, tlsConfig *tls.Config, dialOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	proto, address, err := parseEndpoint(endpoint)
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -60,10 +60,10 @@ func (v Version) Minor() uint {
 }
 
 // Compare compares v with given otherVersion
-// Returns,
-//  0 if two versions are same
-//  >0 if v is greater otherVersion
-//  <0 if v is less than otherVersion
+// Returns
+// - 0 if two versions are same
+// - >0 if v is greater otherVersion
+// - <0 if v is less than otherVersion
 func (v Version) Compare(major, minor uint) int {
 	d := int(v.major - major)
 	if d == 0 {

--- a/pkg/volumepathhandler/volume_path_handler_linux.go
+++ b/pkg/volumepathhandler/volume_path_handler_linux.go
@@ -202,7 +202,8 @@ func parseLosetupOutputForDevice(output []byte, path string) (string, error) {
 // corresponding to map path symlink, and then return global map path with pod uuid.
 // (See pkg/volume/volume.go for details on a global map path and a pod device map path.)
 // ex. mapPath symlink: pods/{podUid}}/{DefaultKubeletVolumeDevicesDirName}/{escapeQualifiedPluginName}/{volumeName} -> /dev/sdX
-//     globalMapPath/{pod uuid} bind mount: plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumePluginDependentPath}/{pod uuid} -> /dev/sdX
+//
+//	globalMapPath/{pod uuid} bind mount: plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumePluginDependentPath}/{pod uuid} -> /dev/sdX
 func (v VolumePathHandler) FindGlobalMapPathUUIDFromPod(ctx context.Context, pluginDir, mapPath string, podUID types.UID) (string, error) {
 	ctx, logger := pmemlog.WithName(ctx, "FindGlobalMapPathUUIDFromPod")
 	var globalMapPathUUID string
@@ -262,9 +263,7 @@ func compareBindMountAndSymlinks(ctx context.Context, global, pod string) (bool,
 }
 
 // getDeviceMajorMinor returns major/minor number for the path with below format:
-// major:minor (in hex)
-// ex)
-//     fc:10
+// major:minor (in hex, for example fc:10)
 func getDeviceMajorMinor(path string) (string, error) {
 	var stat unix.Stat_t
 

--- a/test/e2e/deploy/deploy.go
+++ b/test/e2e/deploy/deploy.go
@@ -1515,12 +1515,12 @@ func Describe(deployment, describe, what string, f func(d *Deployment)) bool {
 // DefineTests must be called to register all tests defined so far via Describe.
 //
 // They are placed inside a "Deploy" node because:
-// - The order of specs inside a node is not randomized by default,
-//   which is what we want, in contrast to the top-level nodes,
-//   which always get randomized (https://github.com/onsi/ginkgo/issues/966#issuecomment-1110046593).
-// - It is easier to focus on specific tests with, for example, "Deploy operator".
-//   "^operator" does not work because the internal test name string has some
-//   builtin, hidden string at the beginning (something like "top level").
+//   - The order of specs inside a node is not randomized by default,
+//     which is what we want, in contrast to the top-level nodes,
+//     which always get randomized (https://github.com/onsi/ginkgo/issues/966#issuecomment-1110046593).
+//   - It is easier to focus on specific tests with, for example, "Deploy operator".
+//     "^operator" does not work because the internal test name string has some
+//     builtin, hidden string at the beginning (something like "top level").
 func DefineTests() {
 	ginkgo.Context("Deploy", defineTests)
 }

--- a/test/e2e/operator/validate/validate.go
+++ b/test/e2e/operator/validate/validate.go
@@ -321,7 +321,8 @@ func DriverDeployment(ctx context.Context, c client.Client, k8sver version.Versi
 // When we get an object back from the apiserver, some fields get populated with generated
 // or fixed default values. defaultSpecValues contains a hierarchy of maps that stores those
 // defaults:
-//    Kind -> field -> field -> ... -> value
+//
+//	Kind -> field -> field -> ... -> value
 //
 // Those defaults are used when the original object didn't have a field value.
 // "ignore" is a special value which let's the comparison skip the field.

--- a/test/e2e/versionskew/versionskew.go
+++ b/test/e2e/versionskew/versionskew.go
@@ -4,12 +4,10 @@ Copyright 2020 Intel Corporation.
 SPDX-License-Identifier: Apache-2.0
 */
 
-/* Version skew testing ensures that APIs and state is compatible
-across up- and downgrades. The driver for older releases is installed
-by checking out the deployment YAML files from an older release.
-
-The operator is not covered yet.
-*/
+// Package versionskew testing ensures that APIs and state is compatible
+// across up- and downgrades. The driver for older releases is installed
+// by checking out the deployment YAML files from an older release.
+// The operator is not covered yet.
 package versionskew
 
 import (


### PR DESCRIPTION
The main practical difference is that 1.19 has enhanced support for doc
comments and enforces certain formatting conventions.