### PR TITLE
test: only use --index-image for "run bundle"

### DIFF
--- a/test/start-operator.sh
+++ b/test/start-operator.sh
@@ -93,7 +93,7 @@ function deploy_using_olm() {
   # Deploy the operator
   # Pinning the image is a workaround for https://github.com/operator-framework/operator-registry/issues/984.
   ${BINDIR}/operator-sdk run bundle${upgrade} ${NAMESPACE} --timeout 5m ${TEST_LOCAL_REGISTRY}/pmem-csi-bundle:v${BUNDLE_VERSION} \
-           --index-image=quay.io/operator-framework/opm:v1.23.0 \
+           $(if ! [ "${upgrade}" ]; then echo '--index-image=quay.io/operator-framework/opm:v1.23.0'; fi) \
            $(if ${TEST_LOCAL_REGISTRY_SKIP_TLS}; then echo '--skip-tls'; fi)
 }
 


### PR DESCRIPTION
"run bundle-upgrade" does not support it, breaking the version skew tests after
merging the PR.